### PR TITLE
#208 Show the Bible reference with the verse of the day

### DIFF
--- a/src/features/home/VerseOfTheDay.tsx
+++ b/src/features/home/VerseOfTheDay.tsx
@@ -174,10 +174,10 @@ const VerseOfTheDay = ({ addDay }: Props) => {
         }}
         style={{ marginTop: 10 }}
       >
-        <Paragraph numberOfLines={4} fontWeight="bold" scaleLineHeight={-1}>
+        <Paragraph numberOfLines={3} fontWeight="bold" scaleLineHeight={-1}>
           {removeBreakLines(content)}
         </Paragraph>
-        <Text color="grey" fontSize={12} mt={5}>
+        <Text color="grey" fontSize={12} mt={5} numberOfLines={2}>
           {title} - {version}
         </Text>
       </Link>

--- a/src/features/home/useVerseOfTheDay.ts
+++ b/src/features/home/useVerseOfTheDay.ts
@@ -92,12 +92,26 @@ export const useVerseOfTheDay = (addDay: number) => {
   const verseOfTheDayPlus1 = useGetVerseOfTheDay(version, 1 + addDay)
 
   const verseOfTheDayContent = hasVerseContent(verseOfTheDay) ? verseOfTheDay.content : undefined
+  const verseOfTheDayReference = hasVerseContent(verseOfTheDay)
+    ? `${verseOfTheDay.title} ${verseOfTheDay.version}`
+    : undefined
   const verseOfTheDayPlus1Content = hasVerseContent(verseOfTheDayPlus1)
     ? verseOfTheDayPlus1.content
     : undefined
+  const verseOfTheDayPlus1Reference = hasVerseContent(verseOfTheDayPlus1)
+    ? `${verseOfTheDayPlus1.title} ${verseOfTheDayPlus1.version}`
+    : undefined
 
   useEffect(() => {
-    if (addDay || !verseOfTheDayContent || !verseOfTheDayPlus1Content || !verseOfTheDayTime) return
+    if (
+      addDay ||
+      !verseOfTheDayContent ||
+      !verseOfTheDayReference ||
+      !verseOfTheDayPlus1Content ||
+      !verseOfTheDayPlus1Reference ||
+      !verseOfTheDayTime
+    )
+      return
 
     const scheduleNotification = async () => {
       try {
@@ -135,8 +149,8 @@ export const useVerseOfTheDay = (addDay: number) => {
           {
             title: `${t('Bonjour')} ${extractFirstName(displayName)}`,
             body: !addDay
-              ? removeBreakLines(verseOfTheDayContent)
-              : removeBreakLines(verseOfTheDayPlus1Content),
+              ? `${removeBreakLines(verseOfTheDayContent)}\n${verseOfTheDayReference}`
+              : `${removeBreakLines(verseOfTheDayPlus1Content)}\n${verseOfTheDayPlus1Reference}`,
             android: {
               channelId,
               pressAction: {
@@ -152,8 +166,8 @@ export const useVerseOfTheDay = (addDay: number) => {
         console.log(
           `[Notification] Notificationset at ${verseOfTheDayTime} on ${date} | addDay: ${addDay} | content: ${
             !addDay
-              ? removeBreakLines(verseOfTheDayContent)
-              : removeBreakLines(verseOfTheDayPlus1Content)
+              ? `${removeBreakLines(verseOfTheDayContent)} ${verseOfTheDayReference}`
+              : `${removeBreakLines(verseOfTheDayPlus1Content)} ${verseOfTheDayPlus1Reference}`
           }`
         )
       } catch (e) {
@@ -185,7 +199,9 @@ export const useVerseOfTheDay = (addDay: number) => {
   }, [
     verseOfTheDayTime,
     verseOfTheDayContent,
+    verseOfTheDayReference,
     verseOfTheDayPlus1Content,
+    verseOfTheDayPlus1Reference,
     displayName,
     addDay,
     dispatch,


### PR DESCRIPTION
## Summary

- Closes #208
- Show the Bible reference with the verse of the day

## Agent Change Summary

Implemented issue #208 by keeping the verse of the day reference visible wherever the existing verse text appears.

Changes:
- Reserved space for the localized Bible reference on the home verse card by reducing verse text clamping and allowing the reference line to wrap to two lines.
- Added the same localized reference and Bible version to the scheduled daily verse notification body.
- Kept the existing verse selection and `verseToReference`/`getVersesContent` conventions unchanged.

Validation:
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn test --watchman=false`
- `yarn agents:quality:check`
- `yarn agents:architecture:check`
- iOS Simulator home smoke with `serve-sim`

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/208
- Branch: `codex/issue-208-show-the-bible-reference-with-the-verse-of-the-day`
- Base: `master`
- Proposed commit: `fix(home): show verse of the day references`
- Owned files or modules:
- `docs/agents/architecture-lint.md`
- `src/features/home/VerseOfTheDay.tsx`
- `src/features/home/useVerseOfTheDay.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [ ] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/208/mobile-validation.md`
- `.scratch/issues/208/codex-runtime-validation.md`
- `.scratch/issues/208/codex-final.md`
- `.scratch/issues/208/commit-message.txt`
- `.scratch/issues/208/change-summary.md`
- `.scratch/issues/208/pr-notes.md`
- `.scratch/issues/208/evidence/after-home-reference.png`
- `.scratch/issues/208/evidence/after-home.png`

## PR Notes

PR notes for issue #208:

- Mobile runtime status: passed.
- Evidence: `.scratch/issues/208/evidence/after-home-reference.png`.
- Notification delivery was not separately waited on; the notification body now appends the same localized reference/version loaded for the card.
- Sensitive areas touched: none. This change touches home UI and local notification payload text only.
- `yarn lint` passed with existing warnings about `eslint-env` comments in tests and an unrelated unused import warning in `src/features/bible/BibleViewer.tsx`.
- `yarn agents:architecture:check` regenerated `docs/agents/architecture-lint.md`, updating warning line numbers for `src/features/home/useVerseOfTheDay.ts`.

## Agent Validation Report

Implemented issue #208 on `codex/issue-208-show-the-bible-reference-with-the-verse-of-the-day`.

Files changed:
- [VerseOfTheDay.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/home/VerseOfTheDay.tsx:174)
- [useVerseOfTheDay.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/home/useVerseOfTheDay.ts:92)
- [architecture-lint.md](/Users/stephane/Projects/bible-strong/bible-strong-app/docs/agents/architecture-lint.md:159) regenerated by harness check

What changed:
- Home verse card now reserves room for the localized Bible reference and version, wrapping the reference up to two lines.
- Daily verse notification body now includes the verse text plus the same localized reference/version on a second line.
- Verse selection logic stayed unchanged.

Validation passed:
- `yarn typecheck`
- `yarn lint` passed with existing warnings only
- `yarn format:check`
- `yarn test --watchman=false` passed: 14 suites, 247 tests
- `yarn agents:quality:check`
- `yarn agents:architecture:check`
- iOS Simulator home smoke via `serve-sim`

Mobile runtime status: `passed`

Evidence files written:
- `.scratch/issues/208/evidence/after-home-reference.png`
- `.scratch/issues/208/evidence/after-home.png`
- `.scratch/issues/208/mobile-validation.md`
- `.scratch/issues/208/commit-message.txt`
- `.scratch/issues/208/change-summary.md`
- `.scratch/issues/208/pr-notes.md`

Sensitive areas touched: none.

Remaining blockers: none. Direct notification delivery was not waited on, but the scheduled notification payload construction was updated and documented in the validation notes.

Status: passed

Device/runtime:
- iOS Simulator UDID: 67D95AA7-A03F-4DFF-A2AF-80E313FCC864
- Development client bundle id: com.smontlouis.biblestrong.dev
- Metro: Node 20 via `npx -y

...

## Diff Stat

```text
docs/agents/architecture-lint.md      |  6 +++---
 src/features/home/VerseOfTheDay.tsx   |  4 ++--
 src/features/home/useVerseOfTheDay.ts | 26 +++++++++++++++++++++-----
 3 files changed, 26 insertions(+), 10 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
