### PR TITLE
#195 Clicking on a searched verse doesn’t open the right version

### DIFF
--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -185,7 +185,7 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/plans/plan.hooks.ts:453 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/profile/components/DeleteAccountModal.tsx:8 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/profile/components/DeleteAccountModal.tsx:56 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:183 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:184 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:54 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:89 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:131 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/docs/agents/quality-score.md
+++ b/docs/agents/quality-score.md
@@ -23,7 +23,7 @@ This report is a directional agent-readability score, not a product quality verd
 | `onboarding` | 6/10 | 7 | 0 | yes | yes | no colocated feature tests; 5 eslint-disable markers; sensitive user/account surface |
 | `plans` | 7/10 | 26 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
 | `profile` | 5/10 | 9 | 0 | no | yes | no colocated feature tests; no mapped smoke path; no feature README; sensitive user/account surface |
-| `search` | 7/10 | 6 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
+| `search` | 9/10 | 7 | 1 | yes | no | 2 eslint-disable markers |
 | `settings` | 5/10 | 35 | 0 | yes | yes | no colocated feature tests; 12 console calls; 1 eslint-disable markers; sensitive user/account surface |
 | `studies` | 5/10 | 34 | 0 | no | no | no colocated feature tests; no mapped smoke path; 17 console calls; 2 eslint-disable markers |
 | `timeline` | 7/10 | 28 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |

--- a/src/features/search/SQLiteSearchScreen.tsx
+++ b/src/features/search/SQLiteSearchScreen.tsx
@@ -31,6 +31,7 @@ import LexiqueResultsWidget from '~features/lexique/LexiqueResultsWidget'
 import NaveResultsWidget from '~features/nave/NaveResultsWidget'
 import BibleReferenceWidget, { parseBibleReference } from '~features/search/BibleReferenceWidget'
 import SearchEmptyState from '~features/search/SearchEmptyState'
