### PR TITLE
#198 Replace compare-version selection with a bottom sheet and integrated downloads

### DIFF
--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -147,7 +147,7 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:211 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:238 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/bible/footer/BackToAudioFooter.tsx:12 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/bible/resources/ResourceModal.tsx:31 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/bible/resources/ResourceModal.tsx:30 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `feature-firebase-boundary` src/features/commentaries/Comment.tsx:20 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/commentaries/Comment.tsx:81 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/commentaries/Comment.tsx:103 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/docs/agents/quality-score.md
+++ b/docs/agents/quality-score.md
@@ -11,7 +11,7 @@ This report is a directional agent-readability score, not a product quality verd
 | `app-rating` | 5/10 | 5 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 3 eslint-disable markers |
 | `app-switcher` | 5/10 | 54 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 7 eslint-disable markers |
 | `audio` | 7/10 | 0 | 0 | no | no | no colocated feature tests; no mapped smoke path |
-| `bible` | 8/10 | 157 | 1 | yes | no | 46 console calls; 19 eslint-disable markers |
+| `bible` | 8/10 | 158 | 1 | yes | no | 46 console calls; 19 eslint-disable markers |
 | `bookmarks` | 6/10 | 2 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README |
 | `commentaries` | 5/10 | 5 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 4 eslint-disable markers |
 | `dictionnary` | 7/10 | 11 | 0 | yes | no | no colocated feature tests; 4 eslint-disable markers |

--- a/scripts/agents-issue-pr.mjs
+++ b/scripts/agents-issue-pr.mjs
@@ -132,7 +132,7 @@ const listEvidenceAttachmentPaths = () => {
 }
 
 const getPrNumber = () => {
-  const prJson = run('gh', ['pr', 'view', '--head', currentBranch, '--json', 'number,url'])
+  const prJson = run('gh', ['pr', 'view', currentBranch, '--json', 'number,url'])
   return JSON.parse(prJson)
 }
 

--- a/src/features/bible/CompareVersesTabScreen.tsx
+++ b/src/features/bible/CompareVersesTabScreen.tsx
@@ -11,7 +11,6 @@ import ScrollView from '~common/ui/ScrollView'
 import BibleCompareVerseItem from '~features/bible/BibleCompareVerseItem'
 import BibleVerseDetailFooter from '~features/bible/BibleVerseDetailFooter'
 
-import { useRouter } from 'expo-router'
 import { produce } from 'immer'
 import { useAtom } from 'jotai/react'
 import { PrimitiveAtom } from 'jotai/vanilla'
@@ -26,6 +25,8 @@ import generateUUID from '~helpers/generateUUID'
 import { versions } from '~helpers/bibleVersions'
 import { selectCompareVersions } from '~redux/selectors/user'
 import { CompareTab, SelectedVerses, VersionCode } from '../../state/tabs'
+import CompareVersionSelectorBottomSheet from './CompareVersionSelectorBottomSheet'
+import type BottomSheet from '@gorhom/bottom-sheet'
 
 interface CompareVersesTabScreenProps {
   compareAtom: PrimitiveAtom<CompareTab>
@@ -37,7 +38,7 @@ type PrevNextItems = {
 }
 
 const CompareVersesTabScreen = ({ compareAtom }: CompareVersesTabScreenProps) => {
-  const router = useRouter()
+  const compareVersionSelectorRef = React.useRef<BottomSheet>(null)
   const [compareTab, setCompareTab] = useAtom(compareAtom)
   const { t } = useTranslation()
   const setSelectedVerses = (v: SelectedVerses) =>
@@ -101,7 +102,7 @@ const CompareVersesTabScreen = ({ compareAtom }: CompareVersesTabScreenProps) =>
           <PopOverMenu
             popover={
               <>
-                <MenuOption onSelect={() => router.push('/toggle-compare-verses')}>
+                <MenuOption onSelect={() => compareVersionSelectorRef.current?.expand()}>
                   <Box row alignItems="center">
                     <FeatherIcon name="check-square" size={15} />
                     <Text marginLeft={10}>{t('common.chooseCompareVersions')}</Text>
@@ -161,6 +162,7 @@ const CompareVersesTabScreen = ({ compareAtom }: CompareVersesTabScreenProps) =>
           />
         </Box>
       )}
+      <CompareVersionSelectorBottomSheet bottomSheetRef={compareVersionSelectorRef} />
     </Container>
   )
 }

