### PR TITLE
#246 Grid mode chapter picker hides later chapters and obscures scrolling

### DIFF
--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -7,17 +7,17 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 ## Summary
 
 - Errors: 0
-- Warnings: 486
+- Warnings: 491
 
 ## Rules
 
 | Rule | Severity | Findings | Meaning |
 |---|---|---:|---|
 | `sqlite-boundary` | error | 0 | Import SQLite through helper boundaries. |
-| `helpers-feature-boundary` | warning | 1 | Shared helpers should not depend on features. |
-| `feature-firebase-boundary` | warning | 8 | Feature code should avoid direct Firebase access. |
+| `helpers-feature-boundary` | warning | 4 | Shared helpers should not depend on features. |
+| `feature-firebase-boundary` | warning | 7 | Feature code should avoid direct Firebase access. |
 | `deep-relative-import` | warning | 52 | Prefer aliases or public module boundaries over deep relative imports. |
-| `raw-console` | warning | 425 | Prefer `appLogger` for agent-queryable diagnostics. |
+| `raw-console` | warning | 428 | Prefer `appLogger` for agent-queryable diagnostics. |
 
 ## Findings
 
@@ -32,24 +32,19 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/common/InitHooks.tsx:149 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/common/InitHooks.tsx:159 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/common/InitHooks.tsx:163 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/VerseAccordion.tsx:51 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForDictionnaireDB.tsx:81 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForNaveDB.tsx:70 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForNaveDB.tsx:95 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForStrongDB.tsx:74 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForStrongDB.tsx:100 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/common/VerseAccordion.tsx:59 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/common/resourceDatabaseAccess.ts:90 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/common/resourceDatabaseAccess.ts:109 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/common/waitForTimeline.tsx:61 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/common/waitForTimeline.tsx:94 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForTresorModal.tsx:49 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/common/waitForTresorModal.tsx:69 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/devtools/reduxDevtoolsPolyfill.ts:39 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/devtools/reduxDevtoolsPolyfill.ts:119 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/app-rating/useAppRating.ts:33 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/app-rating/useAppRating.ts:87 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/app-rating/useAppRating.ts:101 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/AppSwitcherScreen.tsx:11 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/CreateGroupPage.tsx:20 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/CreateGroupPage.tsx:21 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/CreateGroupPage.tsx:22 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/StaticTabPreview.tsx:10 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/TabGroupPage.tsx:18 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/AppSwitcherScreen/TabGroupPage.tsx:19 - Prefer path aliases or a small public module boundary over deep relative imports.
@@ -62,29 +57,29 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/Buttons/MenuButton.tsx:7 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/Buttons/useSearchButton.ts:5 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/Buttons/useTabButtonPress.ts:11 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/EditGroupModal.tsx:13 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/EditGroupModal.tsx:18 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/GroupActionsPopover.tsx:9 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/GroupActionsPopover.tsx:10 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/GroupTitleButton.tsx:6 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/GroupTitleButton.tsx:7 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/GroupTitleButton.tsx:8 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/ViewGroupsModal.tsx:13 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/ViewGroupsModal.tsx:11 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/BottomTabBar/useBottomTabBar.ts:5 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `raw-console` src/features/app-switcher/CachedTabScreens.tsx:21 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/app-switcher/TabPreviewCarousel/TabPreview.tsx:10 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/TabPreviewCarousel/TabPreviewCarousel.tsx:5 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/NewTabItem.tsx:8 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/NewTabItem.tsx:9 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/NewTabScreen.tsx:7 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/NewTabItem.tsx:10 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/NewTabScreen.tsx:15 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/SelectBibleReferenceModal.tsx:8 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/SelectBibleReferenceModalProvider.tsx:3 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/TabScreen/NewTab/atoms.ts:2 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/TabScreen.tsx:19 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/app-switcher/TabScreen/TabScreen.tsx:21 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/getIconByTabType.tsx:4 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/tabHelpers.ts:4 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useExpandNewTab.ts:5 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useOnceAtoms.ts:3 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useOpenInNewTab.ts:6 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `raw-console` src/features/app-switcher/utils/useProviderEffects.ts:48 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/app-switcher/utils/useProviderEffects.ts:74 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useSlideNewTab.ts:4 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useTabAnimations.ts:6 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/app-switcher/utils/useTakeActiveTabSnapshot.ts:6 - Prefer path aliases or a small public module boundary over deep relative imports.
@@ -93,99 +88,102 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/app-switcher/utils/useTakeActiveTabSnapshot.ts:26 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/app-switcher/utils/useTakeActiveTabSnapshot.ts:34 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/app-switcher/utils/useWhyDidYouUpdate.ts:30 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/AnnotationNoteModal.tsx:147 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationEvents.ts:45 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationEvents.ts:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationEvents.ts:100 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationEvents.ts:116 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationHighlights.ts:197 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationModeController.ts:114 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationModeController.ts:146 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:493 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:507 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:538 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:551 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:562 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:569 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:621 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:628 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:648 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:655 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:669 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:676 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:720 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:733 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:746 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:754 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:1131 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMWrapper.tsx:372 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMWrapper.tsx:377 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationHighlights.ts:200 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationModeController.ts:107 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/AnnotationMode/useAnnotationModeController.ts:138 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:616 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:630 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:661 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:674 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:685 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:692 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:744 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:751 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:771 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:778 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:792 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:799 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:838 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:851 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:1349 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:1361 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:1370 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMComponent.tsx:1393 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMWrapper.tsx:465 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMWrapper.tsx:470 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleDOM/BibleDOMWrapper.tsx:747 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/bible/BibleDOM/ContainerText.tsx:4 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `raw-console` src/features/bible/BibleErrorView.tsx:67 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleHeader.tsx:171 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleHeader.tsx:226 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleHeader.tsx:270 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleLinkModal.tsx:216 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleLinkModal.tsx:353 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleLinkModal.tsx:354 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleNoteModal.tsx:137 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleTabScreen.tsx:91 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleTabScreen.tsx:99 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleViewer.tsx:446 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/BibleViewer.tsx:684 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `deep-relative-import` src/features/bible/BookSelectorBottomSheet/BookSelectorBottomSheetProvider.tsx:3 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `raw-console` src/features/bible/BookSelectorBottomSheet/BookSelectorList.tsx:88 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/ListenStrong.tsx:71 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `deep-relative-import` src/features/bible/SelectedVersesModal/SelectedVersesModal.tsx:12 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `raw-console` src/features/bible/BibleHeader.tsx:362 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleHeader.tsx:421 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleHeader.tsx:469 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleLinkScreen.tsx:222 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleLinkScreen.tsx:347 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleLinkScreen.tsx:348 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleTabScreen.tsx:69 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleTabScreen.tsx:77 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleViewer.tsx:481 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BibleViewer.tsx:739 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/BookSelectorSheet/BookSelectorList.tsx:112 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `deep-relative-import` src/features/bible/BookSelectorSheet/BookSelectorSheetProvider.tsx:3 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `raw-console` src/features/bible/BookSelectorSheet/__tests__/BookSelectorList-test.tsx:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `deep-relative-import` src/features/bible/SelectedVersesModal/SelectedVersesModal.tsx:8 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/bible/SelectedVersesModal/hooks/useVerseActions.ts:12 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `deep-relative-import` src/features/bible/SelectedVersesModal/types.ts:3 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/bible/VersionSelectorBottomSheet/VersionSelectorBottomSheet.tsx:14 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/bible/footer/AudioUrlFooter.tsx:20 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:102 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:103 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:178 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:211 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:238 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/StrongAudioProvider.tsx:75 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/StrongAudioProvider.tsx:100 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/StrongAudioProvider.tsx:140 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `deep-relative-import` src/features/bible/VersionSelectorSheet/VersionSelectorSheet.tsx:13 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/bible/footer/AudioUrlFooter.tsx:26 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:115 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:116 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:191 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:226 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/bible/footer/AudioUrlFooter.tsx:254 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/bible/footer/BackToAudioFooter.tsx:12 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/bible/resources/ResourceModal.tsx:30 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `feature-firebase-boundary` src/features/commentaries/Comment.tsx:20 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
+- WARNING `deep-relative-import` src/features/bible/resources/ResourceModal.tsx:28 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `feature-firebase-boundary` src/features/commentaries/Comment.tsx:19 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/commentaries/Comment.tsx:81 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/commentaries/Comment.tsx:103 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/commentaries/Comment.tsx:166 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/commentaries/CommentariesTabScreen.tsx:34 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
-- WARNING `raw-console` src/features/dictionnary/DictionaryDetailTabScreen.tsx:157 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/dictionnary/DictionaryDetailTabScreen.tsx:161 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/home/Events.tsx:5 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `feature-firebase-boundary` src/features/home/HomeScreen.tsx:2 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/home/PlanHome.tsx:44 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/home/StrongOfTheDay.tsx:46 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/home/VerseImageModal.tsx:60 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/home/StrongOfTheDay.tsx:47 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/home/VerseImageModal.tsx:58 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:166 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:174 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/home/useVerseOfTheDay.ts:189 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/lexique/StrongDetailScreen.tsx:183 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:115 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:155 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/notes/NoteDetailTabScreen.tsx:175 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/onboarding/DownloadResources.tsx:50 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/lexique/StrongDetailScreen.tsx:200 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:134 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/nave/NaveDetailTabScreen.tsx:164 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/notes/NoteDetailTabScreen.tsx:282 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/onboarding/DownloadResources.tsx:47 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/onboarding/OnBoarding.tsx:31 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/onboarding/OnBoarding.tsx:43 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/onboarding/OnBoarding.tsx:49 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/onboarding/OnBoarding.tsx:53 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `feature-firebase-boundary` src/features/onboarding/SelectResources.tsx:13 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
-- WARNING `raw-console` src/features/plans/Explore/ExplorePlanItem.tsx:124 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `deep-relative-import` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:23 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `deep-relative-import` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:24 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:193 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/Slice.tsx:22 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:27 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:28 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:29 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:30 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/Explore/ExplorePlanItem.tsx:117 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `deep-relative-import` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:21 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `deep-relative-import` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:22 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/PlanSliceScreen.tsx:192 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/Slice.tsx:26 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:31 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:32 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:33 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/PlanSliceScreen/VideoSlice.tsx:34 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/plans/plan.hooks.ts:6 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
-- WARNING `raw-console` src/features/plans/plan.hooks.ts:453 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `feature-firebase-boundary` src/features/profile/components/DeleteAccountModal.tsx:8 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
-- WARNING `raw-console` src/features/profile/components/DeleteAccountModal.tsx:56 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:184 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/plans/plan.hooks.ts:344 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `feature-firebase-boundary` src/features/profile/components/DeleteAccountModal.tsx:14 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
+- WARNING `raw-console` src/features/profile/components/DeleteAccountModal.tsx:59 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/resources/bibleContentAccess.ts:56 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:390 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:54 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:89 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:131 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -197,29 +195,29 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/settings/ImportExportScreen.tsx:158 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/ImportExportScreen.tsx:208 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/settings/MoreScreen.tsx:2 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
-- WARNING `deep-relative-import` src/features/settings/MoreScreen.tsx:30 - Prefer path aliases or a small public module boundary over deep relative imports.
-- WARNING `raw-console` src/features/settings/MoreScreen.tsx:98 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `deep-relative-import` src/features/settings/MoreScreen.tsx:32 - Prefer path aliases or a small public module boundary over deep relative imports.
+- WARNING `raw-console` src/features/settings/MoreScreen.tsx:101 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/components/StorageSummaryCard.tsx:48 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/EditStudyScreen.tsx:93 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/EditStudyScreen.tsx:109 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/studies/PublishStudyMenuItem.tsx:146 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/studies/StudiesDOM/InlineStrong.ts:21 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/ModuleBlockVerse.ts:26 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/ModuleBlockVerse.ts:50 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/ModuleBlockVerse.ts:46 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/ModuleBlockVerse.ts:70 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/studies/StudiesDOM/StrongBlock.tsx:45 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:160 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:236 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:250 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:253 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:84 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:87 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:94 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:128 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:188 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:193 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:99 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:183 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:259 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:273 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDOMComponent.tsx:276 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:80 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:83 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:90 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:124 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:192 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/studies/StudiesDOM/StudiesDomWrapper.tsx:197 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `deep-relative-import` src/features/studies/hooks/useAddVerseToStudy.ts:9 - Prefer path aliases or a small public module boundary over deep relative imports.
 - WARNING `raw-console` src/features/studies/hooks/useAddVerseToStudy.ts:46 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/timeline/EventDetailsMedia.tsx:104 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/timeline/EventDetailsModalContext.tsx:35 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/timeline/EventDetailsMedia.tsx:112 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/AutoBackupManager.ts:61 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/AutoBackupManager.ts:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/AutoBackupManager.ts:67 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -277,12 +275,13 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/bibleResource.ts:53 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/bibleResource.ts:64 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/bibleResource.ts:67 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:137 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:159 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:219 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:284 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:539 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/biblesDb.ts:562 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `helpers-feature-boundary` src/helpers/bibleVersions.ts:2 - Shared helpers must not depend on feature modules.
