### PR TITLE
#195 Clicking on a searched verse doesn’t open the right version

### DIFF
--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -159,9 +159,9 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/home/PlanHome.tsx:44 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/home/StrongOfTheDay.tsx:46 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/home/VerseImageModal.tsx:60 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:152 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:160 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:175 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:166 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:174 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:189 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/lexique/StrongDetailScreen.tsx:183 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:115 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:155 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -185,7 +185,7 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/plans/plan.hooks.ts:453 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/profile/components/DeleteAccountModal.tsx:8 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/profile/components/DeleteAccountModal.tsx:56 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:183 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:184 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:54 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:89 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:131 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/docs/agents/quality-score.md
+++ b/docs/agents/quality-score.md
@@ -23,7 +23,7 @@ This report is a directional agent-readability score, not a product quality verd
 | `onboarding` | 6/10 | 7 | 0 | yes | yes | no colocated feature tests; 5 eslint-disable markers; sensitive user/account surface |
 | `plans` | 7/10 | 26 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
 | `profile` | 5/10 | 9 | 0 | no | yes | no colocated feature tests; no mapped smoke path; no feature README; sensitive user/account surface |
-| `search` | 7/10 | 6 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
+| `search` | 9/10 | 7 | 1 | yes | no | 2 eslint-disable markers |
 | `settings` | 5/10 | 35 | 0 | yes | yes | no colocated feature tests; 12 console calls; 1 eslint-disable markers; sensitive user/account surface |
 | `studies` | 5/10 | 34 | 0 | no | no | no colocated feature tests; no mapped smoke path; 17 console calls; 2 eslint-disable markers |
 | `timeline` | 7/10 | 28 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |

--- a/src/features/search/SQLiteSearchScreen.tsx
+++ b/src/features/search/SQLiteSearchScreen.tsx
@@ -31,6 +31,7 @@ import LexiqueResultsWidget from '~features/lexique/LexiqueResultsWidget'
 import NaveResultsWidget from '~features/nave/NaveResultsWidget'
 import BibleReferenceWidget, { parseBibleReference } from '~features/search/BibleReferenceWidget'
 import SearchEmptyState from '~features/search/SearchEmptyState'
