### PR TITLE
fix(studies): require login before adding to a study

### DIFF
--- a/i18n/locales/en/translation.json
+++ b/i18n/locales/en/translation.json
@@ -705,6 +705,7 @@
   "study.verseAdded": "Verse added to study",
   "study.openStudy": "Open",
   "study.noStudies": "No studies found",
+  "study.loginRequired": "Sign in to create a study",
   "common.goTo": "Go to tab",
   "common.chooseCompareVersions": "Choose versions to compare",
   "premium.earlyAccess": "Early access",

--- a/i18n/locales/fr/translation.json
+++ b/i18n/locales/fr/translation.json
@@ -706,6 +706,7 @@
   "study.verseAdded": "Verset ajouté à l'étude",
   "study.openStudy": "Ouvrir",
   "study.noStudies": "Aucune étude trouvée",
+  "study.loginRequired": "Connectez-vous pour créer une étude",
   "common.goTo": "Aller à l'onglet",
   "common.chooseCompareVersions": "Choisir les versions à comparer",
   "premium.earlyAccess": "Accès anticipé",

--- a/src/features/bible/BibleViewer.tsx
+++ b/src/features/bible/BibleViewer.tsx
@@ -29,6 +29,7 @@ import getVersesContent from '~helpers/getVersesContent'
 import { useQuery } from '~helpers/react-query-lite'
 import useLanguage from '~helpers/useLanguage'
 import { useSheet } from '~helpers/useSheet'
+import { toast } from '~helpers/toast'
 import verseToReference from '~helpers/verseToReference'
 import { usePushRouteOnce } from '~navigation/usePushRouteOnce'
 import { RootState } from '~redux/modules/reducer'
@@ -52,6 +53,7 @@ import {
   selectNotes,
 } from '~redux/selectors/bible'
 import { makeSelectBookmarksInChapter } from '~redux/selectors/bookmarks'
+import { selectIsLogged } from '~redux/selectors/user'
 import type { AppDispatch } from '~redux/store'
 import { bibleDataRefreshSignalAtom, historyAtom } from '../../state/app'
 import {
@@ -199,6 +201,7 @@ const BibleViewer = ({
 
   const lang = useLanguage()
   const dispatch = useDispatch<AppDispatch>()
+  const isLogged = useSelector(selectIsLogged)
   const [pericope, setPericope] = useState<Pericope | null>(null)
   const [resourceType, onChangeResourceType] = useState<BibleResource>('strong')
   const [resourceModalSelection, setResourceModalSelection] = useState<{
@@ -598,6 +601,11 @@ const BibleViewer = ({
 
   // Add to study handlers
   const handleOpenAddToStudy = () => {
+    if (!isLogged) {
+      toast.info(t('study.loginRequired'))
+      return
+    }
+
     addToStudyModal.open()
   }
 


### PR DESCRIPTION
## Summary

- prevent signed-out users from opening the Add to study flow
- show a localized informational toast asking them to sign in
- preserve the existing behavior for authenticated users

## Why

Guests could indirectly create a Study through the selected-verses flow even though Study creation requires an authenticated account.

Closes #270

## Testing

- `yarn eslint src/features/bible/BibleViewer.tsx`
- `yarn typecheck`
- `yarn test --runInBand` — 57 suites, 469 tests passed
- React Doctor — no findings in the changed files