+- WARNING `raw-console` src/helpers/biblesDb.ts:143 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/biblesDb.ts:165 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/biblesDb.ts:225 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/biblesDb.ts:290 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/biblesDb.ts:582 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/biblesDb.ts:605 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/captureError.ts:5 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/catchDatabaseError.new.ts:9 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/catchDatabaseError.new.ts:47 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -302,84 +301,85 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/databaseMigration.ts:128 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/databaseMigration.ts:130 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/databases.ts:106 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:39 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:61 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:67 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:40 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:60 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:66 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadManager.ts:172 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadManager.ts:255 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadManager.ts:322 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:94 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:142 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:167 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:195 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:197 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:232 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:241 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:249 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:260 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:273 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:278 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:307 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:311 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:339 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:340 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:341 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:344 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:347 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:356 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:361 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:399 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:408 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:420 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:435 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:439 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:450 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:451 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:452 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:457 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:458 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:459 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:517 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:531 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:534 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:542 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:547 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:554 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:564 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:575 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadWithCdnFallback.ts:50 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `helpers-feature-boundary` src/helpers/firestoreMigration.ts:27 - Shared helpers must not depend on feature modules.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:59 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:147 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:169 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:191 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:284 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:334 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:379 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:404 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:432 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:434 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:465 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:466 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:467 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:470 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:473 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:495 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:507 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:512 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:550 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:559 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:572 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:587 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:595 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/firestoreMigration.ts:600 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:606 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:624 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:674 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:718 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:724 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreMigration.ts:748 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:113 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:134 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:194 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:206 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:209 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:211 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:228 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:250 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:261 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:265 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:285 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:312 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:332 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:334 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:372 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:379 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:479 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:486 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:495 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:530 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:611 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:612 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:613 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:618 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:619 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:620 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:676 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:690 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:693 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:701 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:706 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:713 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:723 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:734 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:759 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:765 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:783 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:833 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:877 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:883 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreMigration.ts:907 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:154 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:175 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:240 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:252 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:255 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:257 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:287 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:309 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:320 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:324 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:344 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:371 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:391 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:393 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:431 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:438 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:540 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:547 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:556 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/firestoreSubcollections.ts:592 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/getSQLTransaction.ts:19 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/getSQLTransaction.ts:57 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/getSQLTransaction.ts:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/getSQLTransaction.ts:83 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/getSQLTransaction.ts:91 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/loadBibleChapter.ts:88 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `helpers-feature-boundary` src/helpers/loadBibleChapter.ts:2 - Shared helpers must not depend on feature modules.
 - WARNING `raw-console` src/helpers/migrationState.ts:29 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/migrationState.ts:41 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/migrationState.ts:52 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -388,10 +388,10 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/nukeApp.ts:24 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/nukeApp.ts:30 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/nukeApp.ts:37 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/nukeApp.ts:50 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/nukeApp.ts:57 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/nukeApp.ts:64 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/nukeApp.ts:68 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/nukeApp.ts:44 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/nukeApp.ts:53 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/nukeApp.ts:69 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/nukeApp.ts:73 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/react-native-htmlview/HTMLView.tsx:38 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/react-native-htmlview/vendor/htmlparser2.ts:3009 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/react-native-htmlview/vendor/htmlparser2.ts:3015 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -406,18 +406,18 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/sqlite.ts:44 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/sqlite.ts:59 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/sqlite.ts:62 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:120 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/sqlite.ts:122 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:136 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:138 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:149 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:152 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:213 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:221 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:309 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:331 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:335 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/sqlite.ts:340 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:128 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:148 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:150 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:161 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:164 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:225 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:233 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:321 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:343 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:347 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/sqlite.ts:352 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/storage.ts:23 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/storage.ts:42 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/storage.ts:50 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -430,9 +430,9 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/storage.ts:129 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/storage.ts:177 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/styledProps.ts:13 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:115 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:128 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:137 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:156 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:169 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/tabGroupsFirestoreSync.ts:178 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/toast.ts:17 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useConnection.ts:15 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useDownloadBibleResources.ts:42 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -441,7 +441,7 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/useFirestoreMigration.ts:63 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useFirestoreMigration.ts:78 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useFirestoreMigration.ts:143 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useHTMLView.ts:125 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useHTMLView.ts:172 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:30 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:36 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:41 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -449,48 +449,53 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:46 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:78 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useInitFireAuth.tsx:79 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:38 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:47 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:86 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:93 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:98 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:156 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:160 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:188 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:196 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:205 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/useLiveUpdates.ts:213 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:56 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:104 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:116 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:123 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:131 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:134 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:195 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:199 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:212 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:235 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:243 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:252 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:260 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/useLiveUpdates.ts:270 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useRemoteConfig.ts:18 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/useRemoteConfig.ts:20 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `helpers-feature-boundary` src/helpers/verseToStrong.tsx:2 - Shared helpers must not depend on feature modules.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:195 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:216 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:221 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:228 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:231 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:247 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:346 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:670 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:672 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:682 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:700 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:276 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:326 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:331 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:338 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:341 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:357 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:464 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:675 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:677 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:687 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/redux/firestoreMiddleware.ts:705 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:707 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:717 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:779 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/firestoreMiddleware.ts:781 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/logMiddleware.ts:16 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/logMiddleware.ts:28 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/redux/modules/user.ts:1214 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:39 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:69 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:122 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:127 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:164 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:200 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabGroups.ts:206 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabs.ts:355 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/tabs.ts:375 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:710 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:712 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:722 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:788 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/firestoreMiddleware.ts:790 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/logMiddleware.ts:53 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/logMiddleware.ts:65 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/migrations.ts:35 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/modules/user.ts:281 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/redux/modules/user.ts:1508 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:49 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:82 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:129 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:134 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:166 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabGroups.ts:190 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabs.ts:413 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/tabs.ts:433 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:45 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:48 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:95 - Prefer appLogger for app-owned diagnostic events that agents should query.
