### PR TITLE
feat(migrations): replace legacy Bible resources

### DIFF
--- a/src/helpers/__tests__/legacyBibleUpgrade-test.ts
+++ b/src/helpers/__tests__/legacyBibleUpgrade-test.ts
@@ -37,14 +37,26 @@ describe('legacyBibleUpgrade', () => {
       'LSGS',
       {
         selectedVersion: 'LSG',
-        strongMode: 'visible',
+        strongMode: 'hidden',
+        pendingModeAcquisition: {
+          kind: 'strong',
+          versionId: 'LSG',
+          mode: 'visible',
+          planIds: ['bible-strong:LSG'],
+        },
       },
     ],
     [
       'KJVS',
       {
         selectedVersion: 'KJV',
-        strongMode: 'visible',
+        strongMode: 'hidden',
+        pendingModeAcquisition: {
+          kind: 'strong',
+          versionId: 'KJV',
+          mode: 'visible',
+          planIds: ['bible-strong:KJV'],
+        },
       },
     ],
     [
@@ -53,6 +65,12 @@ describe('legacyBibleUpgrade', () => {
         selectedVersion: 'BHG',
         interlinearMode: 'hidden',
         interlinearLocale: 'fr',
+        pendingModeAcquisition: {
+          kind: 'interlinear',
+          mode: 'interlinear',
+          locale: 'fr',
+          planIds: ['bible-interlinear:BHG:fr'],
+        },
       },
     ],
     [
@@ -61,6 +79,12 @@ describe('legacyBibleUpgrade', () => {
         selectedVersion: 'BHG',
         interlinearMode: 'hidden',
         interlinearLocale: 'en',
+        pendingModeAcquisition: {
+          kind: 'interlinear',
+          mode: 'interlinear',
+          locale: 'en',
+          planIds: ['bible-interlinear:BHG:en'],
+        },
       },
     ],
   ])('migrates a persisted %s Bible tab', (selectedVersion, expected) => {
@@ -79,6 +103,45 @@ describe('legacyBibleUpgrade', () => {
       'BHG',
       'KJV',
     ])
+  })
+
+  it('keeps the capability implied by a removed Bible instead of a stale pending plan', () => {
+    expect(
+      migrateLegacyBibleTabData({
+        selectedVersion: 'INT',
+        pendingModeAcquisition: {
+          kind: 'strong',
+          versionId: 'LSGS',
+          planIds: ['bible:LSGS', 'bible-strong:LSGS'],
+        },
+      })
+    ).toMatchObject({
+      selectedVersion: 'BHG',
+      pendingModeAcquisition: {
+        kind: 'interlinear',
+        locale: 'fr',
+        planIds: ['bible-interlinear:BHG:fr'],
+      },
+    })
+  })
+
+  it('regenerates a pending Strong plan that references a removed Bible', () => {
+    expect(
+      migrateLegacyBibleTabData({
+        selectedVersion: 'LSG',
+        pendingModeAcquisition: {
+          kind: 'strong',
+          versionId: 'LSGS',
+          planIds: ['bible:LSGS', 'bible-strong:LSGS'],
+        },
+      })
+    ).toMatchObject({
+      pendingModeAcquisition: {
+        kind: 'strong',
+        versionId: 'LSG',
+        planIds: ['bible-strong:LSG'],
+      },
+    })
   })
 
   it('removes obsolete downloads from the persisted queue', () => {

--- a/src/helpers/__tests__/managedResourceInstallation-test.ts
+++ b/src/helpers/__tests__/managedResourceInstallation-test.ts
@@ -1,0 +1,149 @@
+/* eslint-disable import/first */
+
+import type { DownloadItem } from '~state/downloadQueue'
+
+const mockInstallResourceDatabaseItem = jest.fn()
+const mockSynchronizeOptionalBibleResources = jest.fn()
+const mockBeginResourceInstallation = jest.fn()
+const mockCommitResourceInstallation = jest.fn()
+const mockCompleteResourceInstallation = jest.fn()
+const mockRollbackResourceInstallation = jest.fn()
+const mockInvalidateOfflineCopyQueries = jest.fn()
+const mockIsAtomicResourceFileRollbackError = jest.fn()
+
+jest.mock('../resourceDatabaseInstallation', () => ({
+  installResourceDatabaseItem: (...args: unknown[]) => mockInstallResourceDatabaseItem(...args),
+  synchronizeOptionalBibleResources: (...args: unknown[]) =>
+    mockSynchronizeOptionalBibleResources(...args),
+}))
+
+jest.mock('../resourceInstallationJournal', () => ({
+  beginResourceInstallation: (...args: unknown[]) => mockBeginResourceInstallation(...args),
+  commitResourceInstallation: (...args: unknown[]) => mockCommitResourceInstallation(...args),
+  completeResourceInstallation: (...args: unknown[]) => mockCompleteResourceInstallation(...args),
+  rollbackResourceInstallation: (...args: unknown[]) => mockRollbackResourceInstallation(...args),
+}))
+
+jest.mock('../offlineCopyQueries', () => ({
+  invalidateOfflineCopyQueries: (...args: unknown[]) => mockInvalidateOfflineCopyQueries(...args),
+}))
+
+jest.mock('../offlineCopy', () => ({
+  getDownloadItemIdentity: (item: { databaseId: string; lang: string }) => ({
+    kind: 'database',
+    databaseId: item.databaseId,
+    language: item.lang,
+  }),
+}))
+
+jest.mock('../atomicResourceFile', () => ({
+  isAtomicResourceFileRollbackError: (...args: unknown[]) =>
+    mockIsAtomicResourceFileRollbackError(...args),
+}))
+
+jest.mock('../strongBibleSidecar', () => ({
+  getStrongBibleSidecarPath: (versionId: string) => `/strong/${versionId}.sqlite`,
+}))
+
+jest.mock('../interlinearBibleSidecar', () => ({
+  getInterlinearSidecarPath: (language: string) => `/interlinear/${language}.sqlite`,
+}))
+
+jest.mock('../strongLexiconModules', () => ({
+  getStrongLexiconModulePath: (moduleId: string) => `/strong-lexicon/${moduleId}.sqlite`,
+}))
+
+import { installManagedResource } from '../managedResourceInstallation'
+
+const databaseItem: DownloadItem = {
+  id: 'database:NAVE:fr',
+  type: 'database',
+  name: 'Nave',
+  databaseId: 'NAVE',
+  lang: 'fr',
+  url: 'https://example.com/nave.sqlite',
+  destinationPath: '/documents/SQLite/fr/nave.sqlite',
+  estimatedSize: 10,
+  addedAt: 1,
+  retryCount: 0,
+}
+
+const callbacks = {
+  onDownloadProgress: jest.fn(),
+  onInsertProgress: jest.fn(),
+  onStatusInserting: jest.fn(),
+  onResumable: jest.fn(),
+  isCancelled: jest.fn(() => false),
+}
+
+const installedResource = {
+  result: { uri: '/resource.sqlite.download', status: 200, headers: {} },
+  publication: { generation: '2', size: 10 },
+  sourceUrl: 'https://example.com/nave.sqlite',
+}
+
+describe('installManagedResource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockBeginResourceInstallation.mockReturnValue({ id: 'journal' })
+    mockIsAtomicResourceFileRollbackError.mockReturnValue(false)
+  })
+
+  it('publishes, completes and invalidates a resource through the shared atomic lifecycle', async () => {
+    mockInstallResourceDatabaseItem.mockImplementation(async (_item, options) => {
+      options.installationLifecycle.prepare(installedResource)
+      options.installationLifecycle.commit()
+    })
+
+    await installManagedResource(databaseItem, callbacks)
+
+    expect(mockBeginResourceInstallation).toHaveBeenCalledWith(databaseItem.id, installedResource, {
+      kind: 'file',
+      destinationPath: databaseItem.destinationPath,
+    })
+    expect(mockCommitResourceInstallation).toHaveBeenCalledWith({ id: 'journal' })
+    expect(mockCompleteResourceInstallation).toHaveBeenCalledWith({ id: 'journal' })
+    expect(mockRollbackResourceInstallation).not.toHaveBeenCalled()
+    expect(mockInvalidateOfflineCopyQueries).toHaveBeenCalledWith({
+      kind: 'database',
+      databaseId: 'NAVE',
+      language: 'fr',
+    })
+  })
+
+  it('rolls back a prepared resource when installation fails before completion', async () => {
+    mockInstallResourceDatabaseItem.mockImplementation(async (_item, options) => {
+      options.installationLifecycle.prepare(installedResource)
+      throw new Error('download-failed')
+    })
+
+    await expect(installManagedResource(databaseItem, callbacks)).rejects.toThrow('download-failed')
+
+    expect(mockRollbackResourceInstallation).toHaveBeenCalledWith({ id: 'journal' })
+    expect(mockInvalidateOfflineCopyQueries).not.toHaveBeenCalled()
+  })
+
+  it('does not double-rollback an atomic installer failure that already restored the resource', async () => {
+    const error = new Error('atomic-rollback')
+    mockIsAtomicResourceFileRollbackError.mockImplementation(value => value === error)
+    mockInstallResourceDatabaseItem.mockImplementation(async (_item, options) => {
+      options.installationLifecycle.prepare(installedResource)
+      throw error
+    })
+
+    await expect(installManagedResource(databaseItem, callbacks)).rejects.toBe(error)
+
+    expect(mockRollbackResourceInstallation).not.toHaveBeenCalled()
+  })
+
+  it('rejects an installer that returns without committing publication metadata', async () => {
+    mockInstallResourceDatabaseItem.mockImplementation(async (_item, options) => {
+      options.installationLifecycle.prepare(installedResource)
+    })
+
+    await expect(installManagedResource(databaseItem, callbacks)).rejects.toThrow(
+      `RESOURCE_PUBLICATION_NOT_COMMITTED:${databaseItem.id}`
+    )
+    expect(mockRollbackResourceInstallation).toHaveBeenCalledWith({ id: 'journal' })
+  })
+})

--- a/src/helpers/downloadManager.ts
+++ b/src/helpers/downloadManager.ts
@@ -12,26 +12,9 @@ import {
 } from '~state/downloadQueue'
 import { installedVersionsSignalAtom, bibleDataRefreshSignalAtom } from '~state/app'
 import { storage } from '~helpers/storage'
-import {
-  installResourceDatabaseItem,
-  synchronizeOptionalBibleResources,
-} from '~helpers/resourceDatabaseInstallation'
 import { getDownloadQueueDecision } from '~helpers/downloadQueueScheduling'
