### PR TITLE
#208 Show the Bible reference with the verse of the day

### DIFF
--- a/src/features/home/VerseOfTheDay.tsx
+++ b/src/features/home/VerseOfTheDay.tsx
@@ -174,10 +174,10 @@ const VerseOfTheDay = ({ addDay }: Props) => {
         }}
         style={{ marginTop: 10 }}
       >
-        <Paragraph numberOfLines={4} fontWeight="bold" scaleLineHeight={-1}>
+        <Paragraph numberOfLines={3} fontWeight="bold" scaleLineHeight={-1}>
           {removeBreakLines(content)}
         </Paragraph>
-        <Text color="grey" fontSize={12} mt={5}>
+        <Text color="grey" fontSize={12} mt={5} numberOfLines={2}>
           {title} - {version}
         </Text>
       </Link>

--- a/src/features/home/useVerseOfTheDay.ts
+++ b/src/features/home/useVerseOfTheDay.ts
@@ -43,6 +43,10 @@ const hasVerseContent = (
 ): verseOfTheDay is Exclude<VerseOfTheDayData, false | { error: true }> =>
   !!verseOfTheDay && 'content' in verseOfTheDay
 
+const formatVerseOfTheDayNotificationBody = (
+  verseOfTheDay: Exclude<VerseOfTheDayData, false | { error: true }>
+) => `${removeBreakLines(verseOfTheDay.content)}\n${verseOfTheDay.title} - ${verseOfTheDay.version}`
+
 const useGetVerseOfTheDay = (version: VersionCode, addDay: number) => {
   const [verseOfTheDay, setVOD] = useState<VerseOfTheDayData>(false)
 
@@ -91,13 +95,11 @@ export const useVerseOfTheDay = (addDay: number) => {
   const verseOfTheDay = useGetVerseOfTheDay(version, addDay)
   const verseOfTheDayPlus1 = useGetVerseOfTheDay(version, 1 + addDay)
 
-  const verseOfTheDayContent = hasVerseContent(verseOfTheDay) ? verseOfTheDay.content : undefined
-  const verseOfTheDayPlus1Content = hasVerseContent(verseOfTheDayPlus1)
-    ? verseOfTheDayPlus1.content
-    : undefined
+  const hasTodayVerse = hasVerseContent(verseOfTheDay)
+  const hasNextVerse = hasVerseContent(verseOfTheDayPlus1)
 
   useEffect(() => {
-    if (addDay || !verseOfTheDayContent || !verseOfTheDayPlus1Content || !verseOfTheDayTime) return
+    if (addDay || !hasTodayVerse || !hasNextVerse || !verseOfTheDayTime) return
 
     const scheduleNotification = async () => {
       try {
@@ -134,9 +136,7 @@ export const useVerseOfTheDay = (addDay: number) => {
         await notifee.createTriggerNotification(
           {
             title: `${t('Bonjour')} ${extractFirstName(displayName)}`,
-            body: !addDay
-              ? removeBreakLines(verseOfTheDayContent)
-              : removeBreakLines(verseOfTheDayPlus1Content),
+            body: formatVerseOfTheDayNotificationBody(!addDay ? verseOfTheDay : verseOfTheDayPlus1),
             android: {
               channelId,
               pressAction: {
@@ -150,11 +150,9 @@ export const useVerseOfTheDay = (addDay: number) => {
         )
 
         console.log(
-          `[Notification] Notificationset at ${verseOfTheDayTime} on ${date} | addDay: ${addDay} | content: ${
-            !addDay
-              ? removeBreakLines(verseOfTheDayContent)
-              : removeBreakLines(verseOfTheDayPlus1Content)
-          }`
+          `[Notification] Notificationset at ${verseOfTheDayTime} on ${date} | addDay: ${addDay} | content: ${formatVerseOfTheDayNotificationBody(
+            !addDay ? verseOfTheDay : verseOfTheDayPlus1
+          )}`
         )
       } catch (e) {
         console.log(e)
@@ -184,8 +182,10 @@ export const useVerseOfTheDay = (addDay: number) => {
     initNotifications()
   }, [
     verseOfTheDayTime,
-    verseOfTheDayContent,
-    verseOfTheDayPlus1Content,
+    hasTodayVerse,
+    hasNextVerse,
+    verseOfTheDay,
+    verseOfTheDayPlus1,
     displayName,
     addDay,
     dispatch,


### PR DESCRIPTION
## Summary

- Closes #208
- Show the Bible reference with the verse of the day

## Agent Change Summary

Implemented issue #208 by keeping the verse of the day reference visible wherever the existing verse text appears.

Changes:
- Reserved space for the localized Bible reference on the home verse card by reducing verse text clamping and allowing the reference line to wrap to two lines.
- Added the same localized reference and Bible version to the scheduled daily verse notification body.
- Kept the existing verse selection and `verseToReference`/`getVersesContent` conventions unchanged.

Validation:
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn test --watchman=false`
- `yarn agents:quality:check`
- `yarn agents:architecture:check`
- iOS Simulator smoke with `serve-sim`

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/208
- Branch: `codex/issue-208-show-the-bible-reference-with-the-verse-of-the-day`
- Base: `master`
- Proposed commit: `fix(home): show verse of the day references`
- Owned files or modules:
- `src/features/home/VerseOfTheDay.tsx`
- `src/features/home/useVerseOfTheDay.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/208/mobile-validation.md`
- `.scratch/issues/208/codex-runtime-validation.md`
- `.scratch/issues/208/codex-final.md`
- `.scratch/issues/208/commit-message.txt`
- `.scratch/issues/208/change-summary.md`
- `.scratch/issues/208/pr-notes.md`
- `.scratch/issues/208/evidence/after-home-reference.png`
- `.scratch/issues/208/evidence/after-home.png`

## PR Notes

PR notes for issue #208:

- Mobile runtime status: passed.
- Evidence: `.scratch/issues/208/evidence/after-home-reference.png`.
- Runtime log: `.scratch/issues/208/logs/metro.log`.
- The notification scheduling log includes the payload with `Proverbes 3:7 - LSG`.
- Sensitive areas touched: none. This change touches home UI and local notification payload text only.
- Existing unrelated runtime warnings were observed from Bible DOM prop forwarding during startup.

## Agent Validation Report

Implemented issue #208 on branch `codex/issue-208-show-the-bible-reference-with-the-verse-of-the-day`.

Files changed:
- [VerseOfTheDay.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/home/VerseOfTheDay.tsx:177)
- [useVerseOfTheDay.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/home/useVerseOfTheDay.ts:46)
- [architecture-lint.md](/Users/stephane/Projects/bible-strong/bible-strong-app/docs/agents/architecture-lint.md:160) regenerated by harness check
- Handoff/evidence files under `.scratch/issues/208/`

What changed:
- Home verse card now reserves space for the localized Bible reference and version.
- Daily verse notification body now includes the same localized reference and version, synced with the selected verse text.

Validation:
- `yarn typecheck` passed
- `yarn lint` passed with existing unrelated warning in `BibleViewer.tsx`
- `yarn format:check` passed
- `yarn test --watchman=false` passed, 14 suites / 247 tests
- `yarn agents:quality:check` passed
- `yarn agents:architecture:check` passed with existing 486 warnings

Mobile runtime status: `passed`
- iOS Simulator iPhone 17 via `serve-sim`
- Evidence written:
  - `.scratch/issues/208/evidence/after-home-reference.png`
  - `.scratch/issues/208/logs/metro.log`
  - `.scratch/issues/208/mobile-validation.md`
- Notification log confirmed payload includes `Proverbes 3:7 - LSG`.

Sensitive areas touched: none.

Remaining blockers: none.

Status: passed

Device/runtime:
- iOS Simulator: iPhone 17, iOS 26.4, UDID 67D95AA7-A03F-4DFF-A2AF-80E313FCC864
- Development client bundle id: com.smontlouis.biblestrong.dev
- Metro: Node 20 via `npx -y -p node@20 node /Users/stephane/.cache/node/corepack/v1/yarn/4.12.0/yarn.js start --port 8081`
- serve-sim URL: http://127.0.0.1:3102

...

## Diff Stat

```text
src/features/home/VerseOfTheDay.tsx   |  4 ++--
 src/features/home/useVerseOfTheDay.ts | 30 +++++++++++++++---------------
 2 files changed, 17 insertions(+), 17 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
