### PR TITLE
fix(bible): prevent render loop in shared DOM props atom

### DIFF
--- a/src/state/tabs.ts
+++ b/src/state/tabs.ts
@@ -2,6 +2,7 @@ import produce from 'immer'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { atom, getDefaultStore, PrimitiveAtom } from 'jotai/vanilla'
 import { atomWithDefault, splitAtom } from 'jotai/vanilla/utils'
+import { shallowEqual } from 'react-redux'
 
 import books, { Book } from '~assets/bible_versions/books-desc'
 import generateUUID from '~helpers/generateUUID'
@@ -1090,6 +1091,17 @@ export const activeBibleTabIdAtom = atom<string | null>(get => {
 /**
  * Props for the shared BibleDOMWrapper instance.
  * Updated by the active BibleViewer via useLayoutEffect.
+ * Uses shallowEqual to skip redundant updates that would cause render loops.
  */
-export const sharedBibleDOMPropsAtom = atom<WebViewProps | null>(null)
+const _sharedBibleDOMPropsBase = atom<WebViewProps | null>(null)
+
+export const sharedBibleDOMPropsAtom = atom(
+  (get) => get(_sharedBibleDOMPropsBase),
+  (get, set, newProps: WebViewProps | null) => {
+    const current = get(_sharedBibleDOMPropsBase)
+    if (!shallowEqual(current, newProps)) {
+      set(_sharedBibleDOMPropsBase, newProps)
+    }
+  }
+)
 


### PR DESCRIPTION
## Summary

- Fix Bible navigation freeze reported by users on iOS 26.4 (iPhone 14 Pro Max)
- The refactor in 674563348 removed the `shallowEqual` guard from the `useLayoutEffect` that pushes `domProps` to `sharedBibleDOMPropsAtom`, causing `setSharedProps` to fire on every render with a new object reference
- Moves deduplication into the Jotai atom write function: compares incoming props against current value with `shallowEqual`, skips update when nothing changed
- Tab-switch updates remain correct since the atom holds the previous tab's props (always different from the new tab's)

## Test plan

- [ ] Open 2 Bible tabs on different passages, switch between them — content updates correctly
- [ ] Navigate with prev/next chapter arrows — works without freezing
- [ ] Select a verse — stays selected
- [ ] Verify no render loop / freeze on devices with heavy user data

🤖 Generated with [Claude Code](https://claude.com/claude-code)