### PR TITLE
fix(migrations): preserve legacy resources until migration completes

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -58,7 +58,6 @@ import { setI18n } from '../i18n'
 import { PlaybackService } from '../playbackService'
 import { PortalProvider } from 'react-native-teleport'
 import { downloadManager } from '~helpers/downloadManager'
-import { cleanupLegacyBibleResources } from '~helpers/legacyBibleUpgrade'
 
 // Register background event handler for Notifee
 // This prevents ANR when notifications fire while app is in background
@@ -129,11 +128,6 @@ const useAppLoad = () => {
 
   useEffect(() => {
     ;(async () => {
-      try {
-        await cleanupLegacyBibleResources()
-      } catch (error) {
-        appLogger.error('startup', 'legacy_bible_cleanup.failed', { error })
-      }
       try {
         await downloadManager.restore()
       } catch (error) {

--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -299,9 +299,9 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:162 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:169 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadBibleToSqlite.ts:175 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadManager.ts:223 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadManager.ts:359 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/helpers/downloadManager.ts:436 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadManager.ts:225 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadManager.ts:361 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/helpers/downloadManager.ts:442 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/helpers/downloadWithCdnFallback.ts:70 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `helpers-feature-boundary` src/helpers/firestoreMigration.ts:27 - Shared helpers must not depend on feature modules.
 - WARNING `raw-console` src/helpers/firestoreMigration.ts:59 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/src/helpers/__tests__/legacyBibleUpgrade-test.ts
+++ b/src/helpers/__tests__/legacyBibleUpgrade-test.ts
@@ -21,6 +21,7 @@ import {
   migrateLegacyBibleTabData,
   migrateLegacyDownloadQueue,
   migrateLegacyParallelVersions,
+  preserveLegacyDownloadsInQueue,
 } from '../legacyBibleVersionMigration'
 
 const mockDeleteAsync = jest.mocked(FileSystem.deleteAsync)
@@ -87,9 +88,46 @@ describe('legacyBibleUpgrade', () => {
           { item: { id: 'bible:LSGS', versionId: 'LSGS' }, status: 'queued' },
           { item: { id: 'bible:KJV', versionId: 'KJV' }, status: 'queued' },
           { item: { id: 'bible:INT_EN', versionId: 'INT_EN' }, status: 'failed' },
+          {
+            item: { id: 'database:STRONG:fr', databaseId: 'STRONG', lang: 'fr' },
+            status: 'queued',
+          },
+          {
+            item: {
+              id: 'database:INTERLINEAIRE:en',
+              databaseId: 'INTERLINEAIRE',
+              lang: 'en',
+            },
+            status: 'failed',
+          },
         ])
       )
     ).toBe(JSON.stringify([{ item: { id: 'bible:KJV', versionId: 'KJV' }, status: 'queued' }]))
+  })
+
+  it('preserves obsolete downloads when the active download queue is persisted', () => {
+    const existingQueue = JSON.stringify([
+      { item: { id: 'bible:LSGS', versionId: 'LSGS' }, status: 'queued' },
+      {
+        item: { id: 'database:STRONG:fr', databaseId: 'STRONG', lang: 'fr' },
+        status: 'failed',
+      },
+      { item: { id: 'bible:KJV', versionId: 'KJV' }, status: 'queued' },
+    ])
+    const activeQueue = JSON.stringify([
+      { item: { id: 'bible:BHG', versionId: 'BHG' }, status: 'failed' },
+    ])
+
+    expect(preserveLegacyDownloadsInQueue(existingQueue, activeQueue)).toBe(
+      JSON.stringify([
+        { item: { id: 'bible:LSGS', versionId: 'LSGS' }, status: 'queued' },
+        {
+          item: { id: 'database:STRONG:fr', databaseId: 'STRONG', lang: 'fr' },
+          status: 'failed',
+        },
+        { item: { id: 'bible:BHG', versionId: 'BHG' }, status: 'failed' },
+      ])
+    )
   })
 
   it('deletes obsolete Bible files and both legacy interlinear databases once', async () => {
@@ -109,7 +147,10 @@ describe('legacyBibleUpgrade', () => {
       remove: jest.fn((key: string) => values.delete(key)),
     }
 
-    await cleanupLegacyBibleResources({ storage: backend })
+    await cleanupLegacyBibleResources({
+      terminalOutcome: 'completed',
+      storage: backend,
+    })
 
     const deletedPaths = mockDeleteAsync.mock.calls.map(([path]) => path)
     expect(deletedPaths).toEqual(
@@ -133,8 +174,27 @@ describe('legacyBibleUpgrade', () => {
     expect(values.get('hasCleanedLegacyBibleResourcesV1')).toBe(true)
 
     mockDeleteAsync.mockClear()
-    await cleanupLegacyBibleResources({ storage: backend })
+    await cleanupLegacyBibleResources({
+      terminalOutcome: 'completed',
+      storage: backend,
+    })
     expect(mockDeleteAsync).not.toHaveBeenCalled()
+  })
+
+  it('preserves obsolete resources until the migration reaches a terminal outcome', async () => {
+    const backend = {
+      getBoolean: jest.fn(() => undefined),
+      getString: jest.fn(() => undefined),
+      set: jest.fn(),
+      remove: jest.fn(),
+    }
+
+    const result = await cleanupLegacyBibleResources({ storage: backend })
+
+    expect(result).toBe('awaiting-terminal-outcome')
+    expect(mockDeleteAsync).not.toHaveBeenCalled()
+    expect(backend.remove).not.toHaveBeenCalled()
+    expect(backend.set).not.toHaveBeenCalled()
   })
 
   it('does not mark cleanup complete when a deletion fails', async () => {
@@ -146,7 +206,12 @@ describe('legacyBibleUpgrade', () => {
       remove: jest.fn(),
     }
 
-    await expect(cleanupLegacyBibleResources({ storage: backend })).rejects.toThrow('disk failure')
+    await expect(
+      cleanupLegacyBibleResources({
+        terminalOutcome: 'completed',
+        storage: backend,
+      })
+    ).rejects.toThrow('disk failure')
     expect(backend.set).not.toHaveBeenCalledWith('hasCleanedLegacyBibleResourcesV1', true)
   })
 })

--- a/src/helpers/downloadManager.ts
+++ b/src/helpers/downloadManager.ts
@@ -32,7 +32,10 @@ import { getStrongBibleSidecarPath } from '~helpers/strongBibleSidecar'
 import { getInterlinearSidecarPath } from '~helpers/interlinearBibleSidecar'
 import { getStrongLexiconModulePath } from '~helpers/strongLexiconModules'
 import { isAtomicResourceFileRollbackError } from '~helpers/atomicResourceFile'
-import { migrateLegacyDownloadQueue } from '~helpers/legacyBibleVersionMigration'
+import {
+  migrateLegacyDownloadQueue,
+  preserveLegacyDownloadsInQueue,
+} from '~helpers/legacyBibleVersionMigration'
 
 const PERSIST_KEY = 'downloadQueue'
 const MAX_RETRIES = 2
@@ -191,7 +194,6 @@ class DownloadManager {
       const raw = storage.getString(PERSIST_KEY)
       if (!raw) return
       const migratedRaw = migrateLegacyDownloadQueue(raw)
-      if (migratedRaw !== raw) storage.set(PERSIST_KEY, migratedRaw)
 
       const persisted: DownloadItemState[] = JSON.parse(migratedRaw)
       const states = new Map(this.jotaiStore.get(downloadItemStatesAtom))
@@ -431,7 +433,11 @@ class DownloadManager {
         }
         return []
       })
-      storage.set(PERSIST_KEY, JSON.stringify(toPersist))
+      const activeQueue = JSON.stringify(toPersist)
+      storage.set(
+        PERSIST_KEY,
+        preserveLegacyDownloadsInQueue(storage.getString(PERSIST_KEY), activeQueue)
+      )
     } catch (e) {
       console.error('[DownloadManager] Persist failed:', e)
     }

--- a/src/helpers/legacyBibleUpgrade.ts
+++ b/src/helpers/legacyBibleUpgrade.ts
@@ -12,6 +12,13 @@ type MigrationStorage = {
   remove(key: string): void
 }
 
+export type LegacyBibleMigrationTerminalOutcome = 'completed' | 'abandoned-after-failure'
+
+export type LegacyBibleCleanupResult =
+  | 'awaiting-terminal-outcome'
+  | 'cleanup-already-completed'
+  | 'cleanup-completed'
+
 const withTemporaryFiles = (path: string): string[] => [path, `${path}.download`, `${path}.backup`]
 
 const withSqliteCompanionFiles = (path: string): string[] => [
@@ -59,13 +66,16 @@ const LEGACY_PUBLICATION_KEYS = [
 ]
 
 export const cleanupLegacyBibleResources = async ({
+  terminalOutcome,
   storage: backend = storage,
   deleteFile = (path: string) => FileSystem.deleteAsync(path, { idempotent: true }),
 }: {
+  terminalOutcome?: LegacyBibleMigrationTerminalOutcome
   storage?: MigrationStorage
   deleteFile?: (path: string) => Promise<void>
-} = {}): Promise<void> => {
-  if (backend.getBoolean(CLEANUP_KEY)) return
+} = {}): Promise<LegacyBibleCleanupResult> => {
+  if (!terminalOutcome) return 'awaiting-terminal-outcome'
+  if (backend.getBoolean(CLEANUP_KEY)) return 'cleanup-already-completed'
 
   await Promise.all(getLegacyBibleResourcePaths().map(deleteFile))
 
@@ -77,4 +87,5 @@ export const cleanupLegacyBibleResources = async ({
     backend.remove(key)
   }
   backend.set(CLEANUP_KEY, true)
+  return 'cleanup-completed'
 }

--- a/src/helpers/legacyBibleVersionMigration.ts
+++ b/src/helpers/legacyBibleVersionMigration.ts
@@ -1,4 +1,5 @@
 const LEGACY_BIBLE_IDS = new Set(['LSGS', 'KJVS', 'INT', 'INT_EN'])
+const LEGACY_DATABASE_IDS = new Set(['STRONG', 'INTERLINEAIRE'])
 
 type PersistedBibleTabData = {
   selectedVersion: string
@@ -88,8 +89,12 @@ const isLegacyDownload = (value: unknown): boolean => {
   if (!item || typeof item !== 'object') return false
   const versionId = 'versionId' in item && typeof item.versionId === 'string' ? item.versionId : ''
   if (isLegacyBibleVersionId(versionId)) return true
+  const databaseId =
+    'databaseId' in item && typeof item.databaseId === 'string' ? item.databaseId : ''
+  if (LEGACY_DATABASE_IDS.has(databaseId)) return true
   const id = 'id' in item && typeof item.id === 'string' ? item.id : ''
-  return [...LEGACY_BIBLE_IDS].some(legacyId => id.split(':').includes(legacyId))
+  const idParts = id.split(':')
+  return [...LEGACY_BIBLE_IDS, ...LEGACY_DATABASE_IDS].some(legacyId => idParts.includes(legacyId))
 }
 
 export const migrateLegacyDownloadQueue = (raw: string): string => {
@@ -99,5 +104,23 @@ export const migrateLegacyDownloadQueue = (raw: string): string => {
     return JSON.stringify(queue.filter(item => !isLegacyDownload(item)))
   } catch {
     return raw
+  }
+}
+
+export const preserveLegacyDownloadsInQueue = (
+  persistedQueue: string | undefined,
+  activeQueue: string
+): string => {
+  try {
+    const persisted = persistedQueue ? (JSON.parse(persistedQueue) as unknown) : []
+    const active = JSON.parse(activeQueue) as unknown
+    if (!Array.isArray(persisted) || !Array.isArray(active)) return activeQueue
+
+    return JSON.stringify([
+      ...persisted.filter(isLegacyDownload),
+      ...active.filter(item => !isLegacyDownload(item)),
+    ])
+  } catch {
+    return activeQueue
   }
 }


### PR DESCRIPTION
## Summary

- stop unconditional deletion of legacy Bible and Strong resources during startup
- require an explicit terminal migration outcome before cleanup can run
- keep legacy download-queue entries persisted as migration evidence while excluding them from normal queue restoration and execution
- retain the existing allowlisted cleanup behavior for a future successful or explicitly abandoned migration

## Validation

- `yarn test src/helpers/__tests__/legacyBibleUpgrade-test.ts --runInBand --watchman=false`
- `yarn typecheck`
- focused ESLint and Prettier checks for changed files
- `yarn agents:architecture:check`
- iOS 26.5 simulator startup smoke with the development client

## Runtime evidence

The development client launched into the Bible reading surface without an ErrorBoundary fallback or startup loop. `serve-sim` connected to the simulator framebuffer but its encoder failed on this simulator runtime, so the final assertion used a direct simulator screenshot.

Part of #274. This PR deliberately does not close the issue; it establishes the destructive-safety prerequisite for the migration orchestrator.