@@ -498,12 +503,12 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:127 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:158 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/state/useTabGroupsSync.ts:171 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:194 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:197 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:214 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:223 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:245 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:346 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:354 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:362 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/state/useTabGroupsSync.ts:364 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:195 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:198 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:215 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:224 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:246 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:347 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:355 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:363 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/state/useTabGroupsSync.ts:365 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/docs/agents/quality-score.md
+++ b/docs/agents/quality-score.md
@@ -9,9 +9,9 @@ This report is a directional agent-readability score, not a product quality verd
 | Domain | Score | Files | Tests | Smoke | Sensitive | Main Risks |
 |---|---:|---:|---:|---|---|---|
 | `app-rating` | 5/10 | 5 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 3 eslint-disable markers |
-| `app-switcher` | 5/10 | 54 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 7 eslint-disable markers |
+| `app-switcher` | 5/10 | 55 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 8 eslint-disable markers |
 | `audio` | 7/10 | 0 | 0 | no | no | no colocated feature tests; no mapped smoke path |
-| `bible` | 8/10 | 158 | 1 | yes | no | 46 console calls; 19 eslint-disable markers |
+| `bible` | 8/10 | 160 | 9 | yes | no | 48 console calls; 18 eslint-disable markers |
 | `bookmarks` | 6/10 | 2 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README |
 | `commentaries` | 5/10 | 5 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 4 eslint-disable markers |
 | `dictionnary` | 7/10 | 11 | 0 | yes | no | no colocated feature tests; 4 eslint-disable markers |
@@ -19,14 +19,16 @@ This report is a directional agent-readability score, not a product quality verd
 | `home` | 5/10 | 23 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 4 eslint-disable markers |
 | `lexique` | 6/10 | 8 | 0 | yes | no | no colocated feature tests; no feature README; 4 eslint-disable markers |
 | `nave` | 7/10 | 12 | 0 | yes | no | no colocated feature tests; 4 eslint-disable markers |
-| `notes` | 5/10 | 5 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 2 eslint-disable markers |
-| `onboarding` | 6/10 | 7 | 0 | yes | yes | no colocated feature tests; 5 eslint-disable markers; sensitive user/account surface |
-| `plans` | 7/10 | 27 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
+| `notes` | 5/10 | 8 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README; 2 eslint-disable markers |
+| `onboarding` | 8/10 | 8 | 1 | yes | yes | 5 eslint-disable markers; sensitive user/account surface |
+| `plans` | 9/10 | 30 | 2 | yes | no | 2 eslint-disable markers |
 | `profile` | 5/10 | 9 | 0 | no | yes | no colocated feature tests; no mapped smoke path; no feature README; sensitive user/account surface |
-| `search` | 9/10 | 7 | 1 | yes | no | 2 eslint-disable markers |
-| `settings` | 5/10 | 35 | 0 | yes | yes | no colocated feature tests; 12 console calls; 1 eslint-disable markers; sensitive user/account surface |
-| `studies` | 5/10 | 34 | 0 | no | no | no colocated feature tests; no mapped smoke path; 17 console calls; 2 eslint-disable markers |
-| `timeline` | 7/10 | 28 | 0 | yes | no | no colocated feature tests; 2 eslint-disable markers |
+| `resources` | 8/10 | 9 | 3 | no | no | no mapped smoke path; no feature README |
+| `search` | 9/10 | 15 | 2 | yes | no | 2 eslint-disable markers |
+| `settings` | 5/10 | 34 | 0 | yes | yes | no colocated feature tests; 12 console calls; 1 eslint-disable markers; sensitive user/account surface |
+| `studies` | 5/10 | 34 | 0 | no | no | no colocated feature tests; no mapped smoke path; 18 console calls; 2 eslint-disable markers |
+| `studyRelations` | 8/10 | 13 | 5 | no | no | no mapped smoke path; no feature README |
+| `timeline` | 7/10 | 30 | 0 | yes | no | no colocated feature tests; 3 eslint-disable markers |
 | `tips` | 6/10 | 2 | 0 | no | no | no colocated feature tests; no mapped smoke path; no feature README |
 
 ## Scoring Inputs

