### PR TITLE
refactor(animation): migrate simple views to EaseView

### DIFF
--- a/src/common/VerseAccordion.tsx
+++ b/src/common/VerseAccordion.tsx
@@ -1,7 +1,8 @@
 import { useTheme } from '@emotion/react'
 import React, { useEffect, useState } from 'react'
 import { ActivityIndicator } from 'react-native'
-import Animated, { useSharedValue } from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
+import { useSharedValue } from 'react-native-reanimated'
 
 import { VerseIds, VerseRefContent } from '~common/types'
 import Box, { TouchableBox } from '~common/ui/Box'
@@ -70,15 +71,20 @@ const VerseAccordion = ({ noteVerses, version }: VerseAccordionProps) => {
             {reference}
           </Text>
         </HStack>
-        <Animated.View
+        <EaseView
+          animate={{ rotate: isExpanded ? 180 : 0 }}
+          transition={{
+            type: 'timing',
+            duration: 300,
+            easing: [0.455, 0.03, 0.515, 0.955],
+          }}
           style={{
-            transform: [{ rotate: isExpanded ? '180deg' : '0deg' }],
-            transitionProperty: 'transform',
-            transitionDuration: 300,
+            width: 20,
+            height: 20,
           }}
         >
           <FeatherIcon name="chevron-down" size={20} color={theme.colors.grey} />
-        </Animated.View>
+        </EaseView>
       </TouchableBox>
 
       <AccordionItem isExpanded={isExpandedShared} viewKey="verse-content">

--- a/src/features/home/VerseOfTheDay.tsx
+++ b/src/features/home/VerseOfTheDay.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { TFunction, useTranslation } from 'react-i18next'
 import { Share, View } from 'react-native'
 import DateTimePicker from 'react-native-modal-datetime-picker'
-import Animated from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import Empty from '~common/Empty'
@@ -55,11 +55,12 @@ const SkeletonLines = () => {
   }, [])
 
   return (
-    <Animated.View
-      style={{
-        opacity: pulse ? 0.4 : 1,
-        transitionProperty: 'opacity',
-        transitionDuration: 800,
+    <EaseView
+      animate={{ opacity: pulse ? 0.4 : 1 }}
+      transition={{
+        type: 'timing',
+        duration: 800,
+        easing: [0.455, 0.03, 0.515, 0.955],
       }}
     >
       <View
@@ -89,7 +90,7 @@ const SkeletonLines = () => {
           marginTop: 8,
         }}
       />
-    </Animated.View>
+    </EaseView>
   )
 }
 

--- a/src/features/onboarding/DownloadResources.tsx
+++ b/src/features/onboarding/DownloadResources.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@emotion/react'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai/react'
-import Animated from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
 
 import Box from '~common/ui/Box'
 import Container from '~common/ui/Container'
@@ -115,7 +115,13 @@ const DownloadResources = () => {
               center
               overflow="visible"
             >
-              <Animated.View
+              <EaseView
+                animate={{ opacity: displayProgress }}
+                transition={{
+                  type: 'timing',
+                  duration: 300,
+                  easing: [0.455, 0.03, 0.515, 0.955],
+                }}
                 style={{
                   position: 'absolute',
                   top: 0,
@@ -125,9 +131,6 @@ const DownloadResources = () => {
                   borderRadius: 50,
                   borderWidth: 5,
                   borderColor: theme.colors.primary,
-                  opacity: displayProgress,
-                  transitionProperty: 'opacity',
-                  transitionDuration: 300,
                 }}
               />
               <Text fontSize={20}>

--- a/src/features/settings/components/DownloadSectionHeader.tsx
+++ b/src/features/settings/components/DownloadSectionHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TouchableOpacity } from 'react-native'
-import Animated from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
 
 import Box from '~common/ui/Box'
 import Text from '~common/ui/Text'
@@ -45,16 +45,21 @@ const DownloadSectionHeader = ({
               />
             </TouchableOpacity>
           )}
-          <Animated.View
+          <EaseView
+            animate={{ rotate: isCollapsed ? 0 : 90 }}
+            transition={{
+              type: 'timing',
+              duration: 200,
+              easing: [0.455, 0.03, 0.515, 0.955],
+            }}
             style={{
-              transform: [{ rotate: isCollapsed ? '0deg' : '90deg' }],
-              transitionProperty: 'transform',
-              transitionDuration: 200,
               marginRight: 8,
+              width: 18,
+              height: 18,
             }}
           >
             <FeatherIcon name="chevron-right" size={18} color="tertiary" />
-          </Animated.View>
+          </EaseView>
           <Text fontSize={16} bold flex>
             {title}
           </Text>

--- a/src/features/settings/components/FilterChipRow.tsx
+++ b/src/features/settings/components/FilterChipRow.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ScrollView, TouchableOpacity } from 'react-native'
 import { useTheme } from '@emotion/react'
 import { useTranslation } from 'react-i18next'
