### PR TITLE
#157 Addition of french translated LXX version

### DIFF
--- a/src/features/bible/VersionSelectorItem.tsx
+++ b/src/features/bible/VersionSelectorItem.tsx
@@ -296,7 +296,9 @@ const VersionSelectorItem = ({
                 </Box>
               )}
             </HStack>
-            <CopyrightText onPress={openSourceUrl}>{version.c}</CopyrightText>
+            <CopyrightText onPress={version.sourceUrl ? openSourceUrl : undefined}>
+              {version.c}
+            </CopyrightText>
           </Box>
           {!isLoading && !isQueued && version.id !== 'LSGS' && version.id !== 'KJVS' && (
             <TouchableOpacity

--- a/src/features/bible/VersionSelectorItem.tsx
+++ b/src/features/bible/VersionSelectorItem.tsx
@@ -373,7 +373,9 @@ const VersionSelectorItem = ({
               </Box>
             )}
           </HStack>
-          <CopyrightText onPress={openSourceUrl}>{version.c}</CopyrightText>
+          <CopyrightText onPress={version.sourceUrl ? openSourceUrl : undefined}>
+            {version.c}
+          </CopyrightText>
         </Box>
         {renderSelectionCheckbox()}
       </Box>

--- a/src/features/bible/VersionSelectorItem.tsx
+++ b/src/features/bible/VersionSelectorItem.tsx
@@ -1,7 +1,7 @@
 import * as Icon from '@expo/vector-icons'
 import * as FileSystem from 'expo-file-system/legacy'
 import React from 'react'
-import { Alert, TouchableOpacity } from 'react-native'
+import { Alert, Linking, TouchableOpacity } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { dbManager } from '~helpers/sqlite'
 
@@ -61,6 +61,12 @@ const TextCopyright = styled.Text<{ isSelected?: boolean }>(({ isSelected, theme
   opacity: 0.5,
 }))
 
+const TextSourceLink = styled(TextCopyright)(({ theme }) => ({
+  color: theme.colors.primary,
+  textDecorationLine: 'underline',
+  opacity: 0.75,
+}))
+
 const TextName = styled.Text<{ isSelected?: boolean }>(({ isSelected, theme }) => ({
   color: isSelected ? theme.colors.primary : theme.colors.default,
   fontSize: 16,
@@ -109,6 +115,12 @@ const VersionSelectorItem = ({
   const isLoading = queueState?.status === 'downloading' || queueState?.status === 'inserting'
   const isQueued = queueState?.status === 'queued'
   const downloadProgress = queueState?.downloadProgress ?? 0
+  const CopyrightText = version.sourceUrl ? TextSourceLink : TextCopyright
+  const openSourceUrl = () => {
+    if (version.sourceUrl) {
+      Linking.openURL(version.sourceUrl)
+    }
+  }
 
   React.useEffect(() => {
     ;(async () => {
@@ -284,7 +296,7 @@ const VersionSelectorItem = ({
                 </Box>
               )}
             </HStack>
-            <TextCopyright>{version.c}</TextCopyright>
+            <CopyrightText onPress={openSourceUrl}>{version.c}</CopyrightText>
           </Box>
           {!isLoading && !isQueued && version.id !== 'LSGS' && version.id !== 'KJVS' && (
             <TouchableOpacity
@@ -361,7 +373,7 @@ const VersionSelectorItem = ({
               </Box>
             )}
           </HStack>
-          <TextCopyright>{version.c}</TextCopyright>
+          <CopyrightText onPress={openSourceUrl}>{version.c}</CopyrightText>
         </Box>
         {renderSelectionCheckbox()}
       </Box>

--- a/src/helpers/bibleVersions.ts
+++ b/src/helpers/bibleVersions.ts
@@ -131,6 +131,7 @@ export interface Version {
   name: string
   name_en?: string
   c?: string
+  sourceUrl?: string
   type?: 'en' | 'fr' | 'other'
   hasAudio?: boolean
   hasRedWords?: boolean
@@ -390,6 +391,14 @@ export const versions: Record<string, Version> = {
     type: 'fr',
     hasRedWords: true,
   },
+  LXX_FR: {
+    id: 'LXX_FR',
+    name: 'Septante française (AT)',
+    name_en: 'French Septuagint (OT)',
+    c: 'Texte grec-français édité par ThéoTeX Éditions - theotex.org',
+    sourceUrl: 'https://theotex.org/',
+    type: 'fr',
+  },
   EASY: {
     id: 'EASY',
     name: 'EasyEnglish Bible 2018',
@@ -599,6 +608,7 @@ export const versionsBySections_en: VersionsBySection[] = Object.values(versions
       case 'NFC':
       case 'BCC1923':
       case 'PDV2017':
+      case 'LXX_FR':
       case 'POV': {
         sectionArray[1].data.push(versionEn)
         return sectionArray

--- a/src/helpers/firebase.ts
+++ b/src/helpers/firebase.ts
@@ -138,6 +138,7 @@ export const biblesRef: {
   PDV2017: cdnUrl('bibles/bible-pdv2017.json'),
   BFC: cdnUrl('bibles/bible-bfc.json'),
   BCC1923: cdnUrl('bibles/bible-bcc1923.json'),
+  LXX_FR: cdnUrl('bibles/bible-lxx-french.json'),
   // JER: cdnUrl('bibles/bible-jer.json'),
   LXX: cdnUrl('bibles/bible-lxx.json'),
   TR1624: cdnUrl('bibles/bible-TR1624.json'),


### PR DESCRIPTION
## Summary

- Closes #157
- Addition of french translated LXX version

## Agent Change Summary

Implemented issue #157 by registering the French LXX as a distinct `LXX_FR` Bible version.

Changes:
- Added `LXX_FR` French Bible metadata with French and English display names.
- Added Theotex attribution metadata and a source URL for clickable source text in the version selector.
- Added the CDN download mapping for `bibles/bible-lxx-french.json`.
- Verified the version appears in French download/version flows, downloads through the regular Bible queue, inserts into SQLite, and renders Genèse 1.

Validation:
- `curl -I -L https://assets.bible-strong.app/bibles/bible-lxx-french.json`: passed, HTTP 200.
- `yarn typecheck`: passed.
- `yarn test --watchman=false`: passed, 14 suites / 247 tests.
- `yarn format:check`: passed.
- `yarn prettier --check src/helpers/bibleVersions.ts src/helpers/firebase.ts src/features/bible/VersionSelectorItem.tsx`: passed.
- `yarn eslint src/helpers/bibleVersions.ts src/helpers/firebase.ts src/features/bible/VersionSelectorItem.tsx`: passed.
- `yarn agents:quality:check`: passed.
- `yarn agents:architecture:check`: passed with existing warnings.
- `yarn lint`: blocked by pre-existing unrelated failures in generated docs app-flow assets and an existing

...

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/157
- Branch: `codex/issue-157-addition-of-french-translated-lxx-version`
- Base: `master`
- Proposed commit: `feat(bible): add French LXX version metadata`
- Owned files or modules:
- `src/features/bible/VersionSelectorItem.tsx`
- `src/helpers/bibleVersions.ts`
- `src/helpers/firebase.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [x] `yarn typecheck`
- [ ] `yarn lint`
- [x] `yarn test`
- [x] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/157/mobile-validation.md`
- `.scratch/issues/157/codex-final.md`
- `.scratch/issues/157/commit-message.txt`
- `.scratch/issues/157/change-summary.md`
- `.scratch/issues/157/pr-notes.md`
- `.scratch/issues/157/evidence/after-downloads-lxx-fr-installed.png`
- `.scratch/issues/157/evidence/after-genesis-1-lxx-fr.png`

## PR Notes

Reviewer notes:
- The new stable version code is `LXX_FR`.
- The download URL resolves to `https://assets.bible-strong.app/bibles/bible-lxx-french.json`.
- Theotex attribution is stored on the version metadata and appears in the selector/download surfaces. In the version selector, source-attributed copyright text is clickable via `sourceUrl`.
- Existing Greek `LXX` remains unchanged and continues to point at `bibles/bible-lxx.json`.

Evidence to attach:
- `.scratch/issues/157/evidence/after-downloads-lxx-fr-installed.png`
- `.scratch/issues/157/evidence/after-genesis-1-lxx-fr.png`

Risks:
- This changes Bible version metadata and the CDN mapping only; no schema or migration change.
- Full `yarn lint` is currently blocked by unrelated baseline issues in generated docs assets and `src/features/bible/BibleViewer.tsx`.

## Agent Validation Report

Implemented issue #157 on branch `codex/issue-157-addition-of-french-translated-lxx-version`.

Files changed:
- [src/helpers/bibleVersions.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/helpers/bibleVersions.ts:129): added `LXX_FR` metadata, French categorization, Theotex attribution, and `sourceUrl`.
- [src/helpers/firebase.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/helpers/firebase.ts:140): mapped `LXX_FR` to `bibles/bible-lxx-french.json`.
- [src/features/bible/VersionSelectorItem.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/VersionSelectorItem.tsx:64): made source-attributed copyright text clickable.

Validation:
- `curl -I -L https://assets.bible-strong.app/bibles/bible-lxx-french.json`: passed, HTTP 200.
- `yarn typecheck`: passed.
- `yarn test --watchman=false`: passed, 14 suites / 247 tests.
- `yarn format:check`: passed.
- `yarn eslint src/helpers/bibleVersions.ts src/helpers/firebase.ts src/features/bible/VersionSelectorItem.tsx`: passed.
- `yarn agents:quality:check`: passed.
- `yarn agents:architecture:check`: passed with existing warnings.
- `yarn lint`: blocked by unrelated baseline lint failures in generated docs app-flow assets and an existing `BibleViewer.tsx` unused import.

Mobile runtime status: `passed`.
- Downloaded `LXX_FR` through the app download flow.
- Confirmed SQLite insertion logs.
- Opened `Genèse 1` with `LXX_FR` and confirmed French LXX text renders.

Evidence/artifacts written:
- `.scratch/issues/157/evidence/after-downloads-lxx-fr-installed.png`
- `.scratch/issues/157/evidence/after-genesis-1-lxx-fr.png`
- `.scratch/issues/157/mobile-validation.md`
- `.scratch/issues/157/commit-message.txt`
- `.scratch/issues/157/change-summary.md`
- `.scratch/issues/157/pr-notes.md`

...

## Diff Stat

```text
src/features/bible/VersionSelectorItem.tsx | 18 +++++++++++++++---
 src/helpers/bibleVersions.ts               | 10 ++++++++++
 src/helpers/firebase.ts                    |  1 +
 3 files changed, 26 insertions(+), 3 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