--- a/src/common/ui/MenuView.d.ts
+++ b/src/common/ui/MenuView.d.ts
@@ -1,0 +1,6 @@
+export {
+  MenuView,
+  type MenuAction,
+  type MenuComponentProps,
+  type MenuComponentRef,
+} from './MenuView.ios'

--- a/src/features/bible/BookSelectorSheet/BookSelectorList.tsx
+++ b/src/features/bible/BookSelectorSheet/BookSelectorList.tsx
@@ -8,6 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { SharedValue } from 'react-native-reanimated'
 import { BibleTab } from 'src/state/tabs'
 import { BookShortItem } from './BookShortItem'
+import ChapterGrid from './ChapterGrid'
 
 interface BookSelectorListProps {
   initialScrollIndex: number
@@ -18,6 +19,8 @@ interface BookSelectorListProps {
   chaptersByBook?: Record<number, number[]>
   renderedChapterBookNumbers: number[]
   onBookSelect: (book: Book) => void
+  gridBook: Book | null
+  onGridBookSelect: (book: Book) => void
 }
 export const BookSelectorList = ({
   data,
@@ -28,6 +31,8 @@ export const BookSelectorList = ({
   chaptersByBook,
   renderedChapterBookNumbers,
   onBookSelect,
+  gridBook,
+  onGridBookSelect,
 }: BookSelectorListProps) => {
   const insets = useSafeAreaInsets()
   const selectionMode = useAtomValue(bookSelectorSelectionModeAtom)
@@ -56,6 +61,20 @@ export const BookSelectorList = ({
   }, [data.length, initialScrollIndex])
 
   if (selectionMode === 'grid') {
+    if (gridBook) {
+      return (
+        <ChapterGrid
+          book={gridBook}
+          chapters={chaptersByBook?.[gridBook.Numero]}
+          selectedChapter={
+            gridBook.Numero === bookSelectorData?.selectedBook.Numero
+              ? bookSelectorData.selectedChapter
+              : undefined
+          }
+        />
+      )
+    }
+
     return (
       <ScrollView
         contentContainerStyle={{
@@ -71,9 +90,8 @@ export const BookSelectorList = ({
           <BookShortItem
             isNT={book.Numero >= 40}
             key={book.Numero}
-            onChange={() => {}}
+            onChange={onGridBookSelect}
             book={book}
-            chapters={chaptersByBook?.[book.Numero]}
             isSelected={book.Numero === bookSelectorData?.selectedBook.Numero}
           />
         ))}

--- a/src/features/bible/BookSelectorSheet/BookSelectorSheet.tsx
+++ b/src/features/bible/BookSelectorSheet/BookSelectorSheet.tsx
@@ -12,7 +12,7 @@ import Box from '~common/ui/Box'
 import { useOpenInNewTab } from '~features/app-switcher/utils/useOpenInNewTab'
 import generateUUID from '~helpers/generateUUID'
 import { HelpTip } from '~features/tips/HelpTip'
-import { bookSelectorSortAtom, bookSelectorVersesAtom } from './atom'
+import { bookSelectorSelectionModeAtom, bookSelectorSortAtom, bookSelectorVersesAtom } from './atom'
 import { itemHeight } from './BookItem'
 import { BookSelectorList } from './BookSelectorList'
 import { BookSelectorParams } from './BookSelectorParams'
@@ -21,6 +21,7 @@ import VerseSheet, { tempSelectedBookAtom, tempSelectedChapterAtom } from './Ver
 import { useQuery } from '~helpers/react-query-lite'
 import { getBibleVersionCoverage } from '~helpers/biblesDb'
 import { useTheme } from '@emotion/react'
+import { applyBookChapterSelection } from './bookSelectorSelection'
 interface BookSelectorSheetProps {
   selectedBookNum?: number
   sheetRef: React.RefObject<SheetRef | null>
@@ -35,11 +36,13 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
   const expandedBook = useSharedValue<number | null>(null)
   const [expandedBookNumber, setExpandedBookNumber] = useState<number | null>(null)
   const [renderedChapterBookNumbers, setRenderedChapterBookNumbers] = useState<number[]>([])
+  const [gridBook, setGridBook] = useState<Book | null>(null)
   const collapseTimeouts = useRef<Record<number, ReturnType<typeof setTimeout>>>({})
   const flatListRef = useRef<FlatList>(null)
   const { t } = useTranslation()
   const sort = useAtomValue(bookSelectorSortAtom)
   const isAlphabetical = sort === 'alphabetical'
+  const selectionMode = useAtomValue(bookSelectorSelectionModeAtom)
   const verses = useAtomValue(bookSelectorVersesAtom)
   const bookSelectorHasVerses = verses === 'with-verses'
   const setTempSelectedBook = useSetAtom(tempSelectedBookAtom)
@@ -66,19 +69,17 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
       }
 
       if (type === 'select') {
-        if (bookSelectorHasVerses) {
-          setTempSelectedBook(book)
-          setTempSelectedChapter(chapter)
-          bookSelectorActions.setTempSelectedBook(book)
-          bookSelectorActions.setTempSelectedChapter(chapter)
-          verseSheetRef.current?.present()
-          return
-        }
-        bookSelectorActions.setTempSelectedBook(book)
-        bookSelectorActions.setTempSelectedChapter(chapter)
-        bookSelectorActions.setTempSelectedVerse(1)
-        bookSelectorActions.validateTempSelected()
-        sheetRef.current?.dismiss()
+        applyBookChapterSelection(
+          { book, chapter },
+          {
+            actions: bookSelectorActions,
+            hasVerses: bookSelectorHasVerses,
+            dismissBookSelector: () => sheetRef.current?.dismiss(),
+            presentVerseSelector: () => verseSheetRef.current?.present(),
+            setVerseSelectorBook: setTempSelectedBook,
+            setVerseSelectorChapter: setTempSelectedChapter,
+          }
+        )
       } else if (type === 'longPress') {
         if (bookSelectorHasVerses) {
           return
@@ -128,6 +129,7 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
     book => book.Numero === (bookSelectorData?.selectedBook.Numero || 1)
   )
   const safeInitialScrollIndex = Math.max(initialScrollIndex, 0)
+  const isGridChapterPicker = selectionMode === 'grid' && gridBook !== null
 
   useEffect(
     () => () => {
@@ -185,6 +187,7 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
         onDismiss={() => {
           expandedBook.set(null)
           setExpandedBookNumber(null)
+          setGridBook(null)
           Object.values(collapseTimeouts.current).forEach(clearTimeout)
           collapseTimeouts.current = {}
           setRenderedChapterBookNumbers([])
@@ -192,12 +195,17 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
         header={
           <>
             <SheetHeader
-              title={t('Livres')}
+              title={isGridChapterPicker ? t(gridBook.Nom) : t('Livres')}
+              subTitle={isGridChapterPicker ? t('Chapitres') : undefined}
               centerTitle
-              leftComponent={<Box width={60} />}
-              rightComponent={<BookSelectorParams />}
+              hasBackButton={isGridChapterPicker}
+              leftComponent={isGridChapterPicker ? undefined : <Box width={60} />}
+              onBackPress={isGridChapterPicker ? () => setGridBook(null) : undefined}
+              rightComponent={isGridChapterPicker ? <Box width={54} /> : <BookSelectorParams />}
             />
-            <HelpTip id="chapter-selector" description={t('tips.chapterSelector')} />
+            {!isGridChapterPicker && (
+              <HelpTip id="chapter-selector" description={t('tips.chapterSelector')} />
+            )}
           </>
         }
       >
@@ -211,6 +219,8 @@ const BookSelectorSheet = ({ sheetRef }: BookSelectorSheetProps) => {
           chaptersByBook={coverageData?.chaptersByBook}
           renderedChapterBookNumbers={renderedChapterBookNumbers}
           onBookSelect={handleBookSelect}
+          gridBook={gridBook}
+          onGridBookSelect={setGridBook}
         />
       </Sheet>
       <VerseSheet

--- a/src/features/bible/BookSelectorSheet/BookShortItem.tsx
+++ b/src/features/bible/BookSelectorSheet/BookShortItem.tsx
@@ -1,59 +1,41 @@
-import { MenuView } from '~common/ui/MenuView'
 import { useTranslation } from 'react-i18next'
-import { DeviceEventEmitter } from 'react-native'
 
 import { Book } from '~assets/bible_versions/books-desc'
-import Box from '~common/ui/Box'
+import { TouchableBox } from '~common/ui/Box'
 import Text from '~common/ui/Text'
 import { wp } from '~helpers/utils'
-import { BOOK_SELECTION_EVENT } from './constants'
 
 interface BookShortItemProps {
   book: Book
-  chapters?: number[]
   isSelected: boolean
   isNT: boolean
   onChange: (book: Book) => void
 }
 
-export const BookShortItem = ({
-  book,
-  chapters: availableChapters,
-  isSelected,
-  isNT,
-}: BookShortItemProps) => {
+export const BookShortItem = ({ book, isSelected, isNT, onChange }: BookShortItemProps) => {
   const { t } = useTranslation()
   const bookName = t(book.Nom).replace(/\s/g, '').substr(0, 3)
 
-  const chapters = availableChapters || Array.from({ length: book.Chapitres }, (_, i) => i + 1)
-
-  const handleChapterSelect = (chapter: number) => {
-    DeviceEventEmitter.emit(BOOK_SELECTION_EVENT, {
-      type: 'select',
-      book,
-      chapter,
-    })
-  }
-
   return (
-    <MenuView
-      actions={chapters.map(chapter => ({
-        id: String(chapter),
-        title: String(chapter),
-      }))}
-      onPressAction={({ nativeEvent }) => handleChapterSelect(Number(nativeEvent.event))}
+    <TouchableBox
+      testID={`book-selector-grid-book-${book.Numero}`}
+      accessibilityLabel={t(book.Nom)}
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      activeOpacity={0.7}
+      alignItems="center"
+      height={45}
+      justifyContent="center"
+      onPress={() => onChange(book)}
+      width={wp(99) / 5}
     >
-      <Box alignItems="center" justifyContent="center" height={45} width={wp(99) / 5}>
-        <Text
-          {...{
-            color: isSelected ? 'primary' : isNT ? 'quart' : 'default',
-            fontWeight: isSelected ? 'bold' : 'normal',
-            fontSize: 16,
-          }}
-        >
-          {bookName}
-        </Text>
-      </Box>
-    </MenuView>
+      <Text
+        color={isSelected ? 'primary' : isNT ? 'quart' : 'default'}
+        fontSize={16}
+        fontWeight={isSelected ? 'bold' : 'normal'}
+      >
+        {bookName}
+      </Text>
+    </TouchableBox>
   )
 }

--- a/src/features/bible/BookSelectorSheet/ChapterGrid.tsx
+++ b/src/features/bible/BookSelectorSheet/ChapterGrid.tsx
@@ -1,0 +1,89 @@
+import { SheetScrollView } from '~common/sheet'
+import { useTranslation } from 'react-i18next'
+import { DeviceEventEmitter, useWindowDimensions } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Book } from '~assets/bible_versions/books-desc'
+import Box, { TouchableBox } from '~common/ui/Box'
+import Text from '~common/ui/Text'
+import { BOOK_SELECTION_EVENT } from './constants'
+
+interface ChapterGridProps {
+  book: Book
+  chapters?: number[]
+  selectedChapter?: number
+}
+
+const ITEM_SIZE = 48
+const ITEM_GAP = 10
+const MAX_WIDTH = 500
+const HORIZONTAL_PADDING = 10
+const BOTTOM_SCROLL_CLEARANCE = ITEM_SIZE + ITEM_GAP
+
+const ChapterGrid = ({ book, chapters: availableChapters, selectedChapter }: ChapterGridProps) => {
+  const { t } = useTranslation()
+  const { width: windowWidth } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+  const chapters =
+    availableChapters ?? Array.from({ length: book.Chapitres }, (_, index) => index + 1)
+  const gridWidth = Math.min(MAX_WIDTH, windowWidth)
+  const availableWidth = gridWidth - HORIZONTAL_PADDING * 2
+  const itemsPerRow = Math.max(1, Math.floor((availableWidth + ITEM_GAP) / (ITEM_SIZE + ITEM_GAP)))
+  const itemsWidth = itemsPerRow * ITEM_SIZE + (itemsPerRow - 1) * ITEM_GAP
+  const horizontalPadding = Math.max(HORIZONTAL_PADDING, (gridWidth - itemsWidth) / 2)
+
+  const emitSelection = (type: 'select' | 'longPress', chapter: number) => {
+    DeviceEventEmitter.emit(BOOK_SELECTION_EVENT, {
+      type,
+      book,
+      chapter,
+    })
+  }
+
+  return (
+    <SheetScrollView
+      testID={`book-selector-chapter-grid-${book.Numero}`}
+      contentContainerStyle={{
+        alignSelf: 'center',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: ITEM_GAP,
+        maxWidth: gridWidth,
+        paddingBottom: insets.bottom + BOTTOM_SCROLL_CLEARANCE,
+        paddingHorizontal: horizontalPadding,
+        paddingTop: 16,
+      }}
+      showsVerticalScrollIndicator
+    >
+      {chapters.map(chapter => {
+        const isSelected = selectedChapter === chapter
+
+        return (
+          <TouchableBox
+            key={chapter}
+            testID={`book-selector-chapter-${book.Numero}-${chapter}`}
+            accessibilityLabel={`${t('Chapitre')} ${chapter}`}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isSelected }}
+            activeOpacity={0.7}
+            alignItems="center"
+            backgroundColor={isSelected ? 'lightGrey' : 'opacity5'}
+            borderRadius={6}
+            height={ITEM_SIZE}
+            justifyContent="center"
+            onLongPress={() => emitSelection('longPress', chapter)}
+            onPress={() => emitSelection('select', chapter)}
+            width={ITEM_SIZE}
+          >
+            <Box absoluteFill alignItems="center" justifyContent="center">
+              <Text bold={isSelected} color={isSelected ? 'primary' : 'default'} textAlign="center">
+                {chapter}
+              </Text>
+            </Box>
+          </TouchableBox>
+        )
+      })}
+    </SheetScrollView>
+  )
+}
+
+export default ChapterGrid

--- a/src/features/bible/BookSelectorSheet/__tests__/BookSelectorList-test.tsx
+++ b/src/features/bible/BookSelectorSheet/__tests__/BookSelectorList-test.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import books from '~assets/bible_versions/books-desc'
+import { BookSelectorList } from '../BookSelectorList'
+
+let mockSelectionMode: 'grid' | 'list' = 'list'
+
+jest.mock('jotai/react', () => ({
+  useAtomValue: () => mockSelectionMode,
+}))
+
+jest.mock('../atom', () => ({
+  bookSelectorSelectionModeAtom: Symbol('bookSelectorSelectionModeAtom'),
+}))
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 }),
+}))
+
+jest.mock('react-native', () => {
+  const React = jest.requireActual<typeof import('react')>('react')
+  return {
+    FlatList: React.forwardRef(
+      (
+        { children, ...props }: React.PropsWithChildren<Record<string, unknown>>,
+        _ref: React.ForwardedRef<unknown>
+      ) => React.createElement('FlatList', props, children)
+    ),
+    ScrollView: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('ScrollView', props, children),
+  }
+})
+
+jest.mock('../BookItem', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) =>
+    jest.requireActual<typeof import('react')>('react').createElement('BookItem', props),
+  itemHeight: 46,
+}))
+
+jest.mock('../BookShortItem', () => ({
+  BookShortItem: (props: Record<string, unknown>) =>
+    jest.requireActual<typeof import('react')>('react').createElement('BookShortItem', props),
+}))
+
+jest.mock('../ChapterGrid', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) =>
+    jest.requireActual<typeof import('react')>('react').createElement('ChapterGrid', props),
+}))
+
+const genesis = books.find(book => book.Numero === 1)!
+const psalms = books.find(book => book.Numero === 19)!
+const expandedBook = { get: jest.fn(), set: jest.fn() }
+const flatListRef = { current: null }
+const onBookSelect = jest.fn()
+const onGridBookSelect = jest.fn()
+
+const createRenderer = (element: React.ReactElement) => {
+  let renderer: ReactTestRenderer
+  const consoleError = jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
+    if (typeof message === 'string' && message.startsWith('react-test-renderer is deprecated')) {
+      return
+    }
+    console.warn(message, ...args)
+  })
+
+  try {
+    act(() => {
+      renderer = create(element)
+    })
+  } finally {
+    consoleError.mockRestore()
+  }
+
+  return renderer!
+}
+
+const renderList = (gridBook: (typeof books)[number] | null = null) => {
+  return createRenderer(
+    <BookSelectorList
+      data={[]}
+      initialScrollIndex={0}
+      expandedBook={expandedBook as never}
+      bookSelectorData={undefined}
+      flatListRef={flatListRef}
+      chaptersByBook={{ 1: [1, 3, 5], 19: [1, 2, 150] }}
+      renderedChapterBookNumbers={[1]}
+      onBookSelect={onBookSelect}
+      gridBook={gridBook}
+      onGridBookSelect={onGridBookSelect}
+    />
+  )
+}
+
+describe('BookSelectorList', () => {
+  beforeEach(() => {
+    ;(
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true
+    mockSelectionMode = 'list'
+    onBookSelect.mockClear()
+    onGridBookSelect.mockClear()
+  })
+
+  it('keeps list mode on the existing FlatList and BookItem path', () => {
+    const renderer = renderList(genesis)
+    const list = renderer.root.findByType('FlatList' as never)
+    const item = list.props.renderItem({ item: genesis })
+
+    expect(renderer.root.findAllByType('ChapterGrid' as never)).toHaveLength(0)
+    expect(item.props).toEqual(
+      expect.objectContaining({
+        book: genesis,
+        chapters: [1, 3, 5],
+        expandedBook,
+        onBookSelect,
+        shouldRenderChapters: true,
+      })
+    )
+    expect(list.props.getItemLayout(undefined, 2)).toEqual({ length: 46, offset: 92, index: 2 })
+    expect(list.props.keyExtractor(genesis)).toBe('1')
+  })
+
+  it('uses grid book presses to enter the chapter grid', () => {
+    mockSelectionMode = 'grid'
+    const renderer = createRenderer(
+      <BookSelectorList
+        data={[genesis, psalms]}
+        initialScrollIndex={0}
+        expandedBook={expandedBook as never}
+        bookSelectorData={undefined}
+        flatListRef={flatListRef}
+        chaptersByBook={{ 1: [1, 3, 5], 19: [1, 2, 150] }}
+        renderedChapterBookNumbers={[]}
+        onBookSelect={onBookSelect}
+        gridBook={null}
+        onGridBookSelect={onGridBookSelect}
+      />
+    )
+
+    const genesisItem = renderer.root.findAllByType('BookShortItem' as never)[0]
+    act(() => {
+      genesisItem.props.onChange(genesis)
+    })
+
+    expect(onGridBookSelect).toHaveBeenCalledWith(genesis)
+  })
+
+  it('passes partial coverage to the selected grid book', () => {
+    mockSelectionMode = 'grid'
+    const renderer = renderList(psalms)
+    const chapterGrid = renderer.root.findByType('ChapterGrid' as never)
+
+    expect(chapterGrid.props).toEqual(
+      expect.objectContaining({ book: psalms, chapters: [1, 2, 150] })
+    )
+  })
+})

--- a/src/features/bible/BookSelectorSheet/__tests__/ChapterGrid-test.tsx
+++ b/src/features/bible/BookSelectorSheet/__tests__/ChapterGrid-test.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import books from '~assets/bible_versions/books-desc'
+import { BOOK_SELECTION_EVENT } from '../constants'
+import ChapterGrid from '../ChapterGrid'
+
+const mockEmit = jest.fn()
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: {
+    emit: (...args: unknown[]) => mockEmit(...args),
+  },
+  useWindowDimensions: () => ({ height: 844, width: 390 }),
+}))
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 }),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('~common/sheet', () => ({
+  SheetScrollView: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    jest
+      .requireActual<typeof import('react')>('react')
+      .createElement('SheetScrollView', props, children),
+}))
+
+jest.mock('~common/ui/Box', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    jest.requireActual<typeof import('react')>('react').createElement('Box', props, children),
+  TouchableBox: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    jest
+      .requireActual<typeof import('react')>('react')
+      .createElement('TouchableBox', props, children),
+}))
+
+jest.mock('~common/ui/Text', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    jest.requireActual<typeof import('react')>('react').createElement('Text', props, children),
+}))
+
+const genesis = books.find(book => book.Numero === 1)!
+const psalms = books.find(book => book.Numero === 19)!
+
+type ChapterButtonProps = {
+  accessibilityLabel: string
+  accessibilityRole: string
+  onLongPress: () => void
+  onPress: () => void
+  testID: string
+}
+
+const renderGrid = (book: (typeof books)[number], chapters?: number[]) => {
+  const grid = ChapterGrid({ book, chapters, selectedChapter: 1 })
+  const chapterButtons = React.Children.toArray(
+    grid.props.children
+  ) as React.ReactElement<ChapterButtonProps>[]
+
+  return { chapterButtons, grid }
+}
+
+describe('ChapterGrid', () => {
+  beforeEach(() => {
+    mockEmit.mockClear()
+  })
+
+  it.each([
+    ['Genesis', genesis, 50],
+    ['Psalms', psalms, 150],
+  ])('renders every canonical chapter for %s and selects the final one', (_, book, lastChapter) => {
+    const { chapterButtons, grid } = renderGrid(book)
+
+    expect(grid.props.testID).toBe(`book-selector-chapter-grid-${book.Numero}`)
+    expect(grid.props.contentContainerStyle).toEqual(
+      expect.objectContaining({ flexDirection: 'row', flexWrap: 'wrap' })
+    )
+    expect(grid.props.showsVerticalScrollIndicator).toBe(true)
+    expect(chapterButtons).toHaveLength(lastChapter)
+
+    const finalChapter = chapterButtons.find(
+      chapter => chapter.props.testID === `book-selector-chapter-${book.Numero}-${lastChapter}`
+    )!
+
+    expect(finalChapter.props.accessibilityLabel).toBe(`Chapitre ${lastChapter}`)
+    expect(finalChapter.props.accessibilityRole).toBe('button')
+    finalChapter.props.onPress()
+
+    expect(mockEmit).toHaveBeenCalledWith(BOOK_SELECTION_EVENT, {
+      type: 'select',
+      book,
+      chapter: lastChapter,
+    })
+  })
+
+  it('preserves the existing long-press selection event', () => {
+    const { chapterButtons } = renderGrid(genesis)
+    const finalChapter = chapterButtons.at(-1)!
+
+    finalChapter.props.onLongPress()
+
+    expect(mockEmit).toHaveBeenCalledWith(BOOK_SELECTION_EVENT, {
+      type: 'longPress',
+      book: genesis,
+      chapter: 50,
+    })
+  })
+
+  it('uses partial-version coverage exactly as supplied', () => {
+    const { chapterButtons } = renderGrid(psalms, [1, 3, 7, 12])
+
+    expect(chapterButtons.map(chapter => chapter.props.testID)).toEqual([
+      'book-selector-chapter-19-1',
+      'book-selector-chapter-19-3',
+      'book-selector-chapter-19-7',
+      'book-selector-chapter-19-12',
+    ])
+  })
+
+  it('does not replace explicitly empty coverage with canonical chapters', () => {
+    const { chapterButtons } = renderGrid(psalms, [])
+
+    expect(chapterButtons).toHaveLength(0)
+  })
+})