-import Animated from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
 
 import Text from '~common/ui/Text'
 
@@ -73,16 +73,21 @@ const FilterChipRow = ({
     >
       {chips.map(chip => (
         <TouchableOpacity key={chip.key} onPress={chip.onPress} activeOpacity={0.7}>
-          <Animated.View
+          <EaseView
+            animate={{
+              backgroundColor: chip.isActive ? theme.colors.primary : theme.colors.border,
+            }}
+            transition={{
+              type: 'timing',
+              duration: 200,
+              easing: [0.455, 0.03, 0.515, 0.955],
+            }}
             style={{
               height: 32,
               paddingHorizontal: 12,
               borderRadius: 16,
               justifyContent: 'center',
               alignItems: 'center',
-              backgroundColor: chip.isActive ? theme.colors.primary : theme.colors.border,
-              transitionProperty: 'backgroundColor',
-              transitionDuration: 200,
             }}
           >
             <Text
@@ -94,7 +99,7 @@ const FilterChipRow = ({
             >
               {chip.label}
             </Text>
-          </Animated.View>
+          </EaseView>
         </TouchableOpacity>
       ))}
     </ScrollView>

--- a/src/features/settings/components/GlobalDownloadBar.tsx
+++ b/src/features/settings/components/GlobalDownloadBar.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '@emotion/react'
 import { useTranslation } from 'react-i18next'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Animated from 'react-native-reanimated'
+import { EaseView } from 'react-native-ease'
 
 import Box from '~common/ui/Box'
 import Text from '~common/ui/Text'
@@ -18,16 +19,18 @@ const GlobalDownloadBar = () => {
   const isVisible = activeQueue.length > 0
 
   return (
-    <Animated.View
+    <EaseView
+      animate={{ translateY: isVisible ? 0 : 100 }}
+      transition={{
+        type: 'timing',
+        duration: 300,
+        easing: 'easeOut',
+      }}
       style={{
         position: 'absolute',
         left: 0,
         right: 0,
         bottom: 0,
-        transform: [{ translateY: isVisible ? 0 : 100 }],
-        transitionProperty: 'transform',
-        transitionDuration: 300,
-        transitionTimingFunction: 'ease-out',
       }}
     >
       <Box
@@ -75,7 +78,7 @@ const GlobalDownloadBar = () => {
           </TouchableOpacity>
         </Box>
       </Box>
-    </Animated.View>
+    </EaseView>
   )
 }
 


### PR DESCRIPTION
## What changed
- Replaced simple Reanimated wrappers with `EaseView` in six state-driven animation sites.
- Preserved Reanimated where animations still rely on shared values, layout animations, unsupported width/color/position properties, or progress-bar widths.
- Mapped timing transitions explicitly so Reanimated v4 default easing behavior is preserved where applicable.

## Why
- Reduces Reanimated usage for simple state-driven opacity, rotate, backgroundColor, and translateY transitions.
- Keeps gesture, scroll, layout, and unsupported-property animations untouched for safety.

## Verification
- `yarn typecheck`
- `yarn lint` (passes; existing ESLintEnvWarning warnings remain in Redux test files)