### PR TITLE
refactor(architecture): deepen bible study modules

### DIFF
--- a/src/features/bible/BibleViewer.tsx
+++ b/src/features/bible/BibleViewer.tsx
@@ -6,10 +6,6 @@ import Box from '~common/ui/Box'
 import { isOnboardingCompletedAtom } from '~features/onboarding/atom'
 import { BibleError } from '~helpers/bibleErrors'
 import BibleErrorView from './BibleErrorView'
-import getBiblePericope from '~helpers/getBiblePericope'
-import loadBibleChapter from '~helpers/loadBibleChapter'
-import { loadRedWords } from '~helpers/loadRedWords'
-import loadMhyComments from '~helpers/loadMhyComments'
 import { usePrevious } from '~helpers/usePrevious'
 import BibleHeader from './BibleHeader'
 
@@ -59,6 +55,19 @@ import SnapshotPlaceholder from './SnapshotPlaceholder'
 import AnnotationNoteModal from './AnnotationNoteModal'
 import AnnotationToolbar from './AnnotationToolbar'
 import { BibleDOMWrapper, ParallelVerse } from './BibleDOM/BibleDOMWrapper'
+import {
+  loadBibleReadingComments,
+  loadBibleReadingMain,
+  loadBibleReadingParallelVerses,
+  loadBibleReadingRedWords,
+  loadBibleReadingSecondaryVerses,
+  RedWordsByVerse,
+} from './bibleReadingChapter'
+import {
+  getFirstSelectedVerseLocation,
+  selectAllChapterVerses,
+  selectedVersesIncludeFocus,
+} from './selectedVersesActions'
 import BibleLinkModal from './BibleLinkModal'
 import BibleNoteModal from './BibleNoteModal'
 import BibleParamsModal from './BibleParamsModal'