+import { getBibleViewParamsForSearchResult } from '~features/search/searchNavigation'
 import { searchFiltersAtom, SearchSection } from '~state/searchFilters'
 
 type Props = {
@@ -297,13 +298,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
                 onPress={() =>
                   router.push({
                     pathname: '/bible-view',
-                    params: {
-                      isReadOnly: 'true',
-                      book: JSON.stringify(booksDesc[result.book - 1]),
-                      chapter: String(result.chapter),
-                      verse: String(result.verse),
-                      focusVerses: JSON.stringify([result.verse]),
-                    },
+                    params: getBibleViewParamsForSearchResult(result),
                   })
                 }
               />

--- a/src/features/search/__tests__/searchNavigation-test.ts
+++ b/src/features/search/__tests__/searchNavigation-test.ts
@@ -1,0 +1,39 @@
+import { getBibleViewParamsForSearchResult } from '../searchNavigation'
+
+describe('getBibleViewParamsForSearchResult', () => {
+  it('preserves the tapped search result version in Bible view params', () => {
+    expect(
+      getBibleViewParamsForSearchResult({
+        book: 51,
+        chapter: 2,
+        verse: 19,
+        version: 'DBY',
+      })
+    ).toEqual({
+      isReadOnly: 'true',
+      book: JSON.stringify({ Numero: 51, Nom: 'Colossiens', Chapitres: 4 }),
+      chapter: '2',
+      verse: '19',
+      version: 'DBY',
+      focusVerses: JSON.stringify([19]),
+    })
+  })
+
+  it('keeps different result versions distinct', () => {
+    const lsgParams = getBibleViewParamsForSearchResult({
+      book: 51,
+      chapter: 2,
+      verse: 19,
+      version: 'LSG',
+    })
+    const dbyParams = getBibleViewParamsForSearchResult({
+      book: 51,
+      chapter: 2,
+      verse: 19,
+      version: 'DBY',
+    })
+
+    expect(lsgParams.version).toBe('LSG')
+    expect(dbyParams.version).toBe('DBY')
+  })
+})

--- a/src/features/search/searchNavigation.ts
+++ b/src/features/search/searchNavigation.ts
@@ -1,0 +1,17 @@
+import booksDesc from '~assets/bible_versions/books-desc'
+
+type BibleViewSearchResult = {
+  book: number
+  chapter: number
+  verse: number
+  version: string
+}
+
+export const getBibleViewParamsForSearchResult = (result: BibleViewSearchResult) => ({
+  isReadOnly: 'true',
+  book: JSON.stringify(booksDesc[result.book - 1]),
+  chapter: String(result.chapter),
+  verse: String(result.verse),
+  version: result.version,
+  focusVerses: JSON.stringify([result.verse]),
+})


### PR DESCRIPTION
## Summary

- Closes #195
- Clicking on a searched verse doesn’t open the right version

## Agent Change Summary

Implemented issue #195 by preserving the tapped search result's Bible version when opening `/bible-view`.

Changes:
- Added `getBibleViewParamsForSearchResult` to build the Bible route params from a search result, including `version`.
- Updated `SQLiteSearchScreen` to use the helper for result taps.
- Added focused Jest coverage proving DBY and LSG search results keep distinct `version` params while preserving book, chapter, verse, focus verse, and read-only params.
- Regenerated the agent quality and architecture reports through the required harness checks.

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/195
- Branch: `codex/issue-195-clicking-on-a-searched-verse-doesn-t-open-the-right-version`
- Base: `master`
- Proposed commit: `fix(search): open Bible results with their result version`
- Owned files or modules:
- `docs/agents/architecture-lint.md`
- `docs/agents/quality-score.md`
- `src/features/search/SQLiteSearchScreen.tsx`
- `src/features/search/__tests__/searchNavigation-test.ts`
- `src/features/search/searchNavigation.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [ ] `yarn typecheck`
- [x] `yarn lint`
- [ ] `yarn test`
- [ ] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/195/mobile-validation.md`
- `.scratch/issues/195/codex-final.md`
- `.scratch/issues/195/commit-message.txt`
- `.scratch/issues/195/change-summary.md`
- `.scratch/issues/195/pr-notes.md`
- `.scratch/issues/195/evidence/runtime-explicit-dby-bible-view.png`
- `.scratch/issues/195/evidence/runtime-launch.png`
- `.scratch/issues/195/evidence/runtime-search-cleared.png`
- `.scratch/issues/195/evidence/runtime-search-dby-results.png`
- `.scratch/issues/195/evidence/runtime-search-results.png`
- `.scratch/issues/195/evidence/runtime-search-tab.png`

## PR Notes

Issue #195 fixes search result navigation so the opened Bible view uses the version shown on the tapped result.

Validation:
- `yarn test src/features/search/__tests__/searchNavigation-test.ts --watchman=false`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn test --watchman=false`
- `yarn agents:quality:check`
- `yarn agents:architecture:check`
- Simulator smoke documented in `.scratch/issues/195/mobile-validation.md`

Evidence:
- `.scratch/issues/195/evidence/runtime-launch.png`
- `.scratch/issues/195/evidence/runtime-search-tab.png`
- `.scratch/issues/195/evidence/runtime-search-results.png`
- `.scratch/issues/195/evidence/runtime-search-dby-results.png`
- `.scratch/issues/195/evidence/runtime-explicit-dby-bible-view.png`

Reviewer notes:
- The current simulator search data returned zero results for the issue phrase during manual smoke, so the result-tap behavior is primarily covered by the focused Jest test and confirmed by the explicit `/bible-view` route smoke showing DBY mounted in the Bible WebView.
- Sensitive areas touched: none.

## Agent Validation Report

Implemented issue #195 on branch `codex/issue-195-clicking-on-a-searched-verse-doesn-t-open-the-right-version`.

Changed:
- `src/features/search/SQLiteSearchScreen.tsx`
- `src/features/search/searchNavigation.ts`
- `src/features/search/__tests__/searchNavigation-test.ts`
- Regenerated harness reports:
  - `docs/agents/quality-score.md`
  - `docs/agents/architecture-lint.md`

What changed:
- Search result taps now pass `version: result.version` into `/bible-view`.
- Book, chapter, verse, focus verse, and read-only params are preserved.
- Added focused Jest coverage proving DBY and LSG result params stay distinct.

Validation passed:
- `yarn test src/features/search/__tests__/searchNavigation-test.ts --watchman=false`
- `yarn typecheck`
- `yarn lint` passed with existing unrelated warnings
- `yarn format:check`
- `yarn test --watchman=false`
- `yarn agents:quality:check`
- `yarn agents:architecture:check`

Mobile runtime status: `passed`
- Evidence/report written under `.scratch/issues/195/`
- Metro logs confirmed explicit `version=DBY` mounted Bible WebView as `version:"DBY"`.

Handoff files written:
- `.scratch/issues/195/mobile-validation.md`
- `.scratch/issues/195/commit-message.txt`
- `.scratch/issues/195/change-summary.md`
- `.scratch/issues/195/pr-notes.md`

Sensitive areas touched: none in code.

Remaining blockers: none.

status: passed

Device: iPhone 17 simulator, iOS 26.4, UDID 67D95AA7-A03F-4DFF-A2AF-80E313FCC864.
serve-sim: already running at http://127.0.0.1:3105.
Metro: started with Node 20 workaround:
`npx -y -p node@20 node /Users/stephane/.cache/node/corepack/v1/yarn/4.12.0/yarn.js start --port 8081`.

Smoke path covered:
- Installed and launched `builds/biblestrong.dev.app` with bundle id `com.smontlouis.biblestrong.dev`.
- Confirmed app startup and Bi

...

## Diff Stat

```text
docs/agents/architecture-lint.md                   |  8 ++---
 docs/agents/quality-score.md                       |  2 +-
 src/features/search/SQLiteSearchScreen.tsx         |  9 ++---
 .../search/__tests__/searchNavigation-test.ts      | 39 ++++++++++++++++++++++
 src/features/search/searchNavigation.ts            | 17 ++++++++++
 5 files changed, 63 insertions(+), 12 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