+import { getBibleViewParamsForSearchResult } from '~features/search/searchNavigation'
 import { searchFiltersAtom, SearchSection } from '~state/searchFilters'
 
 type Props = {
@@ -297,13 +298,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
                 onPress={() =>
                   router.push({
                     pathname: '/bible-view',
-                    params: {
-                      isReadOnly: 'true',
-                      book: JSON.stringify(booksDesc[result.book - 1]),
-                      chapter: String(result.chapter),
-                      verse: String(result.verse),
-                      focusVerses: JSON.stringify([result.verse]),
-                    },
+                    params: getBibleViewParamsForSearchResult(result),
                   })
                 }
               />

--- a/src/features/search/__tests__/searchNavigation-test.ts
+++ b/src/features/search/__tests__/searchNavigation-test.ts
@@ -1,0 +1,39 @@
+import { getBibleViewParamsForSearchResult } from '../searchNavigation'
+
+describe('getBibleViewParamsForSearchResult', () => {
+  it('preserves the tapped search result version in Bible view params', () => {
+    expect(
+      getBibleViewParamsForSearchResult({
+        book: 51,
+        chapter: 2,
+        verse: 19,
+        version: 'DBY',
+      })
+    ).toEqual({
+      isReadOnly: 'true',
+      book: JSON.stringify({ Numero: 51, Nom: 'Colossiens', Chapitres: 4 }),
+      chapter: '2',
+      verse: '19',
+      version: 'DBY',
+      focusVerses: JSON.stringify([19]),
+    })
+  })
+
+  it('keeps different result versions distinct', () => {
+    const lsgParams = getBibleViewParamsForSearchResult({
+      book: 51,
+      chapter: 2,
+      verse: 19,
+      version: 'LSG',
+    })
+    const dbyParams = getBibleViewParamsForSearchResult({
+      book: 51,
+      chapter: 2,
+      verse: 19,
+      version: 'DBY',
+    })
+
+    expect(lsgParams.version).toBe('LSG')
+    expect(dbyParams.version).toBe('DBY')
+  })
+})

--- a/src/features/search/searchNavigation.ts
+++ b/src/features/search/searchNavigation.ts
@@ -1,0 +1,17 @@
+import booksDesc from '~assets/bible_versions/books-desc'
+
+type BibleViewSearchResult = {
+  book: number
+  chapter: number
+  verse: number
+  version: string
+}
+
+export const getBibleViewParamsForSearchResult = (result: BibleViewSearchResult) => ({
+  isReadOnly: 'true',
+  book: JSON.stringify(booksDesc[result.book - 1]),
+  chapter: String(result.chapter),
+  verse: String(result.verse),
+  version: result.version,
+  focusVerses: JSON.stringify([result.verse]),
+})


### PR DESCRIPTION
## Summary

- Closes #195
- Clicking on a searched verse doesn’t open the right version

## Agent Change Summary

Implemented issue #195 by preserving the tapped search result's Bible version when opening `/bible-view`.

Changes:
- Added `getBibleViewParamsForSearchResult` to build the Bible route params from a search result, including `version`.
- Updated `SQLiteSearchScreen` to use the helper for result taps.
- Added focused Jest coverage proving DBY and LSG search results keep distinct `version` params while preserving book, chapter, verse, focus verse, and read-only params.
- Added an ESLint ignore for the generated `docs/assets/app-flows/dist/**` bundle so canonical lint validation checks source files rather than untracked build output.
- Regenerated the agent quality and architecture reports through the required harness checks.

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/195
- Branch: `codex/issue-195-clicking-on-a-searched-verse-doesn-t-open-the-right-version`
- Base: `master`
- Proposed commit: `fix(search): open Bible results with their result version`
- Owned files or modules:
- `docs/agents/architecture-lint.md`
- `docs/agents/quality-score.md`
- `eslint.config.js`
- `src/features/search/SQLiteSearchScreen.tsx`
- `src/features/search/__tests__/searchNavigation-test.ts`
- `src/features/search/searchNavigation.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via `serve-sim` or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/195/mobile-validation.md`
- `.scratch/issues/195/codex-final.md`
- `.scratch/issues/195/commit-message.txt`
- `.scratch/issues/195/change-summary.md`
- `.scratch/issues/195/pr-notes.md`
- `.scratch/issues/195/evidence/runtime-explicit-dby-bible-view.png`
- `.scratch/issues/195/evidence/runtime-launch.png`
- `.scratch/issues/195/evidence/runtime-search-cleared.png`
- `.scratch/issues/195/evidence/runtime-search-dby-results.png`
- `.scratch/issues/195/evidence/runtime-search-results.png`
- `.scratch/issues/195/evidence/runtime-search-tab.png`
- `.scratch/issues/195/evidence/search-result-dby-opened.png`

## PR Notes

Issue #195 fixes search result navigation so the opened Bible view uses the version shown on the tapped result.

Validation:
- `yarn test src/features/search/__tests__/searchNavigation-test.ts --watchman=false`
- `yarn typecheck`
- `yarn lint`
- `yarn test --watchman=false`
- `yarn format:check`
- `yarn agents:quality:check`
- `yarn agents:architecture:check`
- Simulator smoke documented in `.scratch/issues/195/mobile-validation.md`

Evidence:
- `.scratch/issues/195/evidence/search-result-dby-opened.png`

Reviewer notes:
- Manual smoke used `par des jointures et des liens`, which returned `LSG`, `NEG79`, and `DBY`; tapping `DBY` opened `Colossiens 2:19 - DBY`.
- Added a small ESLint ignore for the generated `docs/assets/app-flows/dist/**` bundle so `yarn lint` does not lint untracked build artifacts.
- Sensitive areas touched: none.

## Agent Validation Report

Implemented and validated issue #195 on branch `codex/issue-195-clicking-on-a-searched-verse-doesn-t-open-the-right-version`.

**Files changed**
- `src/features/search/SQLiteSearchScreen.tsx`
- `src/features/search/searchNavigation.ts`
- `src/features/search/__tests__/searchNavigation-test.ts`
- `eslint.config.js`
- `docs/agents/architecture-lint.md`
- `docs/agents/quality-score.md`

**Validation**
- `yarn test src/features/search/__tests__/searchNavigation-test.ts --watchman=false` passed
- `yarn typecheck` passed
- `yarn lint` passed, with existing warnings only
- `yarn test --watchman=false` passed: 249 tests
- `yarn format:check` passed
- `yarn agents:quality:check` passed
- `yarn agents:architecture:check` passed with existing warnings

**Mobile Runtime**
- Status: `passed`
- Tested on iPhone 17 simulator, iOS 26.4.
- Searched `par des jointures et des liens`, tapped the `DBY` result, and confirmed it opened `Colossiens 2:19 - DBY`.

**Evidence Written**
- `.scratch/issues/195/evidence/search-result-dby-opened.png`
- `.scratch/issues/195/mobile-validation.md`
- `.scratch/issues/195/commit-message.txt`
- `.scratch/issues/195/change-summary.md`
- `.scratch/issues/195/pr-notes.md`

Sensitive areas touched: none.

Remaining blockers: none.

status: passed

Device: iPhone 17 simulator, iOS 26.4, UDID 67D95AA7-A03F-4DFF-A2AF-80E313FCC864.
Metro: started with Node 20 workaround:
`npx -y -p node@20 node /Users/stephane/.cache/node/corepack/v1/yarn/4.12.0/yarn.js start --port 8081`.

Smoke path covered:
- Launched `builds/biblestrong.dev.app` with bundle id `com.smontlouis.biblestrong.dev`.
- Confirmed app startup and Bible WebView mount in Metro logs.
- Opened Search from the bottom tab bar.
- Searched for `par des jointures et des liens`.
- Confirmed search returned `Colo

...

## Diff Stat

```text
docs/agents/architecture-lint.md                   |  8 ++---
 docs/agents/quality-score.md                       |  2 +-
 eslint.config.js                                   |  1 +
 src/features/search/SQLiteSearchScreen.tsx         |  9 ++---
 .../search/__tests__/searchNavigation-test.ts      | 39 ++++++++++++++++++++++
 src/features/search/searchNavigation.ts            | 17 ++++++++++
 6 files changed, 64 insertions(+), 12 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