@@ -117,9 +126,7 @@ const BibleViewer = ({
   const [parallelVerses, setParallelVerses] = useState<ParallelVerse[]>([])
   const [secondaryVerses, setSecondaryVerses] = useState<Verse[] | null>(null)
   const [comments, setComments] = useState<{ [key: string]: string } | null>(null)
-  const [redWords, setRedWords] = useState<Record<string, { start: number; end: number }[]> | null>(
-    null
-  )
+  const [redWords, setRedWords] = useState<RedWordsByVerse | null>(null)
   const setUnifiedTagsModal = useSetAtom(unifiedTagsModalAtom)
   const [noteVerses, setNoteVerses] = useState<VerseIds | undefined>(undefined)
   const [linkVerses, setLinkVerses] = useState<VerseIds | undefined>(undefined)
@@ -288,10 +295,7 @@ const BibleViewer = ({
   }, [verses, annotationModeEnabled, setAnnotationVerses])
 
   const selectAllVerses = () => {
-    const selectedVersesToAdd: VerseIds = Object.fromEntries(
-      verses.map(v => [`${v.Livre}-${v.Chapitre}-${v.Verset}`, true])
-    )
-    actions.selectAllVerses(selectedVersesToAdd)
+    actions.selectAllVerses(selectAllChapterVerses(verses))
   }
 
   // Open/close verses modal based on selected verses
@@ -346,10 +350,11 @@ const BibleViewer = ({
     const currentLoadId = ++loadIdRef.current
 
     // Phase 1: Load main verses + pericopes (critical path)
-    const [pericopeToLoad, mainResult] = await Promise.all([
-      getBiblePericope(version),
-      loadBibleChapter(book.Numero, chapter, version),
-    ])
+    const { pericope: pericopeToLoad, mainResult } = await loadBibleReadingMain({
+      book: book.Numero,
+      chapter,
+      version,
+    })
 
     // If main Bible version fails, set error and stop
     if (!mainResult.success || !mainResult.data) {
@@ -387,70 +392,43 @@ const BibleViewer = ({
     })
 
     // Phase 2: Hydrate secondary data in background (non-blocking)
+    const extrasRequest = {
+      book: book.Numero,
+      chapter,
+      version,
+      parallelVersions,
+      commentsDisplay: settings.commentsDisplay,
+      lang,
+    }
 
     // Parallel versions
-    if (parallelVersions.length) {
-      Promise.all(parallelVersions.map(p => loadBibleChapter(book.Numero, chapter, p))).then(
-        parallelResults => {
-          if (loadIdRef.current !== currentLoadId) return
-          const parallelVersesToLoad: ParallelVerse[] = []
-          for (let i = 0; i < parallelVersions.length; i++) {
-            const pResult = parallelResults[i]
-            if (pResult.success && pResult.data) {
-              parallelVersesToLoad.push({
-                id: parallelVersions[i],
-                verses: pResult.data as Verse[],
-              })
-            } else {
-              parallelVersesToLoad.push({
-                id: parallelVersions[i],
-                verses: [],
-                error: pResult.error,
-              })
-            }
-          }
-          setParallelVerses(parallelVersesToLoad)
-        }
-      )
-    } else {
-      setParallelVerses([])
-    }
+    loadBibleReadingParallelVerses(extrasRequest).then(parallelVersesToLoad => {
+      if (loadIdRef.current !== currentLoadId) return
+      setParallelVerses(parallelVersesToLoad)
+    })
 
     // Secondary verses for interlinear mode
-    if (version === 'INT' || version === 'INT_EN') {
-      loadBibleChapter(book.Numero, chapter, getDefaultBibleVersion(lang)).then(secondaryResult => {
-        if (loadIdRef.current !== currentLoadId) return
-        if (secondaryResult.success && secondaryResult.data) {
-          setSecondaryVerses(secondaryResult.data as Verse[])
-        } else {
-          setSecondaryVerses(null)
-        }
-      })
-    } else {
-      setSecondaryVerses(null)
-    }
+    loadBibleReadingSecondaryVerses(extrasRequest).then(secondaryVersesToLoad => {
+      if (loadIdRef.current !== currentLoadId) return
+      setSecondaryVerses(secondaryVersesToLoad)
+    })
 
     // Comments
-    if (settings.commentsDisplay) {
-      loadMhyComments(book.Numero, chapter)
-        .then(c => {
-          if (loadIdRef.current !== currentLoadId) return
-          if (!c || 'error' in c) return
-          setComments(JSON.parse(c.commentaires))
-        })
-        .catch(() => {
-          if (loadIdRef.current !== currentLoadId) return
-          setComments(null)
-        })
-    } else if (comments) {
-      setComments(null)
-    }
+    loadBibleReadingComments(extrasRequest)
+      .then(commentsToLoad => {
+        if (loadIdRef.current !== currentLoadId) return
+        setComments(commentsToLoad)
+      })
+      .catch(() => {
+        if (loadIdRef.current !== currentLoadId) return
+        setComments(null)
+      })
 
     // Red words (memoized, fast on subsequent calls)
-    loadRedWords(version)
-      .then(rw => {
+    loadBibleReadingRedWords(extrasRequest)
+      .then(redWordsToLoad => {
         if (loadIdRef.current !== currentLoadId) return
-        setRedWords(rw)
+        setRedWords(redWordsToLoad)
       })
       .catch(() => setRedWords(null))
   }
@@ -599,12 +577,7 @@ const BibleViewer = ({
 
   // Pin verses handler - toggles focus on/off
   const handlePinVerses = () => {
-    // Check if a selected verse is already in focus
-    const selectedKeys = Object.keys(selectedVerses)
-    const hasFocusActive =
-      focusVerses?.some(v => selectedKeys.some(key => key.endsWith(`-${v}`))) ?? false
-
-    if (hasFocusActive) {
+    if (selectedVersesIncludeFocus(selectedVerses, focusVerses)) {
       actions.clearFocusVerses()
     } else {
       actions.pinSelectedVerses()
@@ -613,14 +586,12 @@ const BibleViewer = ({
 
   // Bookmark handler
   const handleAddBookmark = useCallback(() => {
-    // Get the first selected verse for the bookmark
-    const firstVerseKey = Object.keys(selectedVerses)[0]
-    if (firstVerseKey) {
-      const [bookNum, chapterNum, verseNum] = firstVerseKey.split('-').map(Number)
+    const location = getFirstSelectedVerseLocation(selectedVerses)
+    if (location) {
       setSelectedVerseForBookmark({
-        book: bookNum,
-        chapter: chapterNum,
-        verse: verseNum,
+        book: location.book,
+        chapter: location.chapter,
+        verse: location.verse,
       })
       setEditingBookmark(null)
       // Use setTimeout to ensure state is updated before presenting

--- a/src/features/bible/__tests__/selectedVersesActions-test.ts
+++ b/src/features/bible/__tests__/selectedVersesActions-test.ts
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import {
+  getFirstSelectedVerseLocation,
+  parseVerseLocation,
+  selectAllChapterVerses,
+  selectedVersesIncludeFocus,
+} from '../selectedVersesActions'
+
+describe('selectedVersesActions', () => {
+  it('selects all verses from a chapter', () => {
+    expect(
+      selectAllChapterVerses([
+        { Livre: 1, Chapitre: 1, Verset: 1 },
+        { Livre: 1, Chapitre: 1, Verset: 2 },
+      ])
+    ).toEqual({
+      '1-1-1': true,
+      '1-1-2': true,
+    })
+  })
+
+  it('parses a verse key into a location', () => {
+    expect(parseVerseLocation('2-3-4')).toEqual({ book: 2, chapter: 3, verse: 4 })
+  })
+
+  it('returns null for an invalid verse key', () => {
+    expect(parseVerseLocation('bad-key')).toBeNull()
+  })
+
+  it('returns the first selected verse location', () => {
+    expect(getFirstSelectedVerseLocation({ '1-2-3': true, '1-2-4': true })).toEqual({
+      book: 1,
+      chapter: 2,
+      verse: 3,
+    })
+  })
+
+  it('detects whether selected verses include a focused verse', () => {
+    expect(selectedVersesIncludeFocus({ '1-1-3': true }, [2, 3])).toBe(true)
+    expect(selectedVersesIncludeFocus({ '1-1-4': true }, [2, 3])).toBe(false)
+  })
+})

--- a/src/features/bible/bibleReadingChapter.ts
+++ b/src/features/bible/bibleReadingChapter.ts
@@ -1,0 +1,113 @@
+import type { Pericope, Verse } from '~common/types'
+import { BibleError, BibleChapterResult } from '~helpers/bibleErrors'
+import getBiblePericope from '~helpers/getBiblePericope'
+import loadBibleChapter from '~helpers/loadBibleChapter'
+import { loadRedWords } from '~helpers/loadRedWords'
+import loadMhyComments from '~helpers/loadMhyComments'
+import { getDefaultBibleVersion } from '~helpers/languageUtils'
+import type { VersionCode } from '~state/tabs'
+import type { ParallelVerse } from './BibleDOM/BibleDOMWrapper'
+
+type RedWordsRange = { start: number; end: number }
+export type RedWordsByVerse = Record<string, RedWordsRange[]>
+export type CommentsByVerse = Record<string, string>
+
+export interface BibleReadingChapterRequest {
+  book: number
+  chapter: number
+  version: VersionCode
+}
+
+export interface BibleReadingExtrasRequest extends BibleReadingChapterRequest {
+  parallelVersions: VersionCode[]
+  commentsDisplay: boolean
+  lang: string
+}
+
+export interface BibleReadingMainResult {
+  pericope: Pericope
+  mainResult: BibleChapterResult<Verse[] | null>
+}
+
+export const loadBibleReadingMain = async ({
+  book,
+  chapter,
+  version,
+}: BibleReadingChapterRequest): Promise<BibleReadingMainResult> => {
+  const [pericope, mainResult] = await Promise.all([
+    getBiblePericope(version),
+    loadBibleChapter(book, chapter, version),
+  ])
+
+  return {
+    pericope,
+    mainResult: mainResult as BibleChapterResult<Verse[] | null>,
+  }
+}
+
+export const loadBibleReadingParallelVerses = async ({
+  book,
+  chapter,
+  parallelVersions,
+}: BibleReadingExtrasRequest): Promise<ParallelVerse[]> => {
+  if (!parallelVersions.length) return []
+
+  const parallelResults = await Promise.all(
+    parallelVersions.map(parallelVersion => loadBibleChapter(book, chapter, parallelVersion))
+  )
+
+  return parallelResults.map((result, index) => {
+    const id = parallelVersions[index]
+    if (result.success && result.data) {
+      return {
+        id,
+        verses: result.data as Verse[],
+      }
+    }
+
+    return {
+      id,
+      verses: [],
+      error: result.error as BibleError | undefined,
+    }
+  })
+}
+
+export const loadBibleReadingSecondaryVerses = async ({
+  book,
+  chapter,
+  version,
+  lang,
+}: BibleReadingExtrasRequest): Promise<Verse[] | null> => {
+  if (version !== 'INT' && version !== 'INT_EN') return null
+
+  const secondaryResult = await loadBibleChapter(book, chapter, getDefaultBibleVersion(lang))
+  if (secondaryResult.success && secondaryResult.data) {
+    return secondaryResult.data as Verse[]
+  }
+
+  return null
+}
+
+export const loadBibleReadingComments = async ({
+  book,
+  chapter,
+  commentsDisplay,
+}: BibleReadingExtrasRequest): Promise<CommentsByVerse | null> => {
+  if (!commentsDisplay) return null
+
+  const comments = await loadMhyComments(book, chapter)
+  if (!comments || 'error' in comments) return null
+
+  return JSON.parse(comments.commentaires) as CommentsByVerse
+}
+
+export const loadBibleReadingRedWords = async ({
+  version,
+}: BibleReadingChapterRequest): Promise<RedWordsByVerse | null> => {
+  try {
+    return await loadRedWords(version)
+  } catch {
+    return null
+  }
+}

--- a/src/features/bible/selectedVersesActions.ts
+++ b/src/features/bible/selectedVersesActions.ts
@@ -1,0 +1,42 @@
+import type { Verse, VerseIds } from '~common/types'
+
+export interface VerseLocation {
+  book: number
+  chapter: number
+  verse: number
+}
+
+export const getVerseKey = (verse: Pick<Verse, 'Livre' | 'Chapitre' | 'Verset'>): string =>
+  `${verse.Livre}-${verse.Chapitre}-${verse.Verset}`
+
+export const selectAllChapterVerses = (verses: Pick<Verse, 'Livre' | 'Chapitre' | 'Verset'>[]) =>
+  Object.fromEntries(verses.map(verse => [getVerseKey(verse), true])) as VerseIds
+
+export const parseVerseLocation = (verseKey: string): VerseLocation | null => {
+  const [book, chapter, verse] = verseKey.split('-').map(Number)
+
+  if (!Number.isFinite(book) || !Number.isFinite(chapter) || !Number.isFinite(verse)) {
+    return null
+  }
+
+  return { book, chapter, verse }
+}
+
+export const getFirstSelectedVerseLocation = (selectedVerses: VerseIds): VerseLocation | null => {
+  const firstVerseKey = Object.keys(selectedVerses)[0]
+  if (!firstVerseKey) return null
+
+  return parseVerseLocation(firstVerseKey)
+}
+
+export const selectedVersesIncludeFocus = (
+  selectedVerses: VerseIds,
+  focusVerses: (string | number)[] | undefined
+): boolean => {
+  if (!focusVerses?.length) return false
+
+  const selectedKeys = Object.keys(selectedVerses)
+  return focusVerses.some(focusVerse =>
+    selectedKeys.some(selectedKey => selectedKey.endsWith(`-${focusVerse}`))
+  )
+}

--- a/src/helpers/downloadManager.ts
+++ b/src/helpers/downloadManager.ts
@@ -11,12 +11,8 @@ import {
   type DownloadStatus,
 } from '~state/downloadQueue'
 import { installedVersionsSignalAtom, bibleDataRefreshSignalAtom } from '~state/app'
-import { downloadAndInsertBible } from '~helpers/downloadBibleToSqlite'
-import { dbManager } from '~helpers/sqlite'
-import { downloadRedWordsFile, versionHasRedWords } from '~helpers/redWords'
-import { downloadPericopeFile, versionHasPericope } from '~helpers/pericopes'
 import { storage } from '~helpers/storage'
-import type { DatabaseId } from '~helpers/databaseTypes'
+import { installResourceDatabaseItem } from '~helpers/resourceDatabaseInstallation'
 
 const PERSIST_KEY = 'downloadQueue'
 const MAX_RETRIES = 2
@@ -226,17 +222,15 @@ class DownloadManager {
     try {
       this.updateItemStatus(item.id, 'downloading')
 
-      switch (item.type) {
-        case 'bible':
-          await this.processBible(item)
-          break
-        case 'bible-strong':
-          await this.processBibleStrong(item)
-          break
-        case 'database':
-          await this.processDatabase(item)
-          break
-      }
+      await installResourceDatabaseItem(item, {
+        onDownloadProgress: progress => this.updateItemProgress(item.id, progress, 0),
+        onInsertProgress: progress => this.updateItemProgress(item.id, 1, progress),
+        onStatusInserting: () => this.updateItemStatus(item.id, 'inserting'),
+        onResumable: resumable => {
+          this.currentResumable = resumable
+        },
+        isCancelled: () => this.cancelledIds.has(item.id),
+      })
 
       this.updateItemStatus(item.id, 'completed')
 
@@ -279,100 +273,6 @@ class DownloadManager {
     }
 
     this.schedulePersist()
-  }
-
-  // -----------------------------------------------------------------------
-  // Download strategies by type
-  // -----------------------------------------------------------------------
-
-  private async processBible(item: DownloadItem): Promise<void> {
-    const isCancelled = () => this.cancelledIds.has(item.id)
-
-    await downloadAndInsertBible(item.versionId!, item.url, {
-      onDownloadProgress: ({ totalBytesWritten }) => {
-        const progress = Math.min(totalBytesWritten / item.estimatedSize, 1)
-        this.updateItemProgress(item.id, progress, 0)
-      },
-      onResumable: resumable => {
-        this.currentResumable = resumable
-      },
-      onInsertProgress: progress => {
-        this.updateItemStatus(item.id, 'inserting')
-        this.updateItemProgress(item.id, 1, progress)
-      },
-      isCancelled,
-    })
-
-    this.currentResumable = null
-
-    // Download red words and pericopes
-    if (item.hasRedWords && versionHasRedWords(item.versionId!)) {
-      downloadRedWordsFile(item.versionId!)
-    }
-    if (item.hasPericope && versionHasPericope(item.versionId!)) {
-      downloadPericopeFile(item.versionId!)
-    }
-  }
-
-  private async processBibleStrong(item: DownloadItem): Promise<void> {
-    const path = item.destinationPath!
-
-    const resumable = FileSystem.createDownloadResumable(
-      item.url,
-      path,
-      undefined,
-      ({ totalBytesWritten }) => {
-        const progress = Math.min(totalBytesWritten / item.estimatedSize, 1)
-        this.updateItemProgress(item.id, progress, 0)
-      }
-    )
-
-    this.currentResumable = resumable
-    await resumable.downloadAsync()
-    this.currentResumable = null
-
-    if (this.cancelledIds.has(item.id)) throw new Error('CANCELLED')
-
-    // Initialize the DB after download
-    const versionId = item.versionId!
-    if (versionId === 'INT' || versionId === 'INT_EN') {
-      const lang = versionId === 'INT' ? 'fr' : 'en'
-      await dbManager.getDB('INTERLINEAIRE', lang).init()
-    }
-
-    // Download red words and pericopes
-    if (item.hasRedWords && versionHasRedWords(versionId)) {
-      downloadRedWordsFile(versionId)
-    }
-    if (item.hasPericope && versionHasPericope(versionId)) {
-      downloadPericopeFile(versionId)
-    }
-  }
-
-  private async processDatabase(item: DownloadItem): Promise<void> {
-    const path = item.destinationPath!
-
-    const resumable = FileSystem.createDownloadResumable(
-      item.url,
-      path,
-      undefined,
-      ({ totalBytesWritten }) => {
-        const progress = Math.min(totalBytesWritten / item.estimatedSize, 1)
-        this.updateItemProgress(item.id, progress, 0)
-      }
-    )
-
-    this.currentResumable = resumable
-    await resumable.downloadAsync()
-    this.currentResumable = null
-
-    if (this.cancelledIds.has(item.id)) throw new Error('CANCELLED')
-
-    // Initialize the database
-    const dbId = item.databaseId!
-    const lang = item.lang || 'fr'
-    const db = dbManager.getDB(dbId as DatabaseId, lang)
-    await db.init()
   }
 
   // -----------------------------------------------------------------------

--- a/src/helpers/resourceDatabaseInstallation.ts
+++ b/src/helpers/resourceDatabaseInstallation.ts
@@ -1,0 +1,101 @@
+import * as FileSystem from 'expo-file-system/legacy'
+
+import { downloadAndInsertBible } from '~helpers/downloadBibleToSqlite'
+import { dbManager } from '~helpers/sqlite'
+import { downloadRedWordsFile, versionHasRedWords } from '~helpers/redWords'
+import { downloadPericopeFile, versionHasPericope } from '~helpers/pericopes'
+import type { DatabaseId } from '~helpers/databaseTypes'
+import type { DownloadItem } from '~state/downloadQueue'
+
+export interface ResourceInstallationCallbacks {
+  onDownloadProgress: (progress: number) => void
+  onInsertProgress: (progress: number) => void
+  onStatusInserting: () => void
+  onResumable: (resumable: FileSystem.DownloadResumable | null) => void
+  isCancelled: () => boolean
+}
+
+const downloadSidecarBibleFiles = (item: DownloadItem, versionId: string) => {
+  if (item.hasRedWords && versionHasRedWords(versionId)) {
+    downloadRedWordsFile(versionId)
+  }
+  if (item.hasPericope && versionHasPericope(versionId)) {
+    downloadPericopeFile(versionId)
+  }
+}
+
+const downloadFile = async (item: DownloadItem, callbacks: ResourceInstallationCallbacks) => {
+  const resumable = FileSystem.createDownloadResumable(
+    item.url,
+    item.destinationPath!,
+    undefined,
+    ({ totalBytesWritten }) => {
+      callbacks.onDownloadProgress(Math.min(totalBytesWritten / item.estimatedSize, 1))
+    }
+  )
+
+  callbacks.onResumable(resumable)
+  await resumable.downloadAsync()
+  callbacks.onResumable(null)
+
+  if (callbacks.isCancelled()) throw new Error('CANCELLED')
+}
+
+const installBible = async (item: DownloadItem, callbacks: ResourceInstallationCallbacks) => {
+  const versionId = item.versionId!
+
+  await downloadAndInsertBible(versionId, item.url, {
+    onDownloadProgress: ({ totalBytesWritten }) => {
+      callbacks.onDownloadProgress(Math.min(totalBytesWritten / item.estimatedSize, 1))
+    },
+    onResumable: callbacks.onResumable,
+    onInsertProgress: progress => {
+      callbacks.onStatusInserting()
+      callbacks.onInsertProgress(progress)
+    },
+    isCancelled: callbacks.isCancelled,
+  })
+
+  callbacks.onResumable(null)
+  downloadSidecarBibleFiles(item, versionId)
+}
+
+const installBibleStrong = async (
+  item: DownloadItem,
+  callbacks: ResourceInstallationCallbacks
+) => {
+  await downloadFile(item, callbacks)
+
+  const versionId = item.versionId!
+  if (versionId === 'INT' || versionId === 'INT_EN') {
+    const lang = versionId === 'INT' ? 'fr' : 'en'
+    await dbManager.getDB('INTERLINEAIRE', lang).init()
+  }
+
+  downloadSidecarBibleFiles(item, versionId)
+}
+
+const installDatabase = async (item: DownloadItem, callbacks: ResourceInstallationCallbacks) => {
+  await downloadFile(item, callbacks)
+
+  const dbId = item.databaseId!
+  const lang = item.lang || 'fr'
+  await dbManager.getDB(dbId as DatabaseId, lang).init()
+}
+
+export const installResourceDatabaseItem = async (
+  item: DownloadItem,
+  callbacks: ResourceInstallationCallbacks
+) => {
+  switch (item.type) {
+    case 'bible':
+      await installBible(item, callbacks)
+      break
+    case 'bible-strong':
+      await installBibleStrong(item, callbacks)
+      break
+    case 'database':
+      await installDatabase(item, callbacks)
+      break
+  }
+}

--- a/src/redux/modules/user.ts
+++ b/src/redux/modules/user.ts
@@ -44,6 +44,11 @@ import {
   WordAnnotationsObj,
 } from './user/wordAnnotations'
 import {
+  findOverlappingWordAnnotationIds,
+  getSelectionRangeFromAnnotation,
+  normalizeWordSelectionRange,
+} from './user/wordAnnotationRanges'
+import {
   changeColor,
   decreaseSettingsFontSizeScale,
   increaseSettingsFontSizeScale,
@@ -715,66 +720,17 @@ const userSlice = createSlice({
     builder.addCase(addWordAnnotationAction, (state, action) => {
       const annotation = action.payload.annotation
 
-      // Helper to compare verse keys (e.g., "1-1-5" vs "1-1-10")
-      const parseVerseKey = (key: string) => {
-        const [book, chapter, verse] = key.split('-').map(Number)
-        return { book, chapter, verse }
-      }
+      const selection = getSelectionRangeFromAnnotation(annotation)
+      if (selection) {
+        const idsToRemove = findOverlappingWordAnnotationIds(
+          state.bible.wordAnnotations,
+          annotation.version,
+          selection
+        )
 
-      const compareVerseKeys = (a: string, b: string): number => {
-        const pa = parseVerseKey(a)
-        const pb = parseVerseKey(b)
-        if (pa.book !== pb.book) return pa.book - pb.book
-        if (pa.chapter !== pb.chapter) return pa.chapter - pb.chapter
-        return pa.verse - pb.verse
-      }
-
-      // Get the bounds of the new annotation
-      const newRanges = annotation.ranges
-      if (newRanges.length > 0) {
-        const firstRange = newRanges[0]
-        const lastRange = newRanges[newRanges.length - 1]
-        const start = { verseKey: firstRange.verseKey, wordIndex: firstRange.startWordIndex }
-        const end = { verseKey: lastRange.verseKey, wordIndex: lastRange.endWordIndex }
-
-        // Find and remove overlapping annotations
-        const annotationIds = Object.keys(state.bible.wordAnnotations)
-        annotationIds.forEach(id => {
-          const existingAnnotation = state.bible.wordAnnotations[id]
-          if (existingAnnotation.version !== annotation.version) return
-
-          const overlaps = existingAnnotation.ranges.some(range => {
-            const rangeVerseCompareStart = compareVerseKeys(range.verseKey, start.verseKey)
-            const rangeVerseCompareEnd = compareVerseKeys(range.verseKey, end.verseKey)
-
-            // Check if this range's verse is within the selection verses
-            if (rangeVerseCompareStart < 0 || rangeVerseCompareEnd > 0) {
-              return false
-            }
-
-            // Same verse as both start and end
-            if (rangeVerseCompareStart === 0 && rangeVerseCompareEnd === 0) {
-              return range.endWordIndex >= start.wordIndex && range.startWordIndex <= end.wordIndex
-            }
-
-            // Verse is same as start verse only
-            if (rangeVerseCompareStart === 0) {
-              return range.endWordIndex >= start.wordIndex
-            }
-
-            // Verse is same as end verse only
-            if (rangeVerseCompareEnd === 0) {
-              return range.startWordIndex <= end.wordIndex
-            }
-
-            // Verse is strictly between start and end
-            return true
-          })
-
-          if (overlaps) {
-            delete state.bible.wordAnnotations[id]
-            removeEntityInTags(state, 'wordAnnotations', id)
-          }
+        idsToRemove.forEach(id => {
+          delete state.bible.wordAnnotations[id]
+          removeEntityInTags(state, 'wordAnnotations', id)
         })
       }
 
@@ -817,75 +773,12 @@ const userSlice = createSlice({
     })
     builder.addCase(removeWordAnnotationsInRangeAction, (state, action) => {
       const { version, start, end } = action.payload
-
-      // Helper to compare verse keys (e.g., "1-1-5" vs "1-1-10")
-      const parseVerseKey = (key: string) => {
-        const [book, chapter, verse] = key.split('-').map(Number)
-        return { book, chapter, verse }
-      }
-
-      const compareVerseKeys = (a: string, b: string): number => {
-        const pa = parseVerseKey(a)
-        const pb = parseVerseKey(b)
-        if (pa.book !== pb.book) return pa.book - pb.book
-        if (pa.chapter !== pb.chapter) return pa.chapter - pb.chapter
-        return pa.verse - pb.verse
-      }
-
-      // Normalize start and end (ensure start <= end)
-      let normalizedStart = start
-      let normalizedEnd = end
-      const verseCompare = compareVerseKeys(start.verseKey, end.verseKey)
-      if (verseCompare > 0 || (verseCompare === 0 && start.wordIndex > end.wordIndex)) {
-        normalizedStart = end
-        normalizedEnd = start
-      }
-
-      // Find all annotations that overlap with the selection range
-      const annotationIds = Object.keys(state.bible.wordAnnotations)
-      const idsToRemove: string[] = []
-
-      annotationIds.forEach(id => {
-        const annotation = state.bible.wordAnnotations[id]
-        if (annotation.version !== version) return
-
-        // Check if a range of this annotation overlaps with the selection
-        const overlaps = annotation.ranges.some(range => {
-          const rangeVerseCompare = compareVerseKeys(range.verseKey, normalizedStart.verseKey)
-          const rangeVerseCompareEnd = compareVerseKeys(range.verseKey, normalizedEnd.verseKey)
-
-          // Check if this range's verse is within the selection verses
-          if (rangeVerseCompare < 0 || rangeVerseCompareEnd > 0) {
-            return false // Verse is outside selection
-          }
-
-          // Same verse as start
-          if (rangeVerseCompare === 0 && rangeVerseCompareEnd === 0) {
-            // Single verse selection - check word indices
-            return (
-              range.endWordIndex >= normalizedStart.wordIndex &&
-              range.startWordIndex <= normalizedEnd.wordIndex
-            )
-          }
-
-          // Verse is same as start verse only
-          if (rangeVerseCompare === 0) {
-            return range.endWordIndex >= normalizedStart.wordIndex
-          }
-
-          // Verse is same as end verse only
-          if (rangeVerseCompareEnd === 0) {
-            return range.startWordIndex <= normalizedEnd.wordIndex
-          }
-
-          // Verse is strictly between start and end
-          return true
-        })
-
-        if (overlaps) {
-          idsToRemove.push(id)
-        }
-      })
+      const selection = normalizeWordSelectionRange(start, end)
+      const idsToRemove = findOverlappingWordAnnotationIds(
+        state.bible.wordAnnotations,
+        version,
+        selection
+      )
 
       // Remove the overlapping annotations
       idsToRemove.forEach(id => {

--- a/src/redux/modules/user/__tests__/wordAnnotationRanges-test.ts
+++ b/src/redux/modules/user/__tests__/wordAnnotationRanges-test.ts
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+
+import {
+  annotationRangeOverlapsSelection,
+  findOverlappingWordAnnotationIds,
+  normalizeWordSelectionRange,
+} from '../wordAnnotationRanges'
+import type { WordAnnotation } from '../wordAnnotations'
+
+const makeAnnotation = (
+  id: string,
+  version: WordAnnotation['version'],
+  ranges: WordAnnotation['ranges']
+): WordAnnotation => ({
+  id,
+  version,
+  ranges,
+  color: '#ff0000',
+  type: 'background',
+  date: 1,
+})
+
+describe('wordAnnotationRanges', () => {
+  describe('normalizeWordSelectionRange', () => {
+    it('keeps an ordered range as-is', () => {
+      expect(
+        normalizeWordSelectionRange(
+          { verseKey: '1-1-1', wordIndex: 2 },
+          { verseKey: '1-1-2', wordIndex: 1 }
+        )
+      ).toEqual({
+        start: { verseKey: '1-1-1', wordIndex: 2 },
+        end: { verseKey: '1-1-2', wordIndex: 1 },
+      })
+    })
+
+    it('reverses a backwards range in the same verse', () => {
+      expect(
+        normalizeWordSelectionRange(
+          { verseKey: '1-1-1', wordIndex: 5 },
+          { verseKey: '1-1-1', wordIndex: 2 }
+        )
+      ).toEqual({
+        start: { verseKey: '1-1-1', wordIndex: 2 },
+        end: { verseKey: '1-1-1', wordIndex: 5 },
+      })
+    })
+  })
+
+  describe('annotationRangeOverlapsSelection', () => {
+    it('detects overlap inside a single verse', () => {
+      const selection = normalizeWordSelectionRange(
+        { verseKey: '1-1-1', wordIndex: 2 },
+        { verseKey: '1-1-1', wordIndex: 5 }
+      )
+
+      expect(
+        annotationRangeOverlapsSelection(
+          { verseKey: '1-1-1', startWordIndex: 4, endWordIndex: 8, text: 'text' },
+          selection
+        )
+      ).toBe(true)
+    })
+
+    it('ignores ranges outside a single verse selection', () => {
+      const selection = normalizeWordSelectionRange(
+        { verseKey: '1-1-1', wordIndex: 2 },
+        { verseKey: '1-1-1', wordIndex: 5 }
+      )
+
+      expect(
+        annotationRangeOverlapsSelection(
+          { verseKey: '1-1-1', startWordIndex: 6, endWordIndex: 8, text: 'text' },
+          selection
+        )
+      ).toBe(false)
+    })
+
+    it('detects a whole middle verse in a multi-verse selection', () => {
+      const selection = normalizeWordSelectionRange(
+        { verseKey: '1-1-1', wordIndex: 6 },
+        { verseKey: '1-1-3', wordIndex: 2 }
+      )
+
+      expect(
+        annotationRangeOverlapsSelection(
+          { verseKey: '1-1-2', startWordIndex: 0, endWordIndex: 10, text: 'text' },
+          selection
+        )
+      ).toBe(true)
+    })
+  })
+
+  describe('findOverlappingWordAnnotationIds', () => {
+    it('returns only ids matching the version and overlapping the selection', () => {
+      const selection = normalizeWordSelectionRange(
+        { verseKey: '1-1-1', wordIndex: 2 },
+        { verseKey: '1-1-2', wordIndex: 4 }
+      )
+
+      const annotations = {
+        overlapping: makeAnnotation('overlapping', 'LSG', [
+          { verseKey: '1-1-2', startWordIndex: 1, endWordIndex: 2, text: 'text' },
+        ]),
+        otherVersion: makeAnnotation('otherVersion', 'KJV', [
+          { verseKey: '1-1-2', startWordIndex: 1, endWordIndex: 2, text: 'text' },
+        ]),
+        outside: makeAnnotation('outside', 'LSG', [
+          { verseKey: '1-1-3', startWordIndex: 1, endWordIndex: 2, text: 'text' },
+        ]),
+      }
+
+      expect(findOverlappingWordAnnotationIds(annotations, 'LSG', selection)).toEqual([
+        'overlapping',
+      ])
+    })
+  })
+})

--- a/src/redux/modules/user/wordAnnotationRanges.ts
+++ b/src/redux/modules/user/wordAnnotationRanges.ts
@@ -1,0 +1,102 @@
+import type { AnnotationRange, WordAnnotation, WordAnnotationsObj } from './wordAnnotations'
+
+export interface WordPosition {
+  verseKey: string
+  wordIndex: number
+}
+
+export interface NormalizedWordSelectionRange {
+  start: WordPosition
+  end: WordPosition
+}
+
+export const parseVerseKey = (key: string) => {
+  const [book, chapter, verse] = key.split('-').map(Number)
+  return { book, chapter, verse }
+}
+
+export const compareVerseKeys = (a: string, b: string): number => {
+  const pa = parseVerseKey(a)
+  const pb = parseVerseKey(b)
+  if (pa.book !== pb.book) return pa.book - pb.book
+  if (pa.chapter !== pb.chapter) return pa.chapter - pb.chapter
+  return pa.verse - pb.verse
+}
+
+export const normalizeWordSelectionRange = (
+  start: WordPosition,
+  end: WordPosition
+): NormalizedWordSelectionRange => {
+  const verseCompare = compareVerseKeys(start.verseKey, end.verseKey)
+  if (verseCompare > 0 || (verseCompare === 0 && start.wordIndex > end.wordIndex)) {
+    return { start: end, end: start }
+  }
+  return { start, end }
+}
+
+export const annotationRangeOverlapsSelection = (
+  range: AnnotationRange,
+  selection: NormalizedWordSelectionRange
+): boolean => {
+  const rangeVerseCompareStart = compareVerseKeys(range.verseKey, selection.start.verseKey)
+  const rangeVerseCompareEnd = compareVerseKeys(range.verseKey, selection.end.verseKey)
+
+  if (rangeVerseCompareStart < 0 || rangeVerseCompareEnd > 0) {
+    return false
+  }
+
+  if (rangeVerseCompareStart === 0 && rangeVerseCompareEnd === 0) {
+    return (
+      range.endWordIndex >= selection.start.wordIndex &&
+      range.startWordIndex <= selection.end.wordIndex
+    )
+  }
+
+  if (rangeVerseCompareStart === 0) {
+    return range.endWordIndex >= selection.start.wordIndex
+  }
+
+  if (rangeVerseCompareEnd === 0) {
+    return range.startWordIndex <= selection.end.wordIndex
+  }
+
+  return true
+}
+
+export const wordAnnotationOverlapsSelection = (
+  annotation: WordAnnotation,
+  selection: NormalizedWordSelectionRange
+): boolean => annotation.ranges.some(range => annotationRangeOverlapsSelection(range, selection))
+
+export const getSelectionRangeFromAnnotation = (
+  annotation: WordAnnotation
+): NormalizedWordSelectionRange | null => {
+  const firstRange = annotation.ranges[0]
+  const lastRange = annotation.ranges[annotation.ranges.length - 1]
+
+  if (!firstRange || !lastRange) return null
+
+  return normalizeWordSelectionRange(
+    { verseKey: firstRange.verseKey, wordIndex: firstRange.startWordIndex },
+    { verseKey: lastRange.verseKey, wordIndex: lastRange.endWordIndex }
+  )
+}
+
+export const findOverlappingWordAnnotationIds = (
+  wordAnnotations: WordAnnotationsObj,
+  version: string,
+  selection: NormalizedWordSelectionRange
+): string[] => {
+  const idsToRemove: string[] = []
+
+  for (const id of Object.keys(wordAnnotations)) {
+    const annotation = wordAnnotations[id]
+    if (annotation.version !== version) continue
+
+    if (wordAnnotationOverlapsSelection(annotation, selection)) {
+      idsToRemove.push(id)
+    }
+  }
+
+  return idsToRemove
+}

--- a/src/state/__tests__/tabWorkspace-test.ts
+++ b/src/state/__tests__/tabWorkspace-test.ts
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+
+import { clampTabIndex, updateTabGroupActiveIndex, updateTabGroupTabs } from '../tabWorkspace'
+import type { TabGroup, TabItem } from '../tabs'
+
+const makeTab = (id: string): TabItem => ({
+  id,
+  title: id,
+  isRemovable: true,
+  type: 'new',
+  data: {},
+})
+
+const makeGroup = (id: string, tabs: TabItem[], activeTabIndex = 0): TabGroup => ({
+  id,
+  name: id,
+  isDefault: id === 'default',
+  tabs,
+  activeTabIndex,
+  createdAt: 0,
+  updatedAt: 0,
+})
+
+describe('tabWorkspace', () => {
+  it('clamps active tab indexes into the available tab range', () => {
+    expect(clampTabIndex(-1, 3)).toBe(0)
+    expect(clampTabIndex(9, 3)).toBe(2)
+    expect(clampTabIndex(1, 3)).toBe(1)
+    expect(clampTabIndex(1, 0)).toBe(0)
+  })
+
+  it('updates tabs for one group and clamps its active index', () => {
+    const groups = [
+      makeGroup('default', [makeTab('a'), makeTab('b')], 1),
+      makeGroup('other', [makeTab('c')], 0),
+    ]
+
+    const next = updateTabGroupTabs(groups, 'default', [makeTab('a')])
+
+    expect(next[0].tabs).toHaveLength(1)
+    expect(next[0].activeTabIndex).toBe(0)
+    expect(next[1]).toBe(groups[1])
+  })
+
+  it('updates the active index for one group', () => {
+    const groups = [makeGroup('default', [makeTab('a'), makeTab('b')], 0)]
+
+    const next = updateTabGroupActiveIndex(groups, 'default', 5)
+
+    expect(next[0].activeTabIndex).toBe(1)
+  })
+})

--- a/src/state/tabWorkspace.ts
+++ b/src/state/tabWorkspace.ts
@@ -1,0 +1,37 @@
+import type { TabGroup, TabItem } from './tabs'
+
+export const clampTabIndex = (index: number, tabsLength: number): number => {
+  if (tabsLength <= 0) return 0
+  if (index < 0) return 0
+  if (index >= tabsLength) return tabsLength - 1
+  return index
+}
+
+export const updateTabGroupTabs = (
+  groups: TabGroup[],
+  groupId: string,
+  tabs: TabItem[]
+): TabGroup[] =>
+  groups.map(group =>
+    group.id === groupId
+      ? {
+          ...group,
+          tabs,
+          activeTabIndex: clampTabIndex(group.activeTabIndex, tabs.length),
+        }
+      : group
+  )
+
+export const updateTabGroupActiveIndex = (
+  groups: TabGroup[],
+  groupId: string,
+  activeTabIndex: number
+): TabGroup[] =>
+  groups.map(group =>
+    group.id === groupId
+      ? {
+          ...group,
+          activeTabIndex: clampTabIndex(activeTabIndex, group.tabs.length),
+        }
+      : group
+  )

--- a/src/state/tabs.ts
+++ b/src/state/tabs.ts
@@ -12,6 +12,7 @@ import { storage } from '~helpers/storage'
 import { versions } from '~helpers/bibleVersions'
 import { getDefaultBibleVersion } from '~helpers/languageUtils'
 import i18n, { getLanguage } from '~i18n'
+import { clampTabIndex, updateTabGroupActiveIndex, updateTabGroupTabs } from './tabWorkspace'
 
 // ============================================================================
 // SHARED BIBLE DOM (single WebView instance for all Bible tabs)
@@ -450,7 +451,7 @@ export const tabsAtom = atom(
 
     set(
       tabGroupsAtom,
-      groups.map(g => (g.id === activeId ? { ...g, tabs: newTabs } : g))
+      updateTabGroupTabs(groups, activeId, newTabs)
     )
   }
 )
@@ -481,7 +482,7 @@ const createGroupTabsAtom = (groupId: string) =>
 
       set(
         tabGroupsAtom,
-        groups.map(g => (g.id === groupId ? { ...g, tabs: newTabs } : g))
+        updateTabGroupTabs(groups, groupId, newTabs)
       )
     }
   )
@@ -546,13 +547,7 @@ export const activeTabIndexAtom = atom(
     const tabsAtoms = get(tabsAtomsAtom)
 
     // Bounds checking
-    if (activeGroup.activeTabIndex >= tabsAtoms.length) {
-      return Math.max(0, tabsAtoms.length - 1)
-    }
-    if (activeGroup.activeTabIndex < 0) {
-      return 0
-    }
-    return activeGroup.activeTabIndex
+    return clampTabIndex(activeGroup.activeTabIndex, tabsAtoms.length)
   },
   (get, set, value: number) => {
     const groups = get(tabGroupsAtom)
@@ -561,7 +556,7 @@ export const activeTabIndexAtom = atom(
     // Update the active tab index in the group
     set(
       tabGroupsAtom,
-      groups.map(g => (g.id === activeId ? { ...g, activeTabIndex: value } : g))
+      updateTabGroupActiveIndex(groups, activeId, value)
     )
 
     // Update cache - always persist to storage (LRU behavior: move to front)


### PR DESCRIPTION
## What changed
- Extract Bible chapter loading/hydration rules from `BibleViewer`.
- Extract selected verses helper rules for verse keys, selection, bookmarks, and focus checks.
- Move resource installation strategies out of `DownloadManager`.
- Extract word annotation range/overlap rules from the user reducer.
- Add tab workspace helper rules for tab index clamping and group updates.
- Add focused Jest coverage for the extracted rule modules.

## Why
This concentrates high-friction domain rules behind smaller module interfaces while preserving the current state shapes, sync behavior, and UI orchestration.

## Testing
- `yarn test src/redux/modules/user/__tests__/wordAnnotationRanges-test.ts src/features/bible/__tests__/selectedVersesActions-test.ts src/state/__tests__/tabWorkspace-test.ts --runInBand --watchman=false`
- `yarn typecheck`

## Risks
- Bible chapter hydration and resource installation are behavior-preserving refactors, but they touch sensitive runtime paths for Bible display and offline downloads.