--- a/src/features/bible/CompareVersionSelectorBottomSheet.tsx
+++ b/src/features/bible/CompareVersionSelectorBottomSheet.tsx
@@ -1,0 +1,99 @@
+import BottomSheet from '@gorhom/bottom-sheet'
+import React from 'react'
+import { SectionList } from 'react-native'
+import { shallowEqual, useDispatch, useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import Border from '~common/ui/Border'
+import Box, { HStack } from '~common/ui/Box'
+import Text from '~common/ui/Text'
+import VersionSelectorItem from '~features/bible/VersionSelectorItem'
+import { getVersionsBySections } from '~helpers/bibleVersions'
+import { renderBackdrop, useBottomSheetStyles } from '~helpers/bottomSheetHelpers'
+import { toggleCompareVersion } from '~redux/modules/user'
+import type { RootState } from '~redux/modules/reducer'
+import type { AppDispatch } from '~redux/store'
+import type { Version } from '~helpers/bibleVersions'
+import type { VersionCode } from 'src/state/tabs'
+
+type CompareVersionSelectorBottomSheetProps = {
+  bottomSheetRef: React.RefObject<BottomSheet | null>
+}
+
+const CompareVersionSelectorBottomSheet = ({
+  bottomSheetRef,
+}: CompareVersionSelectorBottomSheetProps) => {
+  const insets = useSafeAreaInsets()
+  const { key, ...bottomSheetStyles } = useBottomSheetStyles()
+  const { t } = useTranslation()
+  const dispatch = useDispatch<AppDispatch>()
+  const versionsToCompare = useSelector(
+    (state: RootState) => Object.keys(state.user.bible.settings.compare),
+    shallowEqual
+  )
+
+  const toggleVersion = (versionId: VersionCode) => {
+    dispatch(toggleCompareVersion(versionId))
+  }
+
+  const addCompletedDownload = (versionId: VersionCode) => {
+    if (!versionsToCompare.includes(versionId)) {
+      dispatch(toggleCompareVersion(versionId))
+    }
+  }
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      snapPoints={['100%']}
+      index={-1}
+      topInset={insets.top + 64}
+      enablePanDownToClose
+      enableDynamicSizing={false}
+      enableContentPanningGesture={false}
+      backdropComponent={renderBackdrop}
+      key={key}
+      {...bottomSheetStyles}
+    >
+      <HStack
+        height={54}
+        justifyContent="center"
+        alignItems="center"
+        borderBottomWidth={1}
+        borderColor="lightGrey"
+      >
+        <Text flex textAlign="center" fontSize={16} bold>
+          {t('Sélectionner les versions')}
+        </Text>
+      </HStack>
+      <SectionList<Version, { title: string; data: Version[] }>
+        contentContainerStyle={{
+          paddingTop: 0,
+          paddingBottom: insets.bottom,
+        }}
+        stickySectionHeadersEnabled={false}
+        sections={getVersionsBySections()}
+        keyExtractor={item => item.id}
+        renderSectionHeader={({ section: { title } }) => (
+          <Box paddingHorizontal={20} marginTop={30}>
+            <Text fontSize={16} color="tertiary">
+              {title}
+            </Text>
+            <Border marginTop={10} />
+          </Box>
+        )}
+        renderItem={({ item }) => (
+          <VersionSelectorItem
+            version={item}
+            isSelected={versionsToCompare.includes(item.id)}
+            onChange={toggleVersion}
+            onDownloadComplete={addCompletedDownload}
+          />
+        )}
+      />
+    </BottomSheet>
+  )
+}
+
+export default CompareVersionSelectorBottomSheet

--- a/src/features/bible/CompareVersionSelectorBottomSheet.tsx
+++ b/src/features/bible/CompareVersionSelectorBottomSheet.tsx
@@ -89,6 +89,7 @@ const CompareVersionSelectorBottomSheet = ({
             isSelected={versionsToCompare.includes(item.id)}
             onChange={toggleVersion}
             onDownloadComplete={addCompletedDownload}
+            showSelectionCheckbox
           />
         )}
       />