--- a/src/features/bible/BookSelectorSheet/__tests__/bookSelectorSelection-test.ts
+++ b/src/features/bible/BookSelectorSheet/__tests__/bookSelectorSelection-test.ts
@@ -1,0 +1,50 @@
+import books from '~assets/bible_versions/books-desc'
+import { applyBookChapterSelection } from '../bookSelectorSelection'
+
+const genesis = books.find(book => book.Numero === 1)!
+const psalms = books.find(book => book.Numero === 19)!
+
+const createDependencies = () => ({
+  actions: {
+    setTempSelectedBook: jest.fn(),
+    setTempSelectedChapter: jest.fn(),
+    setTempSelectedVerse: jest.fn(),
+    validateTempSelected: jest.fn(),
+  },
+  dismissBookSelector: jest.fn(),
+  presentVerseSelector: jest.fn(),
+  setVerseSelectorBook: jest.fn(),
+  setVerseSelectorChapter: jest.fn(),
+})
+
+describe('applyBookChapterSelection', () => {
+  it('keeps without-verses navigation semantics for the final Genesis chapter', () => {
+    const dependencies = createDependencies()
+
+    applyBookChapterSelection({ book: genesis, chapter: 50 }, { hasVerses: false, ...dependencies })
+
+    expect(dependencies.actions.setTempSelectedBook).toHaveBeenCalledWith(genesis)
+    expect(dependencies.actions.setTempSelectedChapter).toHaveBeenCalledWith(50)
+    expect(dependencies.actions.setTempSelectedVerse).toHaveBeenCalledWith(1)
+    expect(dependencies.actions.validateTempSelected).toHaveBeenCalledTimes(1)
+    expect(dependencies.dismissBookSelector).toHaveBeenCalledTimes(1)
+    expect(dependencies.setVerseSelectorBook).not.toHaveBeenCalled()
+    expect(dependencies.setVerseSelectorChapter).not.toHaveBeenCalled()
+    expect(dependencies.presentVerseSelector).not.toHaveBeenCalled()
+  })
+
+  it('keeps with-verses navigation semantics for the final Psalm', () => {
+    const dependencies = createDependencies()
+
+    applyBookChapterSelection({ book: psalms, chapter: 150 }, { hasVerses: true, ...dependencies })
+
+    expect(dependencies.setVerseSelectorBook).toHaveBeenCalledWith(psalms)
+    expect(dependencies.setVerseSelectorChapter).toHaveBeenCalledWith(150)
+    expect(dependencies.actions.setTempSelectedBook).toHaveBeenCalledWith(psalms)
+    expect(dependencies.actions.setTempSelectedChapter).toHaveBeenCalledWith(150)
+    expect(dependencies.presentVerseSelector).toHaveBeenCalledTimes(1)
+    expect(dependencies.actions.setTempSelectedVerse).not.toHaveBeenCalled()
+    expect(dependencies.actions.validateTempSelected).not.toHaveBeenCalled()
+    expect(dependencies.dismissBookSelector).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/bible/BookSelectorSheet/bookSelectorSelection.ts
+++ b/src/features/bible/BookSelectorSheet/bookSelectorSelection.ts
@@ -1,0 +1,48 @@
+import type { Book } from '~assets/bible_versions/books-desc'
+import type { BibleTabActions } from 'src/state/tabs'
+
+type ChapterSelectionActions = Pick<
+  BibleTabActions,
+  'setTempSelectedBook' | 'setTempSelectedChapter' | 'setTempSelectedVerse' | 'validateTempSelected'
+>
+
+interface ChapterSelection {
+  book: Book
+  chapter: number
+}
+
+interface ChapterSelectionDependencies {
+  actions: ChapterSelectionActions
+  hasVerses: boolean
+  dismissBookSelector: () => void
+  presentVerseSelector: () => void
+  setVerseSelectorBook: (book: Book) => void
+  setVerseSelectorChapter: (chapter: number) => void
+}
+
+export const applyBookChapterSelection = (
+  { book, chapter }: ChapterSelection,
+  {
+    actions,
+    hasVerses,
+    dismissBookSelector,
+    presentVerseSelector,
+    setVerseSelectorBook,
+    setVerseSelectorChapter,
+  }: ChapterSelectionDependencies
+) => {
+  if (hasVerses) {
+    setVerseSelectorBook(book)
+    setVerseSelectorChapter(chapter)
+    actions.setTempSelectedBook(book)
+    actions.setTempSelectedChapter(chapter)
+    presentVerseSelector()
+    return
+  }
+
+  actions.setTempSelectedBook(book)
+  actions.setTempSelectedChapter(chapter)
+  actions.setTempSelectedVerse(1)
+  actions.validateTempSelected()
+  dismissBookSelector()
+}

--- a/src/features/timeline/timeline.hooks.ts
+++ b/src/features/timeline/timeline.hooks.ts
@@ -42,12 +42,7 @@ export const useTimeline = ({
   const year = useDerivedValue(() => {
     const currentTimelineX = offset + lineX.get() - x.get()
     const currentYearNb = Math.round(
-      interpolate(
-        currentTimelineX,
-        [0, scrollViewWidth],
-        [startYear, endYear],
-        Extrapolation.CLAMP
-      )
+      interpolate(currentTimelineX, [0, scrollViewWidth], [startYear, endYear], Extrapolation.CLAMP)
     )
 
     if (currentYearNb >= yearNow) {


### PR DESCRIPTION
## Summary

- Closes #246
- Grid mode chapter picker hides later chapters and obscures scrolling

## Agent Change Summary

# Change summary

- Replaced the grid-mode native chapter action menu with an in-sheet, scrollable wrapped chapter grid.
- Added a clear book-to-chapter drill-down with a back action while leaving list mode’s existing inline expansion intact.
- Preserved without-verses selection, with-verses handoff, long-press event behavior, and version-specific chapter coverage.
- Added focused regression tests for Genesis 50, Psalm 150, partial/empty coverage, both verse-navigation modes, and the unchanged list branch.
- Added a declaration-only platform shim required for clean TypeScript validation of the existing platform-specific `MenuView` module.
- Regenerated the repository quality and architecture reports and applied the formatting gate’s existing timeline-hook correction.

## Scope

- Issue/request: https://github.com/smontlouis/bible-strong/issues/246
- Branch: `codex/issue-246-grid-mode-chapter-picker-hides-later-chapters-and-obscures-s`
- Base: `master`
- Proposed commit: `fix(bible): make grid chapters fully reachable`
- Owned files or modules:
- `docs/agents/architecture-lint.md`
- `docs/agents/quality-score.md`
- `src/common/ui/MenuView.d.ts`
- `src/features/bible/BookSelectorSheet/BookSelectorList.tsx`
- `src/features/bible/BookSelectorSheet/BookSelectorSheet.tsx`
- `src/features/bible/BookSelectorSheet/BookShortItem.tsx`
- `src/features/bible/BookSelectorSheet/ChapterGrid.tsx`
- `src/features/bible/BookSelectorSheet/__tests__/BookSelectorList-test.tsx`
- `src/features/bible/BookSelectorSheet/__tests__/ChapterGrid-test.tsx`
- `src/features/bible/BookSelectorSheet/__tests__/bookSelectorSelection-test.ts`
- `src/features/bible/BookSelectorSheet/bookSelectorSelection.ts`
- `src/features/timeline/timeline.hooks.ts`
- Sensitive areas touched: none identified by this wrapper

## Validation

- [ ] `yarn typecheck`
- [ ] `yarn lint`
- [ ] `yarn test`
- [ ] `yarn format:check`
- [ ] i18n extraction run or not needed

## Smoke Status

- [ ] Not needed for this change
- [x] Manual smoke run using `docs/agents/smoke-tests.md`
- [ ] Deferred, with reason: see mobile validation below

## Mobile Validation

- [ ] Not needed: non-runtime or non-user-facing change
- [x] Passed via Argent or equivalent simulator/device flow

Smoke paths:

- See agent validation report below.

Evidence:

- `.scratch/issues/246/mobile-validation.md`
- `.scratch/issues/246/codex-final.md`
- `.scratch/issues/246/commit-message.txt`
- `.scratch/issues/246/change-summary.md`
- `.scratch/issues/246/pr-notes.md`
- `.scratch/issues/246/evidence/01-genesis-chapter-grid.png`
- `.scratch/issues/246/evidence/02-genesis-50-selected.png`
- `.scratch/issues/246/evidence/03-psalms-chapter-grid-through-150.png`
- `.scratch/issues/246/evidence/03b-psalms-scroll-indicator.png`
- `.scratch/issues/246/evidence/04-psalm-150-selected.png`
- `.scratch/issues/246/evidence/05-with-verses-picker.png`
- `.scratch/issues/246/evidence/06-list-mode.png`
- `.scratch/issues/246/evidence/07-list-mode-genesis-expanded.png`

## PR Notes

# PR notes

## Reviewer focus

- Grid mode now drills into `ChapterGrid` inside the existing book selector sheet instead of creating a long native `MenuView` action list.
- `availableChapters ?? canonicalChapters` is intentional: an explicit partial or empty coverage array must not be expanded.
- The shared selection helper preserves the prior side effects for both “Sans versets” and “Avec versets”.
- The list-mode `FlatList` / `BookItem` path is unchanged and has a regression test.

## Validation

- TypeScript, ESLint, Jest (48 suites / 434 tests), Prettier, quality score, and architecture checks pass locally.
- iOS runtime validation passed on an iPhone 17 Pro simulator running iOS 26.5.
- Genesis 50 and Psalm 150 were both reached and selected.
- The existing verse picker and list-mode expansion were exercised.
- Android was not run; both platforms now use the same platform-neutral React Native grid rather than a native chapter menu.

## Visual evidence

- `evidence/01-genesis-chapter-grid.png`
- `evidence/02-genesis-50-selected.png`
- `evidence/03-psalms-chapter-grid-through-150.png`
- `evidence/03b-psalms-scroll-indicator.png`
- `evidence/04-psalm-150-selected.png`
- `evidence

...

## Agent Validation Report

Implemented issue #246. Grid mode now uses a scrollable in-sheet chapter grid, with Genesis 50 and Psalm 150 reachable and selectable.

- **Branch:** `codex/issue-246-grid-mode-chapter-picker-hides-later-chapters-and-obscures-s`
- **Core files:** [ChapterGrid.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/BookSelectorSheet/ChapterGrid.tsx), [BookSelectorSheet.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/BookSelectorSheet/BookSelectorSheet.tsx), [BookSelectorList.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/BookSelectorSheet/BookSelectorList.tsx), [BookShortItem.tsx](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/BookSelectorSheet/BookShortItem.tsx), [bookSelectorSelection.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/features/bible/BookSelectorSheet/bookSelectorSelection.ts)
- **Tests:** three new suites covering final chapters, partial/empty coverage, long press, verse modes, and unchanged list mode.
- **Prerequisites/generated files:** type-only [MenuView.d.ts](/Users/stephane/Projects/bible-strong/bible-strong-app/src/common/ui/MenuView.d.ts), Prettier-only timeline correction, regenerated quality and architecture reports.

Validation passed:

- `yarn typecheck`
- `yarn lint` — 0 errors, 33 existing warnings
- `yarn test --watchman=false` — 48 suites, 434 tests
- `yarn format:check`
- `yarn agents:quality:check`
- `yarn agents:architecture:check` — passed with 491 warnings
- `git diff --check`

**Mobile runtime status: `passed`.** Verified on iPhone 17 Pro / iOS 26.5: Genesis 50, Psalm 150, scrolling affordance, with/without-verses behavior, and list-mode expansion. Android runtime was not exercised; both platforms now use th

...

## Diff Stat

```text
docs/agents/architecture-lint.md                   | 499 +++++++++++----------
 docs/agents/quality-score.md                       |  20 +-
 src/common/ui/MenuView.d.ts                        |   6 +
 .../bible/BookSelectorSheet/BookSelectorList.tsx   |  22 +-
 .../bible/BookSelectorSheet/BookSelectorSheet.tsx  |  46 +-
 .../bible/BookSelectorSheet/BookShortItem.tsx      |  60 +--
 .../bible/BookSelectorSheet/ChapterGrid.tsx        |  89 ++++
 .../__tests__/BookSelectorList-test.tsx            | 159 +++++++
 .../__tests__/ChapterGrid-test.tsx                 | 128 ++++++
 .../__tests__/bookSelectorSelection-test.ts        |  50 +++
 .../BookSelectorSheet/bookSelectorSelection.ts     |  48 ++
 src/features/timeline/timeline.hooks.ts            |   7 +-
 12 files changed, 813 insertions(+), 321 deletions(-)
```

## Sensitive-Area Notes

Use `docs/agents/sensitive-areas.md` before changing auth, sync, migrations, backup/import/export, build identity, native config, external services, or user-owned data.

- Environment used: local
- Account-backed validation: not recorded by wrapper
- Production/staging validation: not run
- Rollback or mitigation notes: standard revert