-import { getDownloadItemIdentity } from '~helpers/offlineCopy'
-import { invalidateOfflineCopyQueries } from '~helpers/offlineCopyQueries'
-import {
-  beginResourceInstallation,
-  commitResourceInstallation,
-  completeResourceInstallation,
-  reconcileResourceInstallationJournal,
-  rollbackResourceInstallation,
-  type ResourceInstallationJournal,
-  type ResourceInstallationRecoveryTarget,
-} from '~helpers/resourceInstallationJournal'
-import { getStrongBibleSidecarPath } from '~helpers/strongBibleSidecar'
-import { getInterlinearSidecarPath } from '~helpers/interlinearBibleSidecar'
-import { getStrongLexiconModulePath } from '~helpers/strongLexiconModules'
-import { isAtomicResourceFileRollbackError } from '~helpers/atomicResourceFile'
+import { reconcileResourceInstallationJournal } from '~helpers/resourceInstallationJournal'
+import { installManagedResource } from '~helpers/managedResourceInstallation'
 import {
   migrateLegacyDownloadQueue,
   preserveLegacyDownloadsInQueue,
@@ -40,26 +23,6 @@ import {
 const PERSIST_KEY = 'downloadQueue'
 const MAX_RETRIES = 2
 const PERSIST_DEBOUNCE_MS = 2000
-
-const getResourceInstallationRecoveryTarget = (
-  item: DownloadItem
-): ResourceInstallationRecoveryTarget => {
-  switch (item.type) {
-    case 'bible':
-      return { kind: 'bible-sqlite', versionId: item.versionId }
-    case 'database':
-      return { kind: 'file', destinationPath: item.destinationPath }
-    case 'bible-strong-sidecar':
-      return { kind: 'file', destinationPath: getStrongBibleSidecarPath(item.versionId) }
-    case 'bible-interlinear-sidecar':
-      return { kind: 'file', destinationPath: getInterlinearSidecarPath(item.lang) }
-    case 'strong-lexicon-module':
-      return {
-        kind: 'file',
-        destinationPath: getStrongLexiconModulePath(item.strongLexiconModuleId),
-      }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // DownloadManager — singleton
@@ -284,55 +247,15 @@ class DownloadManager {
     try {
       this.updateItemStatus(item.id, 'downloading')
 
-      let installationJournal: ResourceInstallationJournal | undefined
-      let installationCommitted = false
-      let installationCompleted = false
-      try {
-        await installResourceDatabaseItem(item, {
-          onDownloadProgress: progress => this.updateItemProgress(item.id, progress, 0),
-          onInsertProgress: progress => this.updateItemProgress(item.id, 1, progress),
-          onStatusInserting: () => this.updateItemStatus(item.id, 'inserting'),
-          onResumable: resumable => {
-            this.currentResumable = resumable
-          },
-          isCancelled: () => this.cancelledIds.has(item.id),
-          installationLifecycle: {
-            prepare: installed => {
-              installationJournal = beginResourceInstallation(
-                item.id,
-                installed,
-                getResourceInstallationRecoveryTarget(item)
-              )
-            },
-            commit: () => {
-              if (!installationJournal) {
-                throw new Error(`RESOURCE_INSTALLATION_NOT_PREPARED:${item.id}`)
-              }
-              commitResourceInstallation(installationJournal)
-              installationCommitted = true
-            },
-          },
-        })
-        if (!installationJournal || !installationCommitted) {
-          throw new Error(`RESOURCE_PUBLICATION_NOT_COMMITTED:${item.id}`)
-        }
-        installationCompleted = true
-        completeResourceInstallation(installationJournal)
-        if (item.type === 'bible') {
-          await synchronizeOptionalBibleResources(item, item.versionId)
-        }
-      } catch (error) {
-        if (
-          installationJournal &&
-          !installationCompleted &&
-          !isAtomicResourceFileRollbackError(error)
-        ) {
-          rollbackResourceInstallation(installationJournal)
-        }
-        throw error
-      }
-
-      await invalidateOfflineCopyQueries(getDownloadItemIdentity(item))
+      await installManagedResource(item, {
+        onDownloadProgress: progress => this.updateItemProgress(item.id, progress, 0),
+        onInsertProgress: progress => this.updateItemProgress(item.id, 1, progress),
+        onStatusInserting: () => this.updateItemStatus(item.id, 'inserting'),
+        onResumable: resumable => {
+          this.currentResumable = resumable
+        },
+        isCancelled: () => this.cancelledIds.has(item.id),
+      })
       this.updateItemStatus(item.id, 'completed')
 
       // Signal to VersionSelectorItem instances

--- a/src/helpers/legacyBibleVersionMigration.ts
+++ b/src/helpers/legacyBibleVersionMigration.ts
@@ -42,6 +42,7 @@ export const migrateLegacyParallelVersions = (
 export const migrateLegacyBibleTabData = <T extends PersistedBibleTabData>(data: T): T => {
   const legacyVersion = data.selectedVersion
   const selectedVersion = migrateLegacyBibleVersionId(legacyVersion)
+  const hasLegacyModeAcquisition = isLegacyBibleVersionId(legacyVersion)
   const migrated = {
     ...data,
     selectedVersion,
@@ -49,13 +50,25 @@ export const migrateLegacyBibleTabData = <T extends PersistedBibleTabData>(data:
   } as PersistedBibleTabData
 
   if (legacyVersion === 'LSGS' || legacyVersion === 'KJVS') {
-    migrated.strongMode = 'visible'
+    migrated.strongMode = 'hidden'
+    migrated.pendingModeAcquisition = {
+      kind: 'strong',
+      versionId: selectedVersion,
+      mode: 'visible',
+      planIds: [`bible-strong:${selectedVersion}`],
+    }
   }
 
   if (legacyVersion === 'INT' || legacyVersion === 'INT_EN') {
     migrated.strongMode = 'hidden'
     migrated.interlinearMode = 'hidden'
     migrated.interlinearLocale = legacyVersion === 'INT' ? 'fr' : 'en'
+    migrated.pendingModeAcquisition = {
+      kind: 'interlinear',
+      mode: 'interlinear',
+      locale: migrated.interlinearLocale,
+      planIds: [`bible-interlinear:BHG:${migrated.interlinearLocale}`],
+    }
   }
 
   if (data.strongBibleSourceVersionId) {
@@ -66,10 +79,16 @@ export const migrateLegacyBibleTabData = <T extends PersistedBibleTabData>(data:
         : data.strongBibleSourceVersionId
   }
 
-  if (data.pendingModeAcquisition?.kind === 'strong' && data.pendingModeAcquisition.versionId) {
+  if (
+    !hasLegacyModeAcquisition &&
+    data.pendingModeAcquisition?.kind === 'strong' &&
+    data.pendingModeAcquisition.versionId
+  ) {
+    const pendingVersionId = migrateLegacyBibleVersionId(data.pendingModeAcquisition.versionId)
     migrated.pendingModeAcquisition = {
       ...data.pendingModeAcquisition,
-      versionId: migrateLegacyBibleVersionId(data.pendingModeAcquisition.versionId),
+      versionId: pendingVersionId,
+      planIds: [`bible-strong:${pendingVersionId}`],
     }
   }
 
@@ -82,6 +101,15 @@ export const migrateLegacyBibleTabData = <T extends PersistedBibleTabData>(data:
 
   return migrated as T
 }
+
+export const getLegacyBibleTabReferenceVersionIds = (data: PersistedBibleTabData): string[] =>
+  [
+    data.selectedVersion,
+    ...(data.parallelVersions ?? []),
+    data.strongBibleSourceVersionId,
+    data.pendingModeAcquisition?.versionId,
+    data.entityReference?.preferredVersion,
+  ].filter((versionId): versionId is string => typeof versionId === 'string')
 
 const isLegacyDownload = (value: unknown): boolean => {
   if (!value || typeof value !== 'object') return false

--- a/src/helpers/managedResourceInstallation.ts
+++ b/src/helpers/managedResourceInstallation.ts
@@ -1,0 +1,99 @@
+import type * as FileSystem from 'expo-file-system/legacy'
+
+import type { DownloadItem } from '~state/downloadQueue'
+
+import { isAtomicResourceFileRollbackError } from './atomicResourceFile'
+import { getInterlinearSidecarPath } from './interlinearBibleSidecar'
+import { getDownloadItemIdentity } from './offlineCopy'
+import { invalidateOfflineCopyQueries } from './offlineCopyQueries'
+import {
+  installResourceDatabaseItem,
+  synchronizeOptionalBibleResources,
+} from './resourceDatabaseInstallation'
+import {
+  beginResourceInstallation,
+  commitResourceInstallation,
+  completeResourceInstallation,
+  rollbackResourceInstallation,
+  type ResourceInstallationJournal,
+  type ResourceInstallationRecoveryTarget,
+} from './resourceInstallationJournal'
+import { getStrongBibleSidecarPath } from './strongBibleSidecar'
+import { getStrongLexiconModulePath } from './strongLexiconModules'
+
+export interface ManagedResourceInstallationCallbacks {
+  onDownloadProgress: (progress: number) => void
+  onInsertProgress: (progress: number) => void
+  onStatusInserting: () => void
+  onResumable: (resumable: FileSystem.DownloadResumable | null) => void
+  isCancelled: () => boolean
+}
+
+const getResourceInstallationRecoveryTarget = (
+  item: DownloadItem
+): ResourceInstallationRecoveryTarget => {
+  switch (item.type) {
+    case 'bible':
+      return { kind: 'bible-sqlite', versionId: item.versionId }
+    case 'database':
+      return { kind: 'file', destinationPath: item.destinationPath }
+    case 'bible-strong-sidecar':
+      return { kind: 'file', destinationPath: getStrongBibleSidecarPath(item.versionId) }
+    case 'bible-interlinear-sidecar':
+      return { kind: 'file', destinationPath: getInterlinearSidecarPath(item.lang) }
+    case 'strong-lexicon-module':
+      return {
+        kind: 'file',
+        destinationPath: getStrongLexiconModulePath(item.strongLexiconModuleId),
+      }
+  }
+}
+
+export const installManagedResource = async (
+  item: DownloadItem,
+  callbacks: ManagedResourceInstallationCallbacks
+): Promise<void> => {
+  let installationJournal: ResourceInstallationJournal | undefined
+  let installationCommitted = false
+  let installationCompleted = false
+  try {
+    await installResourceDatabaseItem(item, {
+      ...callbacks,
+      installationLifecycle: {
+        prepare: installed => {
+          installationJournal = beginResourceInstallation(
+            item.id,
+            installed,
+            getResourceInstallationRecoveryTarget(item)
+          )
+        },
+        commit: () => {
+          if (!installationJournal) {
+            throw new Error(`RESOURCE_INSTALLATION_NOT_PREPARED:${item.id}`)
+          }
+          commitResourceInstallation(installationJournal)
+          installationCommitted = true
+        },
+      },
+    })
+    if (!installationJournal || !installationCommitted) {
+      throw new Error(`RESOURCE_PUBLICATION_NOT_COMMITTED:${item.id}`)
+    }
+    installationCompleted = true
+    completeResourceInstallation(installationJournal)
+    if (item.type === 'bible') {
+      await synchronizeOptionalBibleResources(item, item.versionId)
+    }
+  } catch (error) {
+    if (
+      installationJournal &&
+      !installationCompleted &&
+      !isAtomicResourceFileRollbackError(error)
+    ) {
+      rollbackResourceInstallation(installationJournal)
+    }
+    throw error
+  }
+
+  await invalidateOfflineCopyQueries(getDownloadItemIdentity(item))
+}

--- a/src/migrations/__tests__/legacyPersistedReferences-test.ts
+++ b/src/migrations/__tests__/legacyPersistedReferences-test.ts
@@ -1,0 +1,157 @@
+import {
+  isPersistedCanonicalTabWorkspace,
+  migrateLegacyPersistedReferences,
+} from '../legacyPersistedReferences'
+
+describe('migrateLegacyPersistedReferences', () => {
+  it('recognizes only a non-empty, structurally complete canonical tab workspace', () => {
+    expect(isPersistedCanonicalTabWorkspace([])).toBe(false)
+    expect(isPersistedCanonicalTabWorkspace([{}])).toBe(false)
+    expect(isPersistedCanonicalTabWorkspace([{ id: 'default', tabs: [], activeTabIndex: 0 }])).toBe(
+      true
+    )
+  })
+
+  it('rewrites Redux-persist technical references without changing user-authored text', () => {
+    const values = new Map<string, string>([
+      [
+        'root',
+        JSON.stringify({
+          user: JSON.stringify({
+            bible: {
+              settings: {
+                defaultBibleVersion: 'KJVS',
+                defaultStrongBibleVersionId: 'LSGS',
+                compare: { LSGS: true, LSG: false, INT_EN: true },
+              },
+              bookmarks: { bookmark: { version: 'KJVS' } },
+              highlights: { highlight: { version: 'LSGS' } },
+              notes: {
+                note: { version: 'INT', content: 'KJVS and LSGS are part of my note' },
+              },
+              wordAnnotations: { annotation: { version: 'INT_EN' } },
+              currentTab: {
+                selectedVersion: 'LSG',
+                strongBibleSourceVersionId: 'KJVS',
+              },
+            },
+          }),
+          _persist: JSON.stringify({ version: 36, rehydrated: true }),
+        }),
+      ],
+    ])
+    const backend = {
+      getString: (key: string) => values.get(key),
+      set: (key: string, value: string) => values.set(key, value),
+    }
+
+    migrateLegacyPersistedReferences(backend)
+
+    const root = JSON.parse(values.get('root')!) as Record<string, string>
+    const user = JSON.parse(root.user)
+    expect(user.bible).toMatchObject({
+      settings: {
+        defaultBibleVersion: 'KJV',
+        defaultStrongBibleVersionId: 'LSG',
+        compare: { LSG: true, BHG: true },
+      },
+      bookmarks: { bookmark: { version: 'KJV' } },
+      highlights: { highlight: { version: 'LSG' } },
+      notes: {
+        note: { version: 'BHG', content: 'KJVS and LSGS are part of my note' },
+      },
+      wordAnnotations: { annotation: { version: 'BHG' } },
+      currentTab: {
+        selectedVersion: 'LSG',
+        strongBibleSourceVersionId: 'KJV',
+      },
+    })
+    expect(JSON.parse(root._persist)).toEqual({ version: 36, rehydrated: true })
+  })
+
+  it('migrates current and historical Jotai tab storage while preserving intended capabilities', () => {
+    const values = new Map<string, string>([
+      [
+        'tabGroupsAtom',
+        JSON.stringify([
+          {
+            tabs: [
+              {
+                type: 'bible',
+                data: {
+                  selectedVersion: 'INT_EN',
+                  interlinearMode: 'interlinear',
+                  parallelVersions: ['LSGS', 'KJVS', 'LSG'],
+                },
+              },
+              {
+                type: 'strong',
+                data: { strongBibleVersionId: 'LSGS', bibleVersion: 'KJVS' },
+              },
+            ],
+          },
+        ]),
+      ],
+      [
+        'tabsAtom',
+        JSON.stringify([
+          { type: 'bible', data: { selectedVersion: 'LSGS', strongMode: 'visible' } },
+        ]),
+      ],
+      ['savedParallelVersions', JSON.stringify(['INT', 'INT_EN', 'KJVS'])],
+    ])
+    const backend = {
+      getString: (key: string) => values.get(key),
+      set: (key: string, value: string) => values.set(key, value),
+    }
+
+    migrateLegacyPersistedReferences(backend)
+    migrateLegacyPersistedReferences(backend)
+
+    const groups = JSON.parse(values.get('tabGroupsAtom')!)
+    expect(groups[0].tabs[0].data).toMatchObject({
+      selectedVersion: 'BHG',
+      strongMode: 'hidden',
+      interlinearMode: 'hidden',
+      interlinearLocale: 'en',
+      parallelVersions: ['LSG', 'KJV'],
+      pendingModeAcquisition: {
+        kind: 'interlinear',
+        mode: 'interlinear',
+        locale: 'en',
+        planIds: ['bible-interlinear:BHG:en'],
+      },
+    })
+    expect(groups[0].tabs[1].data).toEqual({
+      strongBibleVersionId: 'LSG',
+      bibleVersion: 'KJV',
+    })
+    expect(JSON.parse(values.get('tabsAtom')!)[0].data).toMatchObject({
+      selectedVersion: 'LSG',
+      strongMode: 'hidden',
+      pendingModeAcquisition: {
+        kind: 'strong',
+        versionId: 'LSG',
+        mode: 'visible',
+        planIds: ['bible-strong:LSG'],
+      },
+    })
+    expect(JSON.parse(values.get('savedParallelVersions')!)).toEqual(['BHG', 'KJV'])
+  })
+
+  it('leaves malformed and already canonical persisted values untouched', () => {
+    const values = new Map<string, string>([
+      ['root', '{broken'],
+      ['tabGroupsAtom', JSON.stringify([{ data: { selectedVersion: 'LSG' } }])],
+    ])
+    const set = jest.fn((key: string, value: string) => values.set(key, value))
+
+    migrateLegacyPersistedReferences({
+      getString: key => values.get(key),
+      set,
+    })
+
+    expect(values.get('root')).toBe('{broken')
+    expect(set).not.toHaveBeenCalled()
+  })
+})

--- a/src/migrations/__tests__/legacyResourceEvidence-test.ts
+++ b/src/migrations/__tests__/legacyResourceEvidence-test.ts
@@ -1,0 +1,217 @@
+import {
+  LEGACY_REFERENCE_EVIDENCE_KEY,
+  getLegacyResourceFileCandidates,
+  getLegacyReferenceVersionIdsFromReduxState,
+  getLegacyReferenceVersionIdsFromJotaiStorage,
+  inspectLegacyResourceEvidence,
+  readLegacyReferenceEvidence,
+  recordLegacyReferenceEvidence,
+  resetLegacyReferenceEvidenceCaptureState,
+  tryRecordLegacyReferenceEvidence,
+} from '../legacyResourceEvidence'
+
+describe('legacyResourceEvidence', () => {
+  beforeEach(() => resetLegacyReferenceEvidenceCaptureState())
+
+  it('extracts only technical Bible version references from persisted Redux state', () => {
+    expect(
+      getLegacyReferenceVersionIdsFromReduxState({
+        user: {
+          bible: {
+            settings: {
+              defaultBibleVersion: 'KJVS',
+              defaultStrongBibleVersionId: 'LSGS',
+              compare: { INT_EN: true, LSG: true },
+            },
+            notes: {
+              note: { version: 'INT', content: 'KJVS is user-authored text' },
+              unrelated: { content: 'LSGS' },
+            },
+            tab: { selectedVersion: 'LSG', strongBibleSourceVersionId: 'KJVS' },
+            relations: {
+              relation: {
+                endpoints: [{ type: 'verse', version: 'LSGS' }],
+              },
+            },
+          },
+        },
+      })
+    ).toEqual(['KJVS', 'LSGS', 'INT_EN', 'LSG', 'INT', 'LSG', 'KJVS', 'LSGS'])
+  })
+
+  it('reads legacy references from current and historical Jotai storage keys before hydration', () => {
+    const values = new Map<string, string>([
+      [
+        'tabGroupsAtom',
+        JSON.stringify([
+          {
+            tabs: [
+              {
+                type: 'bible',
+                data: { selectedVersion: 'KJVS', parallelVersions: ['INT_EN', 'LSG'] },
+              },
+            ],
+          },
+        ]),
+      ],
+      ['tabsAtom', JSON.stringify([{ data: { selectedVersion: 'LSGS' } }])],
+      ['savedParallelVersions', JSON.stringify(['INT'])],
+    ])
+
+    expect(
+      getLegacyReferenceVersionIdsFromJotaiStorage({
+        getString: key => values.get(key),
+        set: jest.fn(),
+        remove: jest.fn(),
+      })
+    ).toEqual(['KJVS', 'INT_EN', 'LSG', 'LSGS', 'INT'])
+  })
+
+  it('journals only removed Bible identities and preserves prior evidence', () => {
+    const values = new Map<string, string>()
+    const backend = {
+      getString: (key: string) => values.get(key),
+      set: (key: string, value: string) => values.set(key, value),
+      remove: (key: string) => values.delete(key),
+    }
+
+    recordLegacyReferenceEvidence(['LSGS', 'KJV', 'INT_EN'], backend)
+    recordLegacyReferenceEvidence(['KJVS', 'LSGS'], backend)
+
+    expect(readLegacyReferenceEvidence(backend)).toEqual(['LSGS', 'KJVS', 'INT_EN'])
+    expect(values.get(LEGACY_REFERENCE_EVIDENCE_KEY)).toBe(
+      JSON.stringify(['LSGS', 'KJVS', 'INT_EN'])
+    )
+  })
+
+  it('fails closed when the reference evidence journal is corrupt', () => {
+    const backend = {
+      getString: () => '{broken',
+      set: jest.fn(),
+      remove: jest.fn(),
+    }
+
+    expect(() => readLegacyReferenceEvidence(backend)).toThrow('LEGACY_REFERENCE_EVIDENCE_CORRUPT')
+    expect(tryRecordLegacyReferenceEvidence(['LSGS'], backend)).toBe(false)
+    expect(backend.set).not.toHaveBeenCalled()
+  })
+
+  it('retries a transient evidence write before detection instead of silently skipping it', async () => {
+    const values = new Map<string, string>()
+    let shouldFailWrite = true
+    const storage = {
+      getString: (key: string) => values.get(key),
+      set: (key: string, value: string) => {
+        if (shouldFailWrite) throw new Error('disk-full')
+        values.set(key, value)
+      },
+      remove: (key: string) => values.delete(key),
+    }
+
+    expect(tryRecordLegacyReferenceEvidence(['LSGS'], storage)).toBe(false)
+    shouldFailWrite = false
+
+    await expect(
+      inspectLegacyResourceEvidence({
+        documentDirectory: 'file:///documents/',
+        rootLanguage: 'fr',
+        storage,
+        getInstalledBibleVersions: async () => [],
+        getFileInfo: async () => ({ exists: false }),
+      })
+    ).resolves.toMatchObject({ legacyIdentities: ['LSGS'] })
+  })
+
+  it('detects root and localized files, shared Bible rows, metadata, queue and references', async () => {
+    const values = new Map<string, string>([
+      [LEGACY_REFERENCE_EVIDENCE_KEY, JSON.stringify(['LSGS'])],
+      ['resource-publication:bible:KJVS', JSON.stringify({ generation: 'old' })],
+      [
+        'downloadQueue',
+        JSON.stringify([{ item: { id: 'database:STRONG:fr', databaseId: 'STRONG', lang: 'fr' } }]),
+      ],
+      ['savedParallelVersions', JSON.stringify(['INT_EN'])],
+    ])
+    const candidates = getLegacyResourceFileCandidates('file:///documents/', 'fr')
+    const existingPaths = new Set([
+      'file:///documents/bible-LSGS.json',
+      'file:///documents/bible-kjvs.json.backup',
+      'file:///documents/SQLite/interlineaire.sqlite-wal',
+      'file:///documents/SQLite/en/interlineaire.sqlite',
+      'file:///documents/SQLite/fr/strong.sqlite-shm',
+    ])
+    expect(candidates.map(candidate => candidate.path)).toEqual(
+      expect.arrayContaining([...existingPaths])
+    )
+
+    const evidence = await inspectLegacyResourceEvidence({
+      documentDirectory: 'file:///documents/',
+      rootLanguage: 'fr',
+      storage: {
+        getString: key => values.get(key),
+        set: (key, value) => values.set(key, value),
+        remove: key => values.delete(key),
+      },
+      getInstalledBibleVersions: async () => ['LSG', 'INT_EN'],
+      getFileInfo: async path => ({ exists: existingPaths.has(path), size: 10 }),
+    })
+
+    expect(evidence).toEqual({
+      legacyIdentities: ['LSGS', 'KJVS', 'INT', 'INT_EN', 'STRONG'],
+      reclaimedBytes: 50,
+    })
+  })
+
+  it('maps a root interlinear database to the current resource language', async () => {
+    const rootPath = 'file:///documents/SQLite/interlineaire.sqlite'
+    const inspect = (rootLanguage: 'fr' | 'en') =>
+      inspectLegacyResourceEvidence({
+        documentDirectory: 'file:///documents/',
+        rootLanguage,
+        storage: {
+          getString: () => undefined,
+          set: jest.fn(),
+          remove: jest.fn(),
+        },
+        getInstalledBibleVersions: async () => [],
+        getFileInfo: async path => ({ exists: path === rootPath, size: 1 }),
+      })
+
+    await expect(inspect('fr')).resolves.toMatchObject({ legacyIdentities: ['INT'] })
+    await expect(inspect('en')).resolves.toMatchObject({ legacyIdentities: ['INT_EN'] })
+  })
+
+  it('allowlists legacy paths without targeting canonical resources', () => {
+    const paths = getLegacyResourceFileCandidates('file:///documents/', 'fr').map(
+      candidate => candidate.path
+    )
+
+    expect(paths).not.toEqual(
+      expect.arrayContaining([
+        'file:///documents/SQLite/bibles.sqlite',
+        'file:///documents/SQLite/bible-lsg-strong.sqlite',
+        'file:///documents/SQLite/bible-bhg-interlinear-fr.sqlite',
+        'file:///documents/SQLite/strong_lexicon.core.sqlite',
+      ])
+    )
+    expect(
+      paths.every(path => /(?:LSGS|KJVS|lsgs|kjvs|interlineaire|strong\.sqlite)/.test(path))
+    ).toBe(true)
+  })
+
+  it('returns no migration evidence on a clean device', async () => {
+    await expect(
+      inspectLegacyResourceEvidence({
+        documentDirectory: 'file:///documents/',
+        rootLanguage: 'fr',
+        storage: {
+          getString: () => undefined,
+          set: jest.fn(),
+          remove: jest.fn(),
+        },
+        getInstalledBibleVersions: async () => ['LSG', 'KJV'],
+        getFileInfo: async () => ({ exists: false }),
+      })
+    ).resolves.toEqual({ legacyIdentities: [], reclaimedBytes: 0 })
+  })
+})

--- a/src/migrations/__tests__/legacyResourceMigration-test.ts
+++ b/src/migrations/__tests__/legacyResourceMigration-test.ts
@@ -1,0 +1,223 @@
+import type { OfflineCopyIdentity } from '~helpers/offlineCopyId'
+
+import {
+  createLegacyResourceMigration,
+  type LegacyResourceEvidence,
+  type LegacyResourceMigrationDependencies,
+  type LegacyResourceIdentity,
+  type LegacyReplacementResource,
+} from '../legacyResourceMigration'
+
+const localContext = { phase: 'local' as const, scopeId: 'device' }
+
+const identityKey = (identity: OfflineCopyIdentity): string => JSON.stringify(identity)
+
+const createEvidence = (legacyIdentities: LegacyResourceIdentity[]): LegacyResourceEvidence => ({
+  legacyIdentities,
+  reclaimedBytes: 42,
+})
+
+const createDependencies = (
+  overrides: Partial<LegacyResourceMigrationDependencies> = {}
+): LegacyResourceMigrationDependencies => ({
+  inspectEvidence: jest.fn(async () => createEvidence([])),
+  resolveReplacementPlan: jest.fn(async request => [
+    { identity: request, estimatedSize: 10, label: identityKey(request) },
+  ]),
+  isReplacementReady: jest.fn(async () => false),
+  installReplacement: jest.fn(async () => {}),
+  migratePersistedReferences: jest.fn(async () => {}),
+  cleanupLegacyIdentity: jest.fn(async () => {}),
+  finalizeCleanup: jest.fn(async () => {}),
+  ...overrides,
+})
+
+describe('legacyResourceMigration', () => {
+  it.each<[LegacyResourceIdentity, OfflineCopyIdentity]>([
+    ['LSGS', { kind: 'strong-bible-index', versionId: 'LSG' }],
+    ['KJVS', { kind: 'strong-bible-index', versionId: 'KJV' }],
+    ['INT', { kind: 'interlinear-index', versionId: 'BHG', language: 'fr' }],
+    ['INT_EN', { kind: 'interlinear-index', versionId: 'BHG', language: 'en' }],
+    ['STRONG', { kind: 'strong-lexicon-module', moduleId: 'core' }],
+  ])('maps %s to its replacement capability', async (legacyIdentity, replacementIdentity) => {
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence([legacyIdentity])),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+
+    const plan = await migration.detect(localContext)
+
+    expect(dependencies.resolveReplacementPlan).toHaveBeenCalledWith(replacementIdentity)
+    expect(plan).toMatchObject({
+      steps: [
+        { id: 'migrate-persisted-references' },
+        { id: `install:${identityKey(replacementIdentity)}` },
+      ],
+      cleanupSteps: [
+        { id: `cleanup:${legacyIdentity}`, resourceId: `legacy:${legacyIdentity}` },
+        { id: 'cleanup:finalize' },
+      ],
+      metadata: {
+        legacyIdentities: [legacyIdentity],
+        reclaimedBytes: 42,
+        estimatedDownloadBytes: 10,
+      },
+    })
+  })
+
+  it('deduplicates shared canonical prerequisites while preserving deterministic order', async () => {
+    const bhg: LegacyReplacementResource = {
+      identity: { kind: 'bible', versionId: 'BHG' },
+      estimatedSize: 100,
+      label: 'BHG',
+    }
+    const french: LegacyReplacementResource = {
+      identity: { kind: 'interlinear-index', versionId: 'BHG', language: 'fr' },
+      estimatedSize: 20,
+      label: 'BHG FR',
+    }
+    const english: LegacyReplacementResource = {
+      identity: { kind: 'interlinear-index', versionId: 'BHG', language: 'en' },
+      estimatedSize: 30,
+      label: 'BHG EN',
+    }
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence(['INT', 'INT_EN'])),
+      resolveReplacementPlan: jest.fn(async request =>
+        request.kind === 'interlinear-index' && request.language === 'fr'
+          ? [bhg, french]
+          : [bhg, english]
+      ),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+
+    const plan = await migration.detect(localContext)
+
+    expect(plan?.steps.map(step => step.resourceId)).toEqual([
+      'persisted-references',
+      identityKey(bhg.identity),
+      identityKey(french.identity),
+      identityKey(english.identity),
+    ])
+    expect(plan?.metadata).toMatchObject({ estimatedDownloadBytes: 150 })
+  })
+
+  it('still migrates references and cleans legacy evidence when replacements are compatible', async () => {
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence(['LSGS'])),
+      resolveReplacementPlan: jest.fn(async () => []),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+
+    const plan = await migration.detect(localContext)
+
+    expect(plan?.steps).toEqual([
+      {
+        id: 'migrate-persisted-references',
+        label: 'migration.legacyResources.references',
+        resourceId: 'persisted-references',
+      },
+    ])
+    expect(plan?.cleanupSteps?.map(step => step.id)).toEqual(['cleanup:LSGS', 'cleanup:finalize'])
+  })
+
+  it('does not create a migration without legacy filesystem, queue, publication or reference evidence', async () => {
+    const dependencies = createDependencies()
+    const migration = createLegacyResourceMigration(dependencies)
+
+    await expect(migration.detect(localContext)).resolves.toBeNull()
+  })
+
+  it('rechecks compatibility before and after installing an atomic replacement', async () => {
+    const replacement: LegacyReplacementResource = {
+      identity: { kind: 'strong-lexicon-module', moduleId: 'core' },
+      estimatedSize: 50,
+      label: 'Lexique Strong',
+    }
+    let ready = false
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence(['STRONG'])),
+      resolveReplacementPlan: jest.fn(async () => [replacement]),
+      isReplacementReady: jest.fn(async () => ready),
+      installReplacement: jest.fn(async (_identity, reportProgress) => {
+        reportProgress({ progress: 0.5, message: 'download' })
+        ready = true
+      }),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+    const plan = (await migration.detect(localContext))!
+    const progress = jest.fn()
+
+    await migration.executeStep({
+      context: localContext,
+      plan,
+      step: plan.steps[1],
+      reportProgress: progress,
+    })
+    await migration.executeStep({
+      context: localContext,
+      plan,
+      step: plan.steps[1],
+      reportProgress: progress,
+    })
+
+    expect(dependencies.installReplacement).toHaveBeenCalledTimes(1)
+    expect(progress).toHaveBeenCalledWith({ progress: 0.5, message: 'download' })
+  })
+
+  it('fails a step when installation does not produce a compatible replacement', async () => {
+    const replacement: LegacyReplacementResource = {
+      identity: { kind: 'strong-lexicon-module', moduleId: 'core' },
+      estimatedSize: 50,
+      label: 'Lexique Strong',
+    }
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence(['STRONG'])),
+      resolveReplacementPlan: jest.fn(async () => [replacement]),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+    const plan = (await migration.detect(localContext))!
+
+    await expect(
+      migration.executeStep({
+        context: localContext,
+        plan,
+        step: plan.steps[1],
+        reportProgress: jest.fn(),
+      })
+    ).rejects.toThrow('LEGACY_REPLACEMENT_NOT_COMPATIBLE')
+  })
+
+  it('checkpoints allowlisted cleanup identities before final migration cleanup', async () => {
+    const dependencies = createDependencies({
+      inspectEvidence: jest.fn(async () => createEvidence(['KJVS', 'STRONG'])),
+      resolveReplacementPlan: jest.fn(async () => []),
+    })
+    const migration = createLegacyResourceMigration(dependencies)
+    const plan = (await migration.detect(localContext))!
+    const checkpoints: string[] = []
+
+    await migration.finalizeIdempotently?.({
+      context: localContext,
+      plan,
+      outcome: 'abandoned-after-failure',
+      async runCleanupStep(stepId, operation) {
+        checkpoints.push(stepId)
+        await operation(jest.fn())
+      },
+    })
+
+    expect(dependencies.cleanupLegacyIdentity).toHaveBeenNthCalledWith(
+      1,
+      'KJVS',
+      'abandoned-after-failure'
+    )
+    expect(dependencies.cleanupLegacyIdentity).toHaveBeenNthCalledWith(
+      2,
+      'STRONG',
+      'abandoned-after-failure'
+    )
+    expect(dependencies.finalizeCleanup).toHaveBeenCalledWith('abandoned-after-failure')
+    expect(checkpoints).toEqual(['cleanup:KJVS', 'cleanup:STRONG', 'cleanup:finalize'])
+  })
+})

--- a/src/migrations/legacyPersistedReferences.ts
+++ b/src/migrations/legacyPersistedReferences.ts
@@ -1,0 +1,147 @@
+import {
+  isLegacyBibleVersionId,
+  migrateLegacyBibleTabData,
+  migrateLegacyBibleVersionId,
+  migrateLegacyParallelVersions,
+} from '~helpers/legacyBibleVersionMigration'
+
+export interface LegacyPersistedReferenceStorage {
+  getString(key: string): string | undefined
+  set(key: string, value: string): void
+}
+
+export const isPersistedCanonicalTabWorkspace = (value: unknown): boolean =>
+  Array.isArray(value) &&
+  value.length > 0 &&
+  value.every(
+    group =>
+      Boolean(group) &&
+      typeof group === 'object' &&
+      typeof (group as Record<string, unknown>).id === 'string' &&
+      Array.isArray((group as Record<string, unknown>).tabs) &&
+      typeof (group as Record<string, unknown>).activeTabIndex === 'number'
+  )
+
+const VERSION_FIELDS = new Set([
+  'version',
+  'versionId',
+  'selectedVersion',
+  'defaultBibleVersion',
+  'defaultStrongBibleVersionId',
+  'strongBibleVersionId',
+  'strongBibleSourceVersionId',
+  'bibleVersion',
+  'preferredVersion',
+])
+
+const migrateCompare = (value: Record<string, unknown>): Record<string, unknown> => {
+  const migrated: Record<string, unknown> = {}
+  for (const [versionId, selection] of Object.entries(value)) {
+    const canonicalVersionId = migrateLegacyBibleVersionId(versionId)
+    const previous = migrated[canonicalVersionId]
+    migrated[canonicalVersionId] =
+      typeof previous === 'boolean' && typeof selection === 'boolean'
+        ? previous || selection
+        : previous === undefined
+          ? selection
+          : previous
+  }
+  return migrated
+}
+
+const migrateValue = (value: unknown, field?: string): unknown => {
+  if (typeof value === 'string') {
+    return field && VERSION_FIELDS.has(field) ? migrateLegacyBibleVersionId(value) : value
+  }
+  if (Array.isArray(value)) {
+    if (field === 'parallelVersions' && value.every(item => typeof item === 'string')) {
+      return migrateLegacyParallelVersions(value)
+    }
+    return value.map(item => migrateValue(item))
+  }
+  if (!value || typeof value !== 'object') return value
+
+  const source = value as Record<string, unknown>
+  const selectedVersion = source.selectedVersion
+  const prepared =
+    typeof selectedVersion === 'string' && isLegacyBibleVersionId(selectedVersion)
+      ? (migrateLegacyBibleTabData(
+          source as Record<string, unknown> & { selectedVersion: string }
+        ) as Record<string, unknown>)
+      : source
+  const migrated: Record<string, unknown> = {}
+
+  for (const [key, nested] of Object.entries(prepared)) {
+    if (key === 'compare' && nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      migrated[key] = migrateCompare(nested as Record<string, unknown>)
+    } else if (
+      key === 'parallelVersions' &&
+      Array.isArray(nested) &&
+      nested.every(item => typeof item === 'string')
+    ) {
+      migrated[key] = migrateLegacyParallelVersions(
+        nested,
+        typeof prepared.selectedVersion === 'string' ? prepared.selectedVersion : undefined
+      )
+    } else {
+      migrated[key] = migrateValue(nested, key)
+    }
+  }
+  return migrated
+}
+
+const migrateJsonStorageKey = (
+  backend: LegacyPersistedReferenceStorage,
+  key: string,
+  migrate: (value: unknown) => unknown = migrateValue
+): void => {
+  const serialized = backend.getString(key)
+  if (typeof serialized === 'undefined') return
+  try {
+    const nextSerialized = JSON.stringify(migrate(JSON.parse(serialized) as unknown))
+    if (nextSerialized !== serialized) backend.set(key, nextSerialized)
+  } catch {
+    // Preserve malformed state so the owning persistence layer can apply its recovery policy.
+  }
+}
+
+const migrateReduxPersistRoot = (backend: LegacyPersistedReferenceStorage): void => {
+  const serialized = backend.getString('root')
+  if (typeof serialized === 'undefined') return
+
+  try {
+    const root = JSON.parse(serialized) as unknown
+    if (!root || typeof root !== 'object' || Array.isArray(root)) return
+
+    const migratedRoot: Record<string, unknown> = {}
+    for (const [key, persistedSlice] of Object.entries(root)) {
+      if (typeof persistedSlice !== 'string') {
+        migratedRoot[key] = migrateValue(persistedSlice)
+        continue
+      }
+      try {
+        migratedRoot[key] = JSON.stringify(migrateValue(JSON.parse(persistedSlice) as unknown))
+      } catch {
+        migratedRoot[key] = persistedSlice
+      }
+    }
+
+    const nextSerialized = JSON.stringify(migratedRoot)
+    if (nextSerialized !== serialized) backend.set('root', nextSerialized)
+  } catch {
+    // Preserve malformed state so redux-persist can fall back or recover it.
+  }
+}
+
+export const migrateLegacyPersistedReferences = (
+  backend: LegacyPersistedReferenceStorage
+): void => {
+  migrateReduxPersistRoot(backend)
+  migrateJsonStorageKey(backend, 'tabGroupsAtom')
+  migrateJsonStorageKey(backend, 'tabsAtom')
+  migrateJsonStorageKey(backend, 'savedParallelVersions', value =>
+    Array.isArray(value) && value.every(item => typeof item === 'string')
+      ? migrateLegacyParallelVersions(value)
+      : value
+  )
+}

--- a/src/migrations/legacyResourceEvidence.ts
+++ b/src/migrations/legacyResourceEvidence.ts
@@ -1,0 +1,347 @@
+import type { ResourceLanguage } from '~helpers/databaseTypes'
+
+import type { LegacyResourceEvidence, LegacyResourceIdentity } from './legacyResourceMigration'
+
+export const LEGACY_REFERENCE_EVIDENCE_KEY = 'legacy_resource_reference_evidence_v1'
+
+const LEGACY_IDENTITY_ORDER: LegacyResourceIdentity[] = ['LSGS', 'KJVS', 'INT', 'INT_EN', 'STRONG']
+const LEGACY_BIBLE_IDENTITIES = new Set<LegacyResourceIdentity>(['LSGS', 'KJVS', 'INT', 'INT_EN'])
+const volatileReferenceEvidence = new Set<LegacyResourceIdentity>()
+let referenceEvidenceCaptureFailed = false
+
+export interface LegacyEvidenceStorage {
+  getString(key: string): string | undefined
+  set(key: string, value: string): void
+  remove(key: string): void
+}
+
+export interface LegacyResourceFileCandidate {
+  identity: LegacyResourceIdentity
+  path: string
+}
+
+export interface LegacyPublicationCandidate {
+  identity: LegacyResourceIdentity
+  key: string
+}
+
+interface LegacyFileInfo {
+  exists: boolean
+  size?: number
+}
+
+export interface LegacyResourceEvidenceDependencies {
+  documentDirectory: string
+  rootLanguage: ResourceLanguage
+  storage: LegacyEvidenceStorage
+  getInstalledBibleVersions(): Promise<string[]>
+  getFileInfo(path: string): Promise<LegacyFileInfo>
+}
+
+const orderIdentities = (
+  identities: Iterable<LegacyResourceIdentity>
+): LegacyResourceIdentity[] => {
+  const identitySet = new Set(identities)
+  return LEGACY_IDENTITY_ORDER.filter(identity => identitySet.has(identity))
+}
+
+export const readLegacyReferenceEvidence = (
+  backend: LegacyEvidenceStorage
+): LegacyResourceIdentity[] => {
+  const serialized = backend.getString(LEGACY_REFERENCE_EVIDENCE_KEY)
+  if (typeof serialized === 'undefined') return []
+
+  try {
+    const value = JSON.parse(serialized) as unknown
+    if (
+      !Array.isArray(value) ||
+      value.some(
+        identity =>
+          typeof identity !== 'string' ||
+          !LEGACY_BIBLE_IDENTITIES.has(identity as LegacyResourceIdentity)
+      )
+    ) {
+      throw new Error('invalid')
+    }
+    return orderIdentities(value as LegacyResourceIdentity[])
+  } catch {
+    throw new Error('LEGACY_REFERENCE_EVIDENCE_CORRUPT')
+  }
+}
+
+export const recordLegacyReferenceEvidence = (
+  versionIds: readonly string[],
+  backend: LegacyEvidenceStorage
+): void => {
+  const priorEvidence = readLegacyReferenceEvidence(backend)
+  const nextEvidence = orderIdentities([
+    ...priorEvidence,
+    ...versionIds.filter(versionId =>
+      LEGACY_BIBLE_IDENTITIES.has(versionId as LegacyResourceIdentity)
+    ),
+  ] as LegacyResourceIdentity[])
+  if (nextEvidence.length > 0) {
+    backend.set(LEGACY_REFERENCE_EVIDENCE_KEY, JSON.stringify(nextEvidence))
+  }
+}
+
+export const tryRecordLegacyReferenceEvidence = (
+  versionIds: readonly string[],
+  backend: LegacyEvidenceStorage
+): boolean => {
+  for (const versionId of versionIds) {
+    if (LEGACY_BIBLE_IDENTITIES.has(versionId as LegacyResourceIdentity)) {
+      volatileReferenceEvidence.add(versionId as LegacyResourceIdentity)
+    }
+  }
+  try {
+    recordLegacyReferenceEvidence([...volatileReferenceEvidence], backend)
+    referenceEvidenceCaptureFailed = false
+    return true
+  } catch {
+    referenceEvidenceCaptureFailed = true
+    return false
+  }
+}
+
+export const resetLegacyReferenceEvidenceCaptureState = (): void => {
+  volatileReferenceEvidence.clear()
+  referenceEvidenceCaptureFailed = false
+}
+
+const flushVolatileReferenceEvidence = (backend: LegacyEvidenceStorage): void => {
+  if (!referenceEvidenceCaptureFailed) return
+  try {
+    recordLegacyReferenceEvidence([...volatileReferenceEvidence], backend)
+    referenceEvidenceCaptureFailed = false
+  } catch {
+    throw new Error('LEGACY_REFERENCE_EVIDENCE_CAPTURE_FAILED')
+  }
+}
+
+const REFERENCE_VERSION_FIELDS = new Set([
+  'version',
+  'versionId',
+  'selectedVersion',
+  'defaultBibleVersion',
+  'defaultStrongBibleVersionId',
+  'strongBibleVersionId',
+  'strongBibleSourceVersionId',
+  'bibleVersion',
+  'preferredVersion',
+  'parallelVersions',
+])
+
+export const getLegacyReferenceVersionIdsFromReduxState = (value: unknown): string[] => {
+  const identities: string[] = []
+  const visit = (current: unknown, field?: string): void => {
+    if (typeof current === 'string') {
+      if (field && REFERENCE_VERSION_FIELDS.has(field)) identities.push(current)
+      return
+    }
+    if (Array.isArray(current)) {
+      current.forEach(item => visit(item, field))
+      return
+    }
+    if (!current || typeof current !== 'object') return
+
+    for (const [key, nested] of Object.entries(current)) {
+      if (key === 'compare' && nested && typeof nested === 'object' && !Array.isArray(nested)) {
+        identities.push(...Object.keys(nested))
+      } else {
+        visit(nested, key)
+      }
+    }
+  }
+  visit(value)
+  return identities
+}
+
+export const captureLegacyReferenceEvidenceFromReduxState = (
+  state: unknown,
+  backend: LegacyEvidenceStorage
+): void => {
+  recordLegacyReferenceEvidence(getLegacyReferenceVersionIdsFromReduxState(state), backend)
+}
+
+export const tryCaptureLegacyReferenceEvidenceFromReduxState = (
+  state: unknown,
+  backend: LegacyEvidenceStorage
+): boolean =>
+  tryRecordLegacyReferenceEvidence(getLegacyReferenceVersionIdsFromReduxState(state), backend)
+
+const JOTAI_REFERENCE_KEYS = ['tabGroupsAtom', 'tabsAtom', 'savedParallelVersions'] as const
+
+export const getLegacyReferenceVersionIdsFromJotaiStorage = (
+  backend: LegacyEvidenceStorage
+): string[] =>
+  JOTAI_REFERENCE_KEYS.flatMap(key => {
+    const serialized = backend.getString(key)
+    if (typeof serialized === 'undefined') return []
+    try {
+      const value = JSON.parse(serialized) as unknown
+      if (key === 'savedParallelVersions' && Array.isArray(value)) {
+        return value.filter((versionId): versionId is string => typeof versionId === 'string')
+      }
+      return getLegacyReferenceVersionIdsFromReduxState(value)
+    } catch {
+      return []
+    }
+  })
+
+const withTemporaryFiles = (path: string): string[] => [path, `${path}.download`, `${path}.backup`]
+
+const withSqliteCompanionFiles = (path: string): string[] => [
+  ...withTemporaryFiles(path),
+  `${path}-wal`,
+  `${path}-shm`,
+  `${path}-journal`,
+]
+
+export const getLegacyResourceFileCandidates = (
+  documentDirectory: string,
+  rootLanguage: ResourceLanguage
+): LegacyResourceFileCandidate[] => {
+  const candidates: LegacyResourceFileCandidate[] = []
+  for (const identity of ['LSGS', 'KJVS'] as const) {
+    const lower = identity.toLowerCase()
+    const paths = [
+      ...withTemporaryFiles(`${documentDirectory}bible-${identity}.json`),
+      ...withTemporaryFiles(`${documentDirectory}bible-${lower}.json`),
+      ...withTemporaryFiles(`${documentDirectory}bible-${identity}-pericope.json`),
+      ...withTemporaryFiles(`${documentDirectory}bible-${lower}-pericope.json`),
+      ...withTemporaryFiles(`${documentDirectory}red-words-${identity}.json`),
+      ...withTemporaryFiles(`${documentDirectory}red-words-${lower}.json`),
+    ]
+    candidates.push(...paths.map(path => ({ identity, path })))
+  }
+
+  const sqliteDirectory = `${documentDirectory}SQLite`
+  const rootInterlinear = withSqliteCompanionFiles(`${sqliteDirectory}/interlineaire.sqlite`)
+  candidates.push(
+    ...rootInterlinear.map(path => ({
+      identity: rootLanguage === 'fr' ? ('INT' as const) : ('INT_EN' as const),
+      path,
+    })),
+    ...withSqliteCompanionFiles(`${sqliteDirectory}/fr/interlineaire.sqlite`).map(path => ({
+      identity: 'INT' as const,
+      path,
+    })),
+    ...withSqliteCompanionFiles(`${sqliteDirectory}/en/interlineaire.sqlite`).map(path => ({
+      identity: 'INT_EN' as const,
+      path,
+    }))
+  )
+
+  for (const directory of [sqliteDirectory, `${sqliteDirectory}/fr`, `${sqliteDirectory}/en`]) {
+    candidates.push(
+      ...withSqliteCompanionFiles(`${directory}/strong.sqlite`).map(path => ({
+        identity: 'STRONG' as const,
+        path,
+      }))
+    )
+  }
+
+  return [...new Map(candidates.map(candidate => [candidate.path, candidate] as const)).values()]
+}
+
+export const LEGACY_PUBLICATION_CANDIDATES: LegacyPublicationCandidate[] = [
+  { identity: 'LSGS', key: 'resource-publication:bible:LSGS' },
+  { identity: 'KJVS', key: 'resource-publication:bible:KJVS' },
+  { identity: 'INT', key: 'resource-publication:bible:INT' },
+  { identity: 'INT_EN', key: 'resource-publication:bible:INT_EN' },
+  { identity: 'LSGS', key: 'resource-publication:bible-pericope:LSGS' },
+  { identity: 'KJVS', key: 'resource-publication:bible-pericope:KJVS' },
+  { identity: 'LSGS', key: 'resource-publication:bible-red-words:LSGS' },
+  { identity: 'KJVS', key: 'resource-publication:bible-red-words:KJVS' },
+  { identity: 'INT', key: 'resource-publication:database:INTERLINEAIRE:fr' },
+  { identity: 'INT_EN', key: 'resource-publication:database:INTERLINEAIRE:en' },
+  { identity: 'STRONG', key: 'resource-publication:database:STRONG:fr' },
+  { identity: 'STRONG', key: 'resource-publication:database:STRONG:en' },
+]
+
+const getLegacyQueueIdentities = (serialized: string | undefined): LegacyResourceIdentity[] => {
+  if (typeof serialized === 'undefined') return []
+  try {
+    const queue = JSON.parse(serialized) as unknown
+    if (!Array.isArray(queue)) return []
+    const identities: LegacyResourceIdentity[] = []
+    for (const state of queue) {
+      if (!state || typeof state !== 'object' || !('item' in state)) continue
+      const item = state.item
+      if (!item || typeof item !== 'object') continue
+      const record = item as Record<string, unknown>
+      if (
+        typeof record.versionId === 'string' &&
+        LEGACY_BIBLE_IDENTITIES.has(record.versionId as LegacyResourceIdentity)
+      ) {
+        identities.push(record.versionId as LegacyResourceIdentity)
+      }
+      if (record.databaseId === 'STRONG') identities.push('STRONG')
+      if (record.databaseId === 'INTERLINEAIRE') {
+        identities.push(record.lang === 'en' ? 'INT_EN' : 'INT')
+      }
+      if (typeof record.id === 'string') {
+        const parts = record.id.split(':')
+        for (const identity of LEGACY_IDENTITY_ORDER) {
+          if (parts.includes(identity)) identities.push(identity)
+        }
+        if (parts.includes('INTERLINEAIRE')) {
+          identities.push(parts.includes('en') ? 'INT_EN' : 'INT')
+        }
+      }
+    }
+    return orderIdentities(identities)
+  } catch {
+    throw new Error('LEGACY_DOWNLOAD_QUEUE_CORRUPT')
+  }
+}
+
+export const inspectLegacyResourceEvidence = async ({
+  documentDirectory,
+  rootLanguage,
+  storage,
+  getInstalledBibleVersions,
+  getFileInfo,
+}: LegacyResourceEvidenceDependencies): Promise<LegacyResourceEvidence> => {
+  flushVolatileReferenceEvidence(storage)
+  const identities = new Set<LegacyResourceIdentity>([
+    ...readLegacyReferenceEvidence(storage),
+    ...volatileReferenceEvidence,
+    ...getLegacyReferenceVersionIdsFromJotaiStorage(storage).filter(versionId =>
+      LEGACY_BIBLE_IDENTITIES.has(versionId as LegacyResourceIdentity)
+    ),
+  ] as LegacyResourceIdentity[])
+  let reclaimedBytes = 0
+
+  const installedVersions = await getInstalledBibleVersions()
+  for (const versionId of installedVersions) {
+    if (LEGACY_BIBLE_IDENTITIES.has(versionId as LegacyResourceIdentity)) {
+      identities.add(versionId as LegacyResourceIdentity)
+    }
+  }
+
+  for (const publication of LEGACY_PUBLICATION_CANDIDATES) {
+    if (typeof storage.getString(publication.key) !== 'undefined') {
+      identities.add(publication.identity)
+    }
+  }
+  for (const identity of getLegacyQueueIdentities(storage.getString('downloadQueue'))) {
+    identities.add(identity)
+  }
+
+  const candidates = getLegacyResourceFileCandidates(documentDirectory, rootLanguage)
+  const results = await Promise.all(
+    candidates.map(async candidate => ({ candidate, info: await getFileInfo(candidate.path) }))
+  )
+  for (const { candidate, info } of results) {
+    if (!info.exists) continue
+    identities.add(candidate.identity)
+    reclaimedBytes += info.size ?? 0
+  }
+
+  return {
+    legacyIdentities: orderIdentities(identities),
+    reclaimedBytes,
+  }
+}

--- a/src/migrations/legacyResourceMigration.ts
+++ b/src/migrations/legacyResourceMigration.ts
@@ -1,0 +1,229 @@
+import type { OfflineCopyIdentity } from '~helpers/offlineCopyId'
+
+import {
+  MigrationExecutionError,
+  type AppMigrationDefinition,
+  type JsonValue,
+  type MigrationContext,
+  type MigrationProgressUpdate,
+  type MigrationTerminalOutcome,
+} from './appMigrationOrchestrator'
+
+export const LEGACY_RESOURCE_MIGRATION_ID = 'legacy-bible-resources'
+
+export type LegacyResourceIdentity = 'LSGS' | 'KJVS' | 'INT' | 'INT_EN' | 'STRONG'
+
+export interface LegacyResourceEvidence {
+  legacyIdentities: LegacyResourceIdentity[]
+  reclaimedBytes?: number
+}
+
+export interface LegacyReplacementResource {
+  identity: OfflineCopyIdentity
+  estimatedSize?: number
+  label: string
+}
+
+export interface LegacyResourceMigrationDependencies {
+  inspectEvidence(): Promise<LegacyResourceEvidence>
+  resolveReplacementPlan(request: OfflineCopyIdentity): Promise<LegacyReplacementResource[]>
+  isReplacementReady(identity: OfflineCopyIdentity): Promise<boolean>
+  installReplacement(
+    identity: OfflineCopyIdentity,
+    reportProgress: (update: MigrationProgressUpdate) => void
+  ): Promise<void>
+  migratePersistedReferences(): Promise<void>
+  cleanupLegacyIdentity(
+    identity: LegacyResourceIdentity,
+    outcome: MigrationTerminalOutcome
+  ): Promise<void>
+  finalizeCleanup(outcome: MigrationTerminalOutcome): Promise<void>
+}
+
+const LEGACY_IDENTITY_ORDER: LegacyResourceIdentity[] = ['LSGS', 'KJVS', 'INT', 'INT_EN', 'STRONG']
+
+const getReplacementRequest = (identity: LegacyResourceIdentity): OfflineCopyIdentity => {
+  switch (identity) {
+    case 'LSGS':
+      return { kind: 'strong-bible-index', versionId: 'LSG' }
+    case 'KJVS':
+      return { kind: 'strong-bible-index', versionId: 'KJV' }
+    case 'INT':
+      return { kind: 'interlinear-index', versionId: 'BHG', language: 'fr' }
+    case 'INT_EN':
+      return { kind: 'interlinear-index', versionId: 'BHG', language: 'en' }
+    case 'STRONG':
+      return { kind: 'strong-lexicon-module', moduleId: 'core' }
+  }
+}
+
+const identityKey = (identity: OfflineCopyIdentity): string => JSON.stringify(identity)
+
+const serializeIdentity = (identity: OfflineCopyIdentity): { [key: string]: JsonValue } => {
+  switch (identity.kind) {
+    case 'bible':
+      return { kind: identity.kind, versionId: identity.versionId }
+    case 'strong-bible-index':
+      return { kind: identity.kind, versionId: identity.versionId }
+    case 'interlinear-index':
+      return {
+        kind: identity.kind,
+        versionId: identity.versionId,
+        language: identity.language,
+      }
+    case 'strong-lexicon-module':
+      return { kind: identity.kind, moduleId: identity.moduleId }
+    case 'database':
+      return {
+        kind: identity.kind,
+        databaseId: identity.databaseId,
+        language: identity.language,
+      }
+    case 'bible-pericope':
+    case 'bible-red-words':
+      return { kind: identity.kind, versionId: identity.versionId }
+  }
+}
+
+const parseIdentity = (value: unknown): OfflineCopyIdentity => {
+  if (!value || typeof value !== 'object' || !('kind' in value)) {
+    throw new MigrationExecutionError('LEGACY_REPLACEMENT_IDENTITY_INVALID')
+  }
+  const identity = value as Record<string, unknown>
+  switch (identity.kind) {
+    case 'bible':
+      if (typeof identity.versionId === 'string') {
+        return { kind: identity.kind, versionId: identity.versionId }
+      }
+      break
+    case 'strong-bible-index':
+      if (identity.versionId === 'LSG' || identity.versionId === 'KJV') {
+        return { kind: identity.kind, versionId: identity.versionId }
+      }
+      break
+    case 'interlinear-index':
+      if (
+        identity.versionId === 'BHG' &&
+        (identity.language === 'fr' || identity.language === 'en')
+      ) {
+        return { kind: identity.kind, versionId: 'BHG', language: identity.language }
+      }
+      break
+    case 'strong-lexicon-module':
+      if (identity.moduleId === 'core') {
+        return { kind: identity.kind, moduleId: identity.moduleId }
+      }
+      break
+  }
+  throw new MigrationExecutionError('LEGACY_REPLACEMENT_IDENTITY_INVALID')
+}
+
+const parseLegacyIdentities = (value: unknown): LegacyResourceIdentity[] => {
+  if (!Array.isArray(value)) {
+    throw new MigrationExecutionError('LEGACY_RESOURCE_PLAN_INVALID')
+  }
+  const identities = value.filter(
+    (identity): identity is LegacyResourceIdentity =>
+      typeof identity === 'string' &&
+      LEGACY_IDENTITY_ORDER.includes(identity as LegacyResourceIdentity)
+  )
+  if (identities.length !== value.length || new Set(identities).size !== identities.length) {
+    throw new MigrationExecutionError('LEGACY_RESOURCE_PLAN_INVALID')
+  }
+  return identities
+}
+
+const orderLegacyIdentities = (identities: LegacyResourceIdentity[]): LegacyResourceIdentity[] =>
+  LEGACY_IDENTITY_ORDER.filter(identity => identities.includes(identity))
+
+export const createLegacyResourceMigration = (
+  dependencies: LegacyResourceMigrationDependencies
+): AppMigrationDefinition => ({
+  id: LEGACY_RESOURCE_MIGRATION_ID,
+  version: 1,
+  phase: 'local',
+  order: 100,
+  async detect() {
+    const evidence = await dependencies.inspectEvidence()
+    const legacyIdentities = orderLegacyIdentities(evidence.legacyIdentities)
+    if (legacyIdentities.length === 0) return null
+
+    const replacements = new Map<string, LegacyReplacementResource>()
+    for (const legacyIdentity of legacyIdentities) {
+      const request = getReplacementRequest(legacyIdentity)
+      const plannedResources = await dependencies.resolveReplacementPlan(request)
+      for (const resource of plannedResources) {
+        const key = identityKey(resource.identity)
+        if (!replacements.has(key)) replacements.set(key, resource)
+      }
+    }
+
+    const replacementSteps = [...replacements.values()].map(resource => ({
+      id: `install:${identityKey(resource.identity)}`,
+      label: resource.label,
+      resourceId: identityKey(resource.identity),
+      payload: { identity: serializeIdentity(resource.identity) },
+    }))
+    const estimatedDownloadBytes = [...replacements.values()].reduce(
+      (total, resource) => total + (resource.estimatedSize ?? 0),
+      0
+    )
+
+    return {
+      steps: [
+        {
+          id: 'migrate-persisted-references',
+          label: 'migration.legacyResources.references',
+          resourceId: 'persisted-references',
+        },
+        ...replacementSteps,
+      ],
+      cleanupSteps: [
+        ...legacyIdentities.map(identity => ({
+          id: `cleanup:${identity}`,
+          label: 'migration.legacyResources.cleanupResource',
+          resourceId: `legacy:${identity}`,
+          payload: { legacyIdentity: identity },
+        })),
+        {
+          id: 'cleanup:finalize',
+          label: 'migration.legacyResources.cleanupFinalize',
+          resourceId: 'legacy:finalize',
+        },
+      ],
+      metadata: {
+        legacyIdentities,
+        reclaimedBytes: evidence.reclaimedBytes ?? 0,
+        estimatedDownloadBytes,
+      },
+    }
+  },
+  async executeStep({ step, reportProgress }) {
+    if (step.id === 'migrate-persisted-references') {
+      await dependencies.migratePersistedReferences()
+      return
+    }
+
+    const identity = parseIdentity(step.payload?.identity)
+    if (await dependencies.isReplacementReady(identity)) return
+    await dependencies.installReplacement(identity, reportProgress)
+    if (!(await dependencies.isReplacementReady(identity))) {
+      throw new MigrationExecutionError('LEGACY_REPLACEMENT_NOT_COMPATIBLE')
+    }
+  },
+  async finalizeIdempotently({ plan, outcome, runCleanupStep }) {
+    const legacyIdentities = parseLegacyIdentities(plan.metadata?.legacyIdentities)
+    for (const legacyIdentity of legacyIdentities) {
+      await runCleanupStep(`cleanup:${legacyIdentity}`, async () => {
+        await dependencies.cleanupLegacyIdentity(legacyIdentity, outcome)
+      })
+    }
+    await runCleanupStep('cleanup:finalize', async () => {
+      await dependencies.finalizeCleanup(outcome)
+    })
+  },
+})
+
+export const isLegacyResourceMigrationContext = (
+  context: MigrationContext
+): context is MigrationContext & { phase: 'local' } => context.phase === 'local'

--- a/src/migrations/legacyResourceMigrationRuntime.ts
+++ b/src/migrations/legacyResourceMigrationRuntime.ts
@@ -1,0 +1,198 @@
+import * as FileSystem from 'expo-file-system/legacy'
+
+import {
+  getBibleVersionMetadata,
+  getInstalledVersions,
+  removeBibleVersion,
+} from '~helpers/biblesDb'
+import { getLanguage } from '~i18n'
+import {
+  createInterlinearSidecarDownloadPlan,
+  createOfflineCopyDownloadItem,
+  createStrongSidecarDownloadPlan,
+} from '~helpers/downloadItemFactory'
+import { installManagedResource } from '~helpers/managedResourceInstallation'
+import { getDownloadItemIdentity, type DownloadItem } from '~helpers/offlineCopy'
+import type { OfflineCopyIdentity } from '~helpers/offlineCopyId'
+import { BHG_INTERLINEAR_PUBLICATION } from '~helpers/interlinearBiblePublications'
+import { getInterlinearSidecarAvailability } from '~helpers/interlinearBibleSidecar'
+import { migrateLegacyDownloadQueue } from '~helpers/legacyBibleVersionMigration'
+import { storage } from '~helpers/storage'
+import { getStrongBiblePublication } from '~helpers/strongBiblePublications'
+import { getStrongBibleSidecarAvailability } from '~helpers/strongBibleSidecar'
+import { createStrongLexiconModuleDownloadItem } from '~helpers/strongLexiconDownloadItems'
+import { getStrongLexiconModuleAvailability } from '~helpers/strongLexiconModules'
+
+import {
+  createLegacyResourceMigration,
+  type LegacyReplacementResource,
+  type LegacyResourceIdentity,
+} from './legacyResourceMigration'
+import {
+  LEGACY_PUBLICATION_CANDIDATES,
+  LEGACY_REFERENCE_EVIDENCE_KEY,
+  getLegacyResourceFileCandidates,
+  inspectLegacyResourceEvidence,
+  resetLegacyReferenceEvidenceCaptureState,
+} from './legacyResourceEvidence'
+import {
+  isPersistedCanonicalTabWorkspace,
+  migrateLegacyPersistedReferences,
+} from './legacyPersistedReferences'
+
+const CLEANUP_MARKER_KEY = 'hasCleanedLegacyBibleResourcesV1'
+
+const toReplacementResource = (item: DownloadItem): LegacyReplacementResource => ({
+  identity: getDownloadItemIdentity(item),
+  estimatedSize: item.estimatedSize,
+  label: item.name,
+})
+
+const resolveReplacementPlan = async (
+  request: OfflineCopyIdentity
+): Promise<LegacyReplacementResource[]> => {
+  switch (request.kind) {
+    case 'strong-bible-index': {
+      const [availability, isCanonicalReady] = await Promise.all([
+        getStrongBibleSidecarAvailability(request.versionId),
+        isCanonicalBibleReady(request.versionId),
+      ])
+      if (availability.status === 'available' && isCanonicalReady) return []
+      return createStrongSidecarDownloadPlan(
+        request.versionId,
+        isCanonicalReady ? availability.status : 'base-incompatible'
+      ).map(toReplacementResource)
+    }
+    case 'interlinear-index': {
+      const [availability, isCanonicalReady] = await Promise.all([
+        getInterlinearSidecarAvailability(request.language),
+        isCanonicalBibleReady('BHG'),
+      ])
+      if (availability.status === 'available' && isCanonicalReady) return []
+      return createInterlinearSidecarDownloadPlan(
+        request.language,
+        isCanonicalReady ? availability.status : 'base-incompatible'
+      ).map(toReplacementResource)
+    }
+    case 'strong-lexicon-module': {
+      const availability = await getStrongLexiconModuleAvailability(request.moduleId)
+      return availability.status === 'available'
+        ? []
+        : [toReplacementResource(createStrongLexiconModuleDownloadItem(request.moduleId))]
+    }
+    default:
+      throw new Error(`LEGACY_REPLACEMENT_REQUEST_UNSUPPORTED:${request.kind}`)
+  }
+}
+
+const isCanonicalBibleReady = async (versionId: string): Promise<boolean> => {
+  const metadata = await getBibleVersionMetadata(versionId)
+  if (!metadata) return false
+  if (versionId === 'BHG') {
+    return (
+      metadata.textRevision === BHG_INTERLINEAR_PUBLICATION.canonical.textRevision &&
+      metadata.textSha256 === BHG_INTERLINEAR_PUBLICATION.canonical.textSha256
+    )
+  }
+  if (versionId === 'LSG' || versionId === 'KJV') {
+    const publication = getStrongBiblePublication(versionId)
+    return (
+      metadata.textRevision === publication.canonical.textRevision &&
+      metadata.textSha256 === publication.canonical.textSha256
+    )
+  }
+  return false
+}
+
+const isReplacementReady = async (identity: OfflineCopyIdentity): Promise<boolean> => {
+  switch (identity.kind) {
+    case 'bible':
+      return isCanonicalBibleReady(identity.versionId)
+    case 'strong-bible-index':
+      return (await getStrongBibleSidecarAvailability(identity.versionId)).status === 'available'
+    case 'interlinear-index':
+      return (await getInterlinearSidecarAvailability(identity.language)).status === 'available'
+    case 'strong-lexicon-module':
+      return (await getStrongLexiconModuleAvailability(identity.moduleId)).status === 'available'
+    default:
+      return false
+  }
+}
+
+const installReplacement = async (
+  identity: OfflineCopyIdentity,
+  reportProgress: (update: { progress: number; message?: string }) => void
+): Promise<void> => {
+  const item = createOfflineCopyDownloadItem(identity)
+  await installManagedResource(item, {
+    onDownloadProgress: progress =>
+      reportProgress({ progress: progress * 0.8, message: 'migration.download' }),
+    onInsertProgress: progress =>
+      reportProgress({ progress: 0.8 + progress * 0.2, message: 'migration.install' }),
+    onStatusInserting: () => reportProgress({ progress: 0.8, message: 'migration.install' }),
+    onResumable: () => {},
+    isCancelled: () => false,
+  })
+}
+
+const cleanupPathsForIdentity = async (identity: LegacyResourceIdentity): Promise<void> => {
+  const documentDirectory = FileSystem.documentDirectory ?? ''
+  const candidates = [
+    ...getLegacyResourceFileCandidates(documentDirectory, 'fr'),
+    ...getLegacyResourceFileCandidates(documentDirectory, 'en'),
+  ].filter(candidate => candidate.identity === identity)
+  const paths = [...new Set(candidates.map(candidate => candidate.path))]
+  await Promise.all(paths.map(path => FileSystem.deleteAsync(path, { idempotent: true })))
+}
+
+const cleanupLegacyIdentity = async (identity: LegacyResourceIdentity): Promise<void> => {
+  await cleanupPathsForIdentity(identity)
+  if (identity !== 'STRONG') {
+    const installedVersions = await getInstalledVersions()
+    if (installedVersions.includes(identity)) await removeBibleVersion(identity)
+  }
+}
+
+const finalizeCleanup = async (): Promise<void> => {
+  const persistedQueue = storage.getString('downloadQueue')
+  if (typeof persistedQueue !== 'undefined') {
+    storage.set('downloadQueue', migrateLegacyDownloadQueue(persistedQueue))
+  }
+  for (const publication of LEGACY_PUBLICATION_CANDIDATES) {
+    storage.remove(publication.key)
+  }
+  storage.remove(LEGACY_REFERENCE_EVIDENCE_KEY)
+  const persistedTabGroups = storage.getString('tabGroupsAtom')
+  if (persistedTabGroups) {
+    try {
+      if (isPersistedCanonicalTabWorkspace(JSON.parse(persistedTabGroups) as unknown)) {
+        storage.remove('tabsAtom')
+        storage.remove('activeTabIndexAtomOriginal')
+      }
+    } catch {
+      // Preserve historical tab state until the canonical workspace is safely persisted.
+    }
+  }
+  resetLegacyReferenceEvidenceCaptureState()
+  storage.set(CLEANUP_MARKER_KEY, true)
+}
+
+export const legacyResourceMigration = createLegacyResourceMigration({
+  inspectEvidence: () =>
+    inspectLegacyResourceEvidence({
+      documentDirectory: FileSystem.documentDirectory ?? '',
+      rootLanguage: getLanguage(),
+      storage,
+      getInstalledBibleVersions: getInstalledVersions,
+      getFileInfo: async path => {
+        const info = await FileSystem.getInfoAsync(path)
+        return { exists: info.exists, ...(info.exists ? { size: info.size } : {}) }
+      },
+    }),
+  resolveReplacementPlan,
+  isReplacementReady,
+  installReplacement,
+  migratePersistedReferences: async () => migrateLegacyPersistedReferences(storage),
+  cleanupLegacyIdentity,
+  finalizeCleanup,
+})

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,6 +6,7 @@ import {
   getStoredState,
   type PersistConfig,
 } from 'redux-persist'
+import type { PersistedState } from 'redux-persist/es/types'
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2'
 import FilesystemStorage from 'redux-persist-filesystem-storage'
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin'
@@ -16,7 +17,8 @@ import migrations from './migrations'
 import { applyPreferredColorScheme, themeAppearanceMiddleware } from './themeAppearanceMiddleware'
 
 import reducer from '~redux/modules/reducer'
-import { mmkvStorage } from '~helpers/storage'
+import { mmkvStorage, storage } from '~helpers/storage'
+import { tryCaptureLegacyReferenceEvidenceFromReduxState } from '../migrations/legacyResourceEvidence'
 
 type RootReducerState = ReturnType<typeof reducer>
 type HotModule = NodeJS.Module & {
@@ -42,10 +44,11 @@ function configureStore() {
 
   // MMKV migration
   persistConfig.getStoredState = async config => {
-    const storedState = getStoredState(config).catch(err => {
-      return getStoredState({ ...config, storage: FilesystemStorage })
-    })
-    return storedState as ReturnType<NonNullable<typeof persistConfig.getStoredState>>
+    const storedState = (await getStoredState(config).catch(() =>
+      getStoredState({ ...config, storage: FilesystemStorage })
+    )) as PersistedState
+    tryCaptureLegacyReferenceEvidenceFromReduxState(storedState, storage)
+    return storedState
   }
 
   const persistedReducer = persistReducer(persistConfig, reducer)

--- a/src/state/tabs.ts
+++ b/src/state/tabs.ts
@@ -29,10 +29,12 @@ import type { InterlinearMode } from '~helpers/interlinearBiblePublications'
 import type { ResourceLanguage } from '~helpers/databaseTypes'
 import type { PendingBibleModeAcquisition } from '~helpers/bibleModeAcquisition'
 import {
+  getLegacyBibleTabReferenceVersionIds,
   migrateLegacyBibleTabData,
   migrateLegacyBibleVersionId,
   migrateLegacyParallelVersions,
 } from '~helpers/legacyBibleVersionMigration'
+import { tryRecordLegacyReferenceEvidence } from '../migrations/legacyResourceEvidence'
 
 // ============================================================================
 // SHARED BIBLE DOM (single WebView instance for all Bible tabs)
@@ -411,6 +413,7 @@ const migrateTabsToRemovable = (tabs: TabItem[]): TabItem[] => {
     // First migrate old tab types
     tab = migrateTabTypes(tab)
     if (tab.type === 'bible') {
+      tryRecordLegacyReferenceEvidence(getLegacyBibleTabReferenceVersionIds(tab.data), storage)
       const migratedData = migrateLegacyBibleTabData(
         tab.data as BibleTab['data'] & { selectedVersion: string }
       )
@@ -427,6 +430,12 @@ const migrateTabsToRemovable = (tabs: TabItem[]): TabItem[] => {
         },
       }
     } else if (tab.type === 'strong') {
+      tryRecordLegacyReferenceEvidence(
+        [tab.data.strongBibleVersionId, tab.data.bibleVersion].filter(
+          (versionId): versionId is string => typeof versionId === 'string'
+        ),
+        storage
+      )
       tab = {
         ...tab,
         data: {
@@ -478,19 +487,16 @@ const migrateTabGroups = (groups: TabGroup[]): TabGroup[] => {
       const oldTabs = JSON.parse(oldTabsJson) as TabItem[]
       if (oldTabs.length > 0) {
         const activeIndex = oldActiveIndexJson ? JSON.parse(oldActiveIndexJson) : 0
+        const migratedTabs = migrateTabsToRemovable(oldTabs)
 
         console.log('[TabGroups] Migrating', oldTabs.length, 'tabs from old storage')
-
-        // Delete old storage keys after successful migration
-        storage.remove('tabsAtom')
-        storage.remove('activeTabIndexAtomOriginal')
 
         return [
           {
             id: DEFAULT_GROUP_ID,
             name: i18n.t('Principal'),
             isDefault: true,
-            tabs: migrateTabsToRemovable(oldTabs),
+            tabs: migratedTabs,
             activeTabIndex: Math.min(activeIndex, oldTabs.length - 1),
             createdAt: 0,
             updatedAt: 0,
@@ -531,7 +537,10 @@ export const savedParallelVersionsAtom = atomWithAsyncStorage<VersionCode[]>(
   'savedParallelVersions',
   [],
   {
-    migrate: versions => migrateLegacyParallelVersions(versions) as VersionCode[],
+    migrate: versions => {
+      tryRecordLegacyReferenceEvidence(versions, storage)
+      return migrateLegacyParallelVersions(versions) as VersionCode[]
+    },
   }
 )
 


### PR DESCRIPTION
## Summary

- detect obsolete LSGS, KJVS, INT, INT_EN and historical Strong resources from persisted references, files, SQLite rows, publication metadata and queued downloads
- build a deterministic, deduplicated replacement plan for canonical Bibles, per-Bible Strong sidecars, localized BHG interlinear indexes and the modular Strong core lexicon
- reuse the validated atomic resource installer, preserve resumability, and restrict terminal cleanup to explicit legacy paths and metadata
- migrate persisted Bible identities while keeping Strong/interlinear modes disabled until compatible replacement sidecars are available

## Safety

- no cleanup occurs before a terminal migration outcome
- compatible replacements are detected before download and revalidated after installation
- temporary, backup and SQLite companion files are included in the legacy allowlist
- canonical Bible storage, current sidecars, localized indexes, modular lexicon files and user-created data are excluded from cleanup

## Validation

- `yarn test --runInBand --watchman=false` (163 suites, 1142 tests)
- `yarn typecheck`
- targeted ESLint and Prettier checks
- `yarn agents:architecture:check`
- `yarn agents:quality:check`

Stacked on #277.

Part of #274.