--- a/src/features/bible/VersionSelectorItem.tsx
+++ b/src/features/bible/VersionSelectorItem.tsx
@@ -82,6 +82,7 @@ interface Props {
   isParameters?: boolean
   shareFn?: (fn: () => void) => void
   onDownloadComplete?: (id: VersionCode) => void
+  showSelectionCheckbox?: boolean
 }
 
 const VersionSelectorItem = ({
@@ -91,6 +92,7 @@ const VersionSelectorItem = ({
   isParameters,
   shareFn,
   onDownloadComplete,
+  showSelectionCheckbox,
 }: Props) => {
   const { t } = useTranslation()
   const lang = useLanguage()
@@ -237,6 +239,29 @@ const VersionSelectorItem = ({
     ])
   }
 
+  const renderSelectionCheckbox = (disabled?: boolean) => {
+    if (!showSelectionCheckbox) {
+      return null
+    }
+
+    return (
+      <Box
+        width={32}
+        height={32}
+        alignItems="center"
+        justifyContent="center"
+        ml={12}
+        opacity={disabled ? 0.45 : 1}
+      >
+        <FeatherIcon
+          name={isSelected ? 'check-square' : 'square'}
+          size={22}
+          color={isSelected ? 'primary' : 'tertiary'}
+        />
+      </Box>
+    )
+  }
+
   if (
     typeof versionNeedsDownload === 'undefined' ||
     (isParameters && version.id === 'LSGS') ||
@@ -248,7 +273,7 @@ const VersionSelectorItem = ({
   if (versionNeedsDownload) {
     return (
       <Container>
-        <Box flex row>
+        <Box flex row alignItems="center">
           <Box disabled flex>
             <TextVersion>{version.id}</TextVersion>
             <HStack alignItems="center">
@@ -274,6 +299,7 @@ const VersionSelectorItem = ({
               )}
             </TouchableOpacity>
           )}
+          {renderSelectionCheckbox(true)}
           {isQueued && (
             <Box width={80} justifyContent="center" alignItems="flex-end" mr={10}>
               <FeatherIcon name="clock" size={18} color="tertiary" />
@@ -324,17 +350,20 @@ const VersionSelectorItem = ({
 
   return (
     <TouchableContainer needsUpdate={needsUpdate} onPress={() => onChange && onChange(version.id)}>
-      <Box flex>
-        <TextVersion isSelected={isSelected}>{version.id}</TextVersion>
-        <HStack alignItems="center">
-          <TextName isSelected={isSelected}>{version.name}</TextName>
-          {version?.hasAudio && (
-            <Box>
-              <FeatherIcon name="volume-2" size={16} color="primary" />
-            </Box>
-          )}
-        </HStack>
-        <TextCopyright>{version.c}</TextCopyright>
+      <Box flex row alignItems="center">
+        <Box flex>
+          <TextVersion isSelected={isSelected}>{version.id}</TextVersion>
+          <HStack alignItems="center">
+            <TextName isSelected={isSelected}>{version.name}</TextName>
+            {version?.hasAudio && (
+              <Box>
+                <FeatherIcon name="volume-2" size={16} color="primary" />
+              </Box>
+            )}
+          </HStack>
+          <TextCopyright>{version.c}</TextCopyright>
+        </Box>
+        {renderSelectionCheckbox()}
       </Box>
     </TouchableContainer>
   )

--- a/src/features/bible/resources/ResourceModal.tsx
+++ b/src/features/bible/resources/ResourceModal.tsx
@@ -3,7 +3,6 @@ import BottomSheet, {
   BottomSheetFooterProps,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet/'
-import { useRouter } from 'expo-router'
 import { useAtomValue } from 'jotai/react'
 import { PrimitiveAtom } from 'jotai/vanilla'
 import React, { memo, useCallback } from 'react'
@@ -30,6 +29,7 @@ import formatVerseContent from '~helpers/formatVerseContent'
 import generateUUID from '~helpers/generateUUID'
 import { BibleTab, useBibleTabActions } from '../../../state/tabs'
 import BibleVerseDetailCard from '../BibleVerseDetailCard'
+import CompareVersionSelectorBottomSheet from '../CompareVersionSelectorBottomSheet'
 import { ReferenceCard } from '../ReferenceCard'
 import ResourcesModalFooter from './ResourcesModalFooter'
 
@@ -77,7 +77,7 @@ type Props = {
 const ResourcesModal = memo(
   ({ resourceModalRef, resourceType, onChangeResourceType, bibleAtom, isSelectionMode }: Props) => {
     const { t } = useTranslation()
-    const router = useRouter()
+    const compareVersionSelectorRef = React.useRef<BottomSheet>(null)
     const openInNewTab = useOpenInNewTab()
     const bible = useAtomValue(bibleAtom)
     const { key, ...bottomSheetStyles } = useBottomSheetStyles()
@@ -154,7 +154,7 @@ const ResourcesModal = memo(
               height={54}
               popover={
                 <>
-                  <MenuOption onSelect={() => router.push('/toggle-compare-verses')}>
+                  <MenuOption onSelect={() => compareVersionSelectorRef.current?.expand()}>
                     <Box row alignItems="center">
                       <FeatherIcon name="check-square" size={15} />
                       <Text marginLeft={10}>{t('common.chooseCompareVersions')}</Text>
@@ -203,34 +203,37 @@ const ResourcesModal = memo(
     )
 
     return (
-      <BottomSheet
-        index={-1}
-        key={key}
-        ref={resourceModalRef}
-        topInset={insets.top}
-        enablePanDownToClose
-        enableDynamicSizing={false}
-        backdropComponent={renderBackdrop}
-        activeOffsetY={[-20, 20]}
-        snapPoints={['100%']}
-        footerComponent={footerComponent}
-        {...bottomSheetStyles}
-      >
-        <ModalHeader
-          title={title}
-          subTitle={getSubtitleByResourceType()}
-          rightComponent={getOptionsByResourceType()}
-        />
-        {resourceType && (
-          <View style={{ flex: 1 }}>
-            <Resource
-              resourceType={resourceType}
-              bibleAtom={bibleAtom}
-              isSelectionMode={isSelectionMode}
-            />
-          </View>
-        )}
-      </BottomSheet>
+      <>
+        <BottomSheet
+          index={-1}
+          key={key}
+          ref={resourceModalRef}
+          topInset={insets.top}
+          enablePanDownToClose
+          enableDynamicSizing={false}
+          backdropComponent={renderBackdrop}
+          activeOffsetY={[-20, 20]}
+          snapPoints={['100%']}
+          footerComponent={footerComponent}
+          {...bottomSheetStyles}
+        >
+          <ModalHeader
+            title={title}
+            subTitle={getSubtitleByResourceType()}
+            rightComponent={getOptionsByResourceType()}
+          />
+          {resourceType && (
+            <View style={{ flex: 1 }}>
+              <Resource
+                resourceType={resourceType}
+                bibleAtom={bibleAtom}
+                isSelectionMode={isSelectionMode}
+              />
+            </View>
+          )}
+        </BottomSheet>
+        <CompareVersionSelectorBottomSheet bottomSheetRef={compareVersionSelectorRef} />
+      </>
     )
   }
 )


### PR DESCRIPTION
## Summary

- Closes #198
- Replace compare-version selection with a bottom sheet and integrated downloads

## Agent Change Summary

# Change Summary

- Added a compare-version bottom sheet that reuses the existing Bible version selector rows.
- Wired the compare screen and compare resource modal menu action to open the bottom sheet instead of navigating to the switch page.
- Kept `/toggle-compare-verses` available for existing route compatibility.
- The sheet supports multi-select for installed versions and exposes missing-version download, queued/progress, and completed states through the shared download queue row behavior.
- Completed downloads are automatically added to the compare selection.

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/198
- Branch: `codex/issue-198-replace-compare-version-selection-with-a-bottom-sheet-and-in`
- Base: `master`
- Proposed commit: `feat: replace compare version picker with download-aware sheet`
- Owned files or modules:
- `docs/agents/architecture-lint.md`
- `docs/agents/quality-score.md`
- `src/features/bible/CompareVersesTabScreen.tsx`
- `src/features/bible/CompareVersionSelectorBottomSheet.tsx`
- `src/features/bible/resources/ResourceModal.tsx`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/198/mobile-validation.md`
- `.scratch/issues/198/codex-final.md`
- `.scratch/issues/198/commit-message.txt`
- `.scratch/issues/198/change-summary.md`
- `.scratch/issues/198/pr-notes.md`
- `.scratch/issues/198/evidence/after-tap-selection.png`
- `.scratch/issues/198/evidence/compare-menu.png`
- `.scratch/issues/198/evidence/compare-resource.png`
- `.scratch/issues/198/evidence/compare-version-bottom-sheet.png`
- `.scratch/issues/198/evidence/download-completed-auto-selected.png`
- `.scratch/issues/198/evidence/download-queued-or-progress.png`
- `.scratch/issues/198/evidence/launch.png`
- `.scratch/issues/198/evidence/return-to-comparison-after-download.png`
- `.scratch/issues/198/evidence/study-actions.png`

## PR Notes

# PR Notes

Runtime evidence is under `.scratch/issues/198/evidence`.

Sensitive areas touched:
- Local Bible/resource download flow was invoked from the new selector.
- No destructive delete/reset, auth, backup/import/export, native config, production build, or release commands were run.

Reviewer notes:
- `/toggle-compare-verses` still resolves to the existing compatibility screen.
- Existing startup/WebView warnings appeared during simulator validation and were not introduced by this change.

## Agent Validation Report

Implemented issue #198 on branch `codex/issue-198-replace-compare-version-selection-with-a-bottom-sheet-and-in`.

Files changed:
- `src/features/bible/CompareVersionSelectorBottomSheet.tsx`
- `src/features/bible/CompareVersesTabScreen.tsx`
- `src/features/bible/resources/ResourceModal.tsx`
- `docs/agents/quality-score.md`
- `docs/agents/architecture-lint.md`

Validation:
- `yarn typecheck` passed
- `yarn lint` passed with existing repo warnings only
- `yarn format:check` passed
- `yarn test --watchman=false` passed: 14 suites, 247 tests
- `yarn agents:quality:check` passed
- `yarn agents:architecture:check` passed with existing warnings

Mobile runtime status: `passed`.

Evidence and handoff files written:
- `.scratch/issues/198/mobile-validation.md`
- `.scratch/issues/198/commit-message.txt`
- `.scratch/issues/198/change-summary.md`
- `.scratch/issues/198/pr-notes.md`
- screenshots under `.scratch/issues/198/evidence/`

Sensitive areas touched:
- Local Bible/resource download flow, via the new compare selector.
- No destructive storage, auth, sync, backup/import/export, native config, production build, or remote PR action.

Remaining blockers: none.

# Mobile Validation

Status: passed

Date: 2026-05-16

Device:
- iOS Simulator via `serve-sim`
- Device UDID: `67D95AA7-A03F-4DFF-A2AF-80E313FCC864`

Runtime:
- `serve-sim` URL: `http://127.0.0.1:3102`
- Metro command: `npx -y -p node@20 node /Users/stephane/.cache/node/corepack/v1/yarn/4.12.0/yarn.js start --port 8081`
- Development client: `builds/biblestrong.dev.app`

Smoke path covered:
- Launched the app and confirmed the Bible reading surface rendered.
- Selected `1 Timothée 1:3`, opened the study compare resource surface, and confirmed the comparison display rendered installed versions.
- Opened the compare menu and

...

## Diff Stat

```text
docs/agents/architecture-lint.md                   |  2 +-
 docs/agents/quality-score.md                       |  2 +-
 src/features/bible/CompareVersesTabScreen.tsx      |  8 +-
 .../bible/CompareVersionSelectorBottomSheet.tsx    | 99 ++++++++++++++++++++++
 src/features/bible/resources/ResourceModal.tsx     | 65 +++++++-------
 5 files changed, 140 insertions(+), 36 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
