### PR TITLE
#303 Publish and serve every Strong Bible index locally

### DIFF
--- a/docs/agents/architecture-lint.md
+++ b/docs/agents/architecture-lint.md
@@ -178,7 +178,7 @@ This is a repo-specific architecture scan for agent work. It is intentionally co
 - WARNING `raw-console` src/features/plans/plan.hooks.ts:340 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/profile/components/DeleteAccountModal.tsx:14 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/profile/components/DeleteAccountModal.tsx:59 - Prefer appLogger for app-owned diagnostic events that agents should query.
-- WARNING `raw-console` src/features/resources/bibleContentAccess.ts:227 - Prefer appLogger for app-owned diagnostic events that agents should query.
+- WARNING `raw-console` src/features/resources/bibleContentAccess.ts:251 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `feature-firebase-boundary` src/features/resources/commentaryAccess.ts:5 - Feature code should prefer a local helper/hook boundary over direct Firebase access.
 - WARNING `raw-console` src/features/search/SQLiteSearchScreen.tsx:396 - Prefer appLogger for app-owned diagnostic events that agents should query.
 - WARNING `raw-console` src/features/settings/AutomaticBackupsScreen.tsx:62 - Prefer appLogger for app-owned diagnostic events that agents should query.

--- a/docs/agents/quality-score.md
+++ b/docs/agents/quality-score.md
@@ -28,7 +28,7 @@ This report is a directional agent-readability score, not a product quality verd
 | `plans` | 9/10 | 30 | 2 | yes | no | 2 eslint-disable markers |
 | `playground` | 8/10 | 3 | 1 | no | no | no mapped smoke path; no feature README |
 | `profile` | 5/10 | 9 | 0 | no | yes | no colocated feature tests; no mapped smoke path; no feature README; sensitive user/account surface |
-| `resources` | 8/10 | 21 | 15 | no | no | no mapped smoke path; no feature README |
+| `resources` | 8/10 | 22 | 16 | no | no | no mapped smoke path; no feature README |
 | `search` | 9/10 | 15 | 2 | yes | no | 2 eslint-disable markers |
 | `settings` | 8/10 | 37 | 4 | yes | yes | 1 eslint-disable markers; sensitive user/account surface |
 | `studies` | 7/10 | 37 | 3 | no | no | no mapped smoke path; 18 console calls; 2 eslint-disable markers |

--- a/docs/agents/resource-coverage-matrix.md
+++ b/docs/agents/resource-coverage-matrix.md
@@ -15,7 +15,7 @@ search ranking or routing.
 | `bible-text:<version>` | `bibleContent`, `bibleReading`, `bibleSearch` | `LSG`: remotely readable through `/v1/bibles/...` including ordered coverage; remote full-text search is not part of this first slice; other versions are unsupported for now | Bible SQLite archive, removable even when selected/default | Reader, book/chapter navigation, version selector, comparison, search, export, audio helpers | Resource model, hybrid source/coverage, queries, complete LSG API/presentation parity, version catalogue |
 | `bible-presentation:<version>:pericope` | `bibleReading` | Unsupported for now | Pericope sidecar, independent from canonical Bible text | Pericope reader, passage navigation | Identity/offline-copy mapping and Bible reading tests |
 | `bible-presentation:<version>:red-words` | `bibleReading` | Unsupported for now | Red-word sidecar, independent from canonical Bible text | Bible reader and export | Identity/offline-copy mapping and Bible reading tests |
-| `strong-bible-index:<version>` | `strongBible`, `lexiconBible` | Unsupported for now | Strong index sidecar, independently downloadable/removable | Strong mode selector, concordance, verse detail, lexicon source selector | Strong Bible and lexicon Bible adapter suites |
+| `strong-bible-index:<version>` | `strongBible`, `lexiconBible` | All 12 cataloged versions: remotely readable through `/v1/strong-bibles/...` when the index and its exact Bible revision and text SHA-256 are active | Strong index sidecar, independently downloadable/removable; installed copy wins | Strong mode selector, concordance, verse detail, lexicon source selector | Publication/archive parity, atomic PostgreSQL import, typed API, hybrid HTTP/SQLite source selection, failure/recovery/removal, and existing managed download/update suites |
 | `interlinear-index:BHG:<language>` | `strongBible`, `lexiconBible` | Unsupported for now | BHG interlinear sidecar for FR/EN | Interlinear selector and Strong verse display | Resource model plus Strong/lexicon adapter suites |
 | `strong-lexicon:<module>` | `strongLexicon` | Unsupported for now | Core, resources, and entity modules remain independent | Lexicon list/detail, Strong entry routes, relation graph | Strong lexicon adapter and route tests |
 | `dictionary:<language>` | `dictionary` | Unsupported for now | FR/EN dictionary database | Dictionary list/detail and verse cards | Dictionary adapter/query tests and architecture guard |
@@ -41,7 +41,7 @@ search ranking or routing.
 | Valid Offline copy, with or without network | Read the installed copy. Online content never silently replaces the installed revision. |
 | Search while connected, once remote search exists | Query the remote search service first, even when a local index is installed; fall back locally on a temporary remote failure. |
 | Search while disconnected | Query the installed local index first; if none exists, show the shared unavailable state without offering an impossible transfer. |
-| No Offline copy, online operation supported and connected | Read Online content. LSG chapter text/coverage and NAVE_FR topic operations are implemented. |
+| No Offline copy, online operation supported and connected | Read Online content. LSG chapter text/coverage, all cataloged Strong Bible index operations, and NAVE_FR topic operations are implemented. |
 | No Offline copy, Online operation not implemented, connected | Keep the feature open and explain that an Offline copy is needed for now; offer **Make available offline**. |
 | No Offline copy and disconnected | Keep the feature open, explain that reconnection is required, and disable the transfer action. |
 | Download queued while connectivity disappears | Keep the item queued without consuming retries; resume processing after reconnection. |
@@ -65,6 +65,9 @@ never become a download button merely because the check returned no data.
   provenance, rights, independent canonical/SQLite checksums, and delivery capabilities.
 - NAVE_FR import and repository integration tests exercise atomic activation, lookup,
   alphabetical browse, temporary domain search, verse-linked topics, and random topic selection.
+- Strong Bible publication tests preserve token identity, alignment, morphology token links, lexical
+  references, dependency revisions, and canonical/SQLite counts. The complete-set gate requires all
+  12 Maker handoffs before import/API parity can pass.
 - Mobile adapter tests cover installed-copy priority, zero-copy HTTP, local not-found without source
   hopping, invalid local copy recovery, network-offline, inactive service, malformed content, and
   unsupported English remote access. Existing managed installation/removal suites cover the shared

--- a/docs/agents/validation.md
+++ b/docs/agents/validation.md
@@ -27,6 +27,7 @@ Copy `.env.example` to the appropriate local environment file and fill required 
 | Resource unit tests | `yarn resources:test` | Bundle, importer, API, repository, or runtime changes |
 | Resource Postgres integration | `yarn resources:test:integration` | Schema, migrations, importer, or persistence changes |
 | Complete LSG parity | `yarn resources:test:lsg` | Publication, API response, or Bible presentation changes |
+| Complete Strong Bible parity | `RESOURCE_STRONG_BIBLE_BUNDLES_ROOT=/absolute/path yarn resources:test:strong` | Strong publication, importer, API, or sidecar changes |
 
 `yarn agents:architecture:check` regenerates `docs/agents/architecture-lint.md` and `.scratch/architecture/architecture.json`, then fails on high-risk boundary errors. Warnings are intentionally non-blocking for the current brownfield baseline.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "resources:test:integration": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/*/__tests__/*.integration.node-test.ts",
     "resources:test:lsg": "RESOURCE_LSG_BUNDLE=resource-service/.local/publications/lsg tsx --test --test-concurrency=1 resource-service/src/*/__tests__/*completeLsg*.integration.node-test.ts",
     "resources:test:bibles": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/publication/__tests__/completeOrdinaryBiblePublications.integration.node-test.ts",
+    "resources:test:strong": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/publication/__tests__/completeStrongBiblePublications.integration.node-test.ts",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/README.md
+++ b/resource-service/README.md
@@ -30,16 +30,22 @@ not generate its manifest, editorial metadata, or Offline-copy artifact:
 yarn resources:bundle:validate --bundle /absolute/path/to/bible-lexicon-maker/lsg-bundle
 ```
 
-The accepted schema-v1 bundle represents exactly one `bible-text` or `nave` identity and immutable
-revision.
+The accepted schema-v1 bundle represents exactly one `bible-text`, `strong-bible-index`, or `nave`
+identity and immutable revision.
 It contains:
 
 - `manifest.json`, with identity, language, revision, provenance, independent delivery capabilities,
   rights, domain coverage, counts, format versions, sizes, and SHA-256 checksums;
 - `canonical/*.json`, used by the PostgreSQL importer;
 - `offline/*.zip`, the matching Offline-copy artifact delivered to the app. Bible bundles contain
-  the canonical JSON; Nave bundles contain the generated SQLite database used by existing mobile
-  surfaces.
+  the canonical JSON; Strong Bible and Nave bundles contain the generated SQLite database used by
+  existing mobile surfaces.
+
+A Strong Bible manifest declares its matching `bible-text:<version>` revision and text SHA-256 as
+required in both Online and Offline-copy modes. It also declares the Strong lexicon modules required
+for lexical details. Validation compares every identity, span offset, alignment flag, morphology
+token link, lexeme assignment, and aggregate count between canonical JSON and the archived SQLite
+sidecar.
 
 The NAVE_FR archive entry is `nave-fr.sqlite`. In addition to the existing `TOPICS` and `VERSES`
 tables, publication copies contain one `RESOURCE_METADATA` row with `resource_id`, `revision`,
@@ -63,6 +69,7 @@ yarn resources:migrate
 yarn resources:import --bundle resource-service/.local/publications/lsg
 yarn resources:import --bundle resource-service/.local/publications/nave-fr
 yarn resources:import-all --root /path/to/ordinary-bible-publications-current
+yarn resources:import-all --root /path/to/strong-bible-publications-current
 ```
 
 `import-all` is the explicit local-development path: it activates publications whose manifest sets
@@ -73,11 +80,17 @@ Reimporting the same revision and checksums returns `unchanged`. Reusing a revis
 content fails. Validation failures or Effect interruption roll back staging and preserve the prior
 active publication.
 
-The local Effect HttpApi exposes Bible reading plus the Nave operations consumed by the app:
+The local Effect HttpApi exposes Bible reading, Strong Bible indexes, and the Nave operations
+consumed by the app:
 
 - `GET /v1/bibles/:version/books/:book/chapters/:chapter`
 - `GET /v1/bibles/:version/coverage`
 - `GET /v1/bibles/:version/pericopes`
+- `GET /v1/strong-bibles/:version/coverage`
+- `GET /v1/strong-bibles/:version/books/:book/chapters/:chapter`
+- `GET /v1/strong-bibles/:version/books/:book/identities/:reference/counts`
+- `GET /v1/strong-bibles/:version/books/:book/identities/:reference/occurrences`
+- `GET /v1/strong-bibles/:version/books/:book/identities/:reference/lemmas`
 - `GET /v1/naves/:language/topics/:normalizedName`
 - `GET /v1/naves/:language/topics?initial=:initial`
 - `GET /v1/naves/:language/topics?search=:search`
@@ -85,7 +98,10 @@ The local Effect HttpApi exposes Bible reading plus the Nave operations consumed
 - `GET /v1/naves/:language/random`
 
 Only `nave:fr` (`NAVE_FR`) is remotely readable in this tracer. English Nave remains available
-through its existing optional Offline copy.
+through its existing optional Offline copy. All 12 cataloged Strong Bible versions are remotely
+readable when their validated index publication and the exact declared Bible text revision and
+SHA-256 are active. An active index with a missing or mismatched Bible publication is deliberately
+unavailable.
 
 ## Verification
 
@@ -93,11 +109,16 @@ through its existing optional Offline copy.
 yarn resources:test
 yarn resources:test:integration
 yarn resources:test:lsg
+yarn resources:test:strong
 yarn resources:architecture:check
 ```
 
 `resources:test:lsg` compares all 66 books, 1,189 chapters, 31,171 verses, and every presentation
 value in the complete local LSG bundle with the active PostgreSQL publication.
+
+`resources:test:strong` reads `RESOURCE_STRONG_BIBLE_BUNDLES_ROOT`, requires exactly the 12 mobile
+catalog identities, validates canonical/archive parity, imports each domain atomically, and queries
+chapter coverage and spans. The suite is skipped when the external Maker handoff path is absent.
 
 ## Mobile development URL
 

--- a/resource-service/drizzle/0003_massive_fenris.sql
+++ b/resource-service/drizzle/0003_massive_fenris.sql
@@ -1,0 +1,62 @@
+CREATE TABLE "strong_bible_identities" (
+	"publication_id" integer NOT NULL,
+	"identity_id" integer NOT NULL,
+	"kind" text NOT NULL,
+	"code" text NOT NULL,
+	CONSTRAINT "strong_bible_identities_publication_id_primary" PRIMARY KEY("publication_id","identity_id")
+);
+--> statement-breakpoint
+CREATE TABLE "strong_bible_lexemes" (
+	"publication_id" integer NOT NULL,
+	"lexeme_id" integer NOT NULL,
+	"lemma" text NOT NULL,
+	"part_of_speech" text NOT NULL,
+	CONSTRAINT "strong_bible_lexemes_publication_id_primary" PRIMARY KEY("publication_id","lexeme_id")
+);
+--> statement-breakpoint
+CREATE TABLE "strong_bible_span_identities" (
+	"publication_id" integer NOT NULL,
+	"book" integer NOT NULL,
+	"chapter" integer NOT NULL,
+	"verse" integer NOT NULL,
+	"ordinal" integer NOT NULL,
+	"identity_order" integer NOT NULL,
+	"identity_id" integer NOT NULL,
+	CONSTRAINT "strong_bible_span_identities_publication_location_primary" PRIMARY KEY("publication_id","book","chapter","verse","ordinal","identity_order")
+);
+--> statement-breakpoint
+CREATE TABLE "strong_bible_spans" (
+	"publication_id" integer NOT NULL,
+	"book" integer NOT NULL,
+	"chapter" integer NOT NULL,
+	"verse" integer NOT NULL,
+	"ordinal" integer NOT NULL,
+	"start_offset" integer NOT NULL,
+	"length" integer NOT NULL,
+	"is_aligned" boolean NOT NULL,
+	"lexeme_id" integer,
+	"step_token_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	CONSTRAINT "strong_bible_spans_publication_location_primary" PRIMARY KEY("publication_id","book","chapter","verse","ordinal")
+);
+--> statement-breakpoint
+CREATE TABLE "strong_bible_verses" (
+	"publication_id" integer NOT NULL,
+	"book" integer NOT NULL,
+	"chapter" integer NOT NULL,
+	"verse" integer NOT NULL,
+	CONSTRAINT "strong_bible_verses_publication_location_primary" PRIMARY KEY("publication_id","book","chapter","verse")
+);
+--> statement-breakpoint
+ALTER TABLE "strong_bible_identities" ADD CONSTRAINT "strong_bible_identities_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_lexemes" ADD CONSTRAINT "strong_bible_lexemes_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_span_identities" ADD CONSTRAINT "strong_bible_span_identities_span_fk" FOREIGN KEY ("publication_id","book","chapter","verse","ordinal") REFERENCES "public"."strong_bible_spans"("publication_id","book","chapter","verse","ordinal") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_span_identities" ADD CONSTRAINT "strong_bible_span_identities_identity_fk" FOREIGN KEY ("publication_id","identity_id") REFERENCES "public"."strong_bible_identities"("publication_id","identity_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_spans" ADD CONSTRAINT "strong_bible_spans_verse_fk" FOREIGN KEY ("publication_id","book","chapter","verse") REFERENCES "public"."strong_bible_verses"("publication_id","book","chapter","verse") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_spans" ADD CONSTRAINT "strong_bible_spans_lexeme_fk" FOREIGN KEY ("publication_id","lexeme_id") REFERENCES "public"."strong_bible_lexemes"("publication_id","lexeme_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "strong_bible_verses" ADD CONSTRAINT "strong_bible_verses_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "strong_bible_identities_code_unique" ON "strong_bible_identities" USING btree ("publication_id","kind","code");--> statement-breakpoint
+CREATE INDEX "strong_bible_lexemes_label_lookup" ON "strong_bible_lexemes" USING btree ("publication_id","lemma","part_of_speech");--> statement-breakpoint
+CREATE INDEX "strong_bible_span_identities_lookup" ON "strong_bible_span_identities" USING btree ("publication_id","identity_id","book","chapter","verse");--> statement-breakpoint
+CREATE INDEX "strong_bible_spans_chapter_lookup" ON "strong_bible_spans" USING btree ("publication_id","book","chapter","verse","ordinal");--> statement-breakpoint
+CREATE INDEX "strong_bible_spans_lexeme_lookup" ON "strong_bible_spans" USING btree ("publication_id","lexeme_id");--> statement-breakpoint
+CREATE INDEX "strong_bible_verses_chapter_lookup" ON "strong_bible_verses" USING btree ("publication_id","book","chapter","verse");

--- a/resource-service/drizzle/meta/0003_snapshot.json
+++ b/resource-service/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1099 @@
+{
+  "id": "e25550a7-e4a4-4af1-a96c-fd05f8efb783",
+  "prevId": "80320b19-efc4-4808-ac94-36f4e65be076",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bible_verses": {
+      "name": "bible_verses",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presentation": {
+          "name": "presentation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"startTags\":[],\"layout\":[],\"notes\":[],\"headings\":[]}'::jsonb"
+        }
+      },
+      "indexes": {
+        "bible_verses_chapter_lookup": {
+          "name": "bible_verses_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bible_verses_publication_id_resource_publications_id_fk": {
+          "name": "bible_verses_publication_id_resource_publications_id_fk",
+          "tableFrom": "bible_verses",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bible_verses_publication_location_primary": {
+          "name": "bible_verses_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nave_topics": {
+      "name": "nave_topics",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial": {
+          "name": "initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nave_topics_browse": {
+          "name": "nave_topics_browse",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initial",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nave_topics_search": {
+          "name": "nave_topics_search",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nave_topics_publication_id_resource_publications_id_fk": {
+          "name": "nave_topics_publication_id_resource_publications_id_fk",
+          "tableFrom": "nave_topics",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "nave_topics_publication_name_primary": {
+          "name": "nave_topics_publication_name_primary",
+          "columns": [
+            "publication_id",
+            "normalized_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nave_verse_links": {
+      "name": "nave_verse_links",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_key": {
+          "name": "verse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nave_verse_links_verse_lookup": {
+          "name": "nave_verse_links_verse_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nave_verse_links_topic_lookup": {
+          "name": "nave_verse_links_topic_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nave_verse_links_publication_id_resource_publications_id_fk": {
+          "name": "nave_verse_links_publication_id_resource_publications_id_fk",
+          "tableFrom": "nave_verse_links",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nave_verse_links_topic_fk": {
+          "name": "nave_verse_links_topic_fk",
+          "tableFrom": "nave_verse_links",
+          "tableTo": "nave_topics",
+          "columnsFrom": [
+            "publication_id",
+            "normalized_name"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "normalized_name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "nave_verse_links_publication_verse_topic_primary": {
+          "name": "nave_verse_links_publication_verse_topic_primary",
+          "columns": [
+            "publication_id",
+            "verse_key",
+            "normalized_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_publications": {
+      "name": "resource_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "resource_publications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "resource_identity": {
+          "name": "resource_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_kind": {
+          "name": "resource_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "canonical_sha256": {
+          "name": "canonical_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offline_artifact_sha256": {
+          "name": "offline_artifact_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "resource_publications_identity_revision_unique": {
+          "name": "resource_publications_identity_revision_unique",
+          "columns": [
+            {
+              "expression": "resource_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_publications_one_active_identity": {
+          "name": "resource_publications_one_active_identity",
+          "columns": [
+            {
+              "expression": "resource_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resource_publications\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_identities": {
+      "name": "strong_bible_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_identities_code_unique": {
+          "name": "strong_bible_identities_code_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_identities_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_identities_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_identities",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_identities_publication_id_primary": {
+          "name": "strong_bible_identities_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "identity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_lexemes": {
+      "name": "strong_bible_lexemes",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lexeme_id": {
+          "name": "lexeme_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_lexemes_label_lookup": {
+          "name": "strong_bible_lexemes_label_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lemma",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "part_of_speech",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_lexemes_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_lexemes_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_lexemes",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_lexemes_publication_id_primary": {
+          "name": "strong_bible_lexemes_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "lexeme_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_span_identities": {
+      "name": "strong_bible_span_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_order": {
+          "name": "identity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_span_identities_lookup": {
+          "name": "strong_bible_span_identities_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_span_identities_span_fk": {
+          "name": "strong_bible_span_identities_span_fk",
+          "tableFrom": "strong_bible_span_identities",
+          "tableTo": "strong_bible_spans",
+          "columnsFrom": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_span_identities_identity_fk": {
+          "name": "strong_bible_span_identities_identity_fk",
+          "tableFrom": "strong_bible_span_identities",
+          "tableTo": "strong_bible_identities",
+          "columnsFrom": [
+            "publication_id",
+            "identity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "identity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_span_identities_publication_location_primary": {
+          "name": "strong_bible_span_identities_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal",
+            "identity_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_spans": {
+      "name": "strong_bible_spans",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_aligned": {
+          "name": "is_aligned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lexeme_id": {
+          "name": "lexeme_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_token_ids": {
+          "name": "step_token_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "strong_bible_spans_chapter_lookup": {
+          "name": "strong_bible_spans_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "strong_bible_spans_lexeme_lookup": {
+          "name": "strong_bible_spans_lexeme_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lexeme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_spans_verse_fk": {
+          "name": "strong_bible_spans_verse_fk",
+          "tableFrom": "strong_bible_spans",
+          "tableTo": "strong_bible_verses",
+          "columnsFrom": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_spans_lexeme_fk": {
+          "name": "strong_bible_spans_lexeme_fk",
+          "tableFrom": "strong_bible_spans",
+          "tableTo": "strong_bible_lexemes",
+          "columnsFrom": [
+            "publication_id",
+            "lexeme_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "lexeme_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_spans_publication_location_primary": {
+          "name": "strong_bible_spans_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_verses": {
+      "name": "strong_bible_verses",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_verses_chapter_lookup": {
+          "name": "strong_bible_verses_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_verses_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_verses_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_verses",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_verses_publication_location_primary": {
+          "name": "strong_bible_verses_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.resource_publication_status": {
+      "name": "resource_publication_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "active"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/resource-service/drizzle/meta/_journal.json
+++ b/resource-service/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1786906757064,
       "tag": "0002_amazing_katie_power",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786918964631,
+      "tag": "0003_massive_fenris",
+      "breakpoints": true
     }
   ]
 }

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import {
+  boolean,
   index,
   foreignKey,
   integer,
@@ -133,5 +134,169 @@ export const naveVerseLinks = pgTable(
     }).onDelete('cascade'),
     index('nave_verse_links_verse_lookup').on(table.publication_id, table.verse_key),
     index('nave_verse_links_topic_lookup').on(table.publication_id, table.normalized_name),
+  ]
+)
+
+export const strongBibleVerses = pgTable(
+  'strong_bible_verses',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    book: integer('book').notNull(),
+    chapter: integer('chapter').notNull(),
+    verse: integer('verse').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'strong_bible_verses_publication_location_primary',
+      columns: [table.publication_id, table.book, table.chapter, table.verse],
+    }),
+    index('strong_bible_verses_chapter_lookup').on(
+      table.publication_id,
+      table.book,
+      table.chapter,
+      table.verse
+    ),
+  ]
+)
+
+export const strongBibleLexemes = pgTable(
+  'strong_bible_lexemes',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    lexeme_id: integer('lexeme_id').notNull(),
+    lemma: text('lemma').notNull(),
+    part_of_speech: text('part_of_speech').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'strong_bible_lexemes_publication_id_primary',
+      columns: [table.publication_id, table.lexeme_id],
+    }),
+    index('strong_bible_lexemes_label_lookup').on(
+      table.publication_id,
+      table.lemma,
+      table.part_of_speech
+    ),
+  ]
+)
+
+export const strongBibleIdentities = pgTable(
+  'strong_bible_identities',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    identity_id: integer('identity_id').notNull(),
+    kind: text('kind').notNull(),
+    code: text('code').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'strong_bible_identities_publication_id_primary',
+      columns: [table.publication_id, table.identity_id],
+    }),
+    uniqueIndex('strong_bible_identities_code_unique').on(
+      table.publication_id,
+      table.kind,
+      table.code
+    ),
+  ]
+)
+
+export const strongBibleSpans = pgTable(
+  'strong_bible_spans',
+  {
+    publication_id: integer('publication_id').notNull(),
+    book: integer('book').notNull(),
+    chapter: integer('chapter').notNull(),
+    verse: integer('verse').notNull(),
+    ordinal: integer('ordinal').notNull(),
+    start_offset: integer('start_offset').notNull(),
+    length: integer('length').notNull(),
+    is_aligned: boolean('is_aligned').notNull(),
+    lexeme_id: integer('lexeme_id'),
+    step_token_ids: jsonb('step_token_ids').$type<number[]>().notNull().default([]),
+  },
+  table => [
+    primaryKey({
+      name: 'strong_bible_spans_publication_location_primary',
+      columns: [table.publication_id, table.book, table.chapter, table.verse, table.ordinal],
+    }),
+    foreignKey({
+      name: 'strong_bible_spans_verse_fk',
+      columns: [table.publication_id, table.book, table.chapter, table.verse],
+      foreignColumns: [
+        strongBibleVerses.publication_id,
+        strongBibleVerses.book,
+        strongBibleVerses.chapter,
+        strongBibleVerses.verse,
+      ],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'strong_bible_spans_lexeme_fk',
+      columns: [table.publication_id, table.lexeme_id],
+      foreignColumns: [strongBibleLexemes.publication_id, strongBibleLexemes.lexeme_id],
+    }).onDelete('cascade'),
+    index('strong_bible_spans_chapter_lookup').on(
+      table.publication_id,
+      table.book,
+      table.chapter,
+      table.verse,
+      table.ordinal
+    ),
+    index('strong_bible_spans_lexeme_lookup').on(table.publication_id, table.lexeme_id),
+  ]
+)
+
+export const strongBibleSpanIdentities = pgTable(
+  'strong_bible_span_identities',
+  {
+    publication_id: integer('publication_id').notNull(),
+    book: integer('book').notNull(),
+    chapter: integer('chapter').notNull(),
+    verse: integer('verse').notNull(),
+    ordinal: integer('ordinal').notNull(),
+    identity_order: integer('identity_order').notNull(),
+    identity_id: integer('identity_id').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'strong_bible_span_identities_publication_location_primary',
+      columns: [
+        table.publication_id,
+        table.book,
+        table.chapter,
+        table.verse,
+        table.ordinal,
+        table.identity_order,
+      ],
+    }),
+    foreignKey({
+      name: 'strong_bible_span_identities_span_fk',
+      columns: [table.publication_id, table.book, table.chapter, table.verse, table.ordinal],
+      foreignColumns: [
+        strongBibleSpans.publication_id,
+        strongBibleSpans.book,
+        strongBibleSpans.chapter,
+        strongBibleSpans.verse,
+        strongBibleSpans.ordinal,
+      ],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'strong_bible_span_identities_identity_fk',
+      columns: [table.publication_id, table.identity_id],
+      foreignColumns: [strongBibleIdentities.publication_id, strongBibleIdentities.identity_id],
+    }).onDelete('cascade'),
+    index('strong_bible_span_identities_lookup').on(
+      table.publication_id,
+      table.identity_id,
+      table.book,
+      table.chapter,
+      table.verse
+    ),
   ]
 )

--- a/resource-service/src/database/types.ts
+++ b/resource-service/src/database/types.ts
@@ -1,15 +1,35 @@
 import type { Kyselify } from 'drizzle-orm/kysely'
 
-import type { bibleVerses, naveTopics, naveVerseLinks, resourcePublications } from './schema'
+import type {
+  bibleVerses,
+  naveTopics,
+  naveVerseLinks,
+  resourcePublications,
+  strongBibleIdentities,
+  strongBibleLexemes,
+  strongBibleSpanIdentities,
+  strongBibleSpans,
+  strongBibleVerses,
+} from './schema'
 
 export type ResourcePublicationRow = Kyselify<typeof resourcePublications>
 export type BibleVerseRow = Kyselify<typeof bibleVerses>
 export type NaveTopicRow = Kyselify<typeof naveTopics>
 export type NaveVerseLinkRow = Kyselify<typeof naveVerseLinks>
+export type StrongBibleVerseRow = Kyselify<typeof strongBibleVerses>
+export type StrongBibleLexemeRow = Kyselify<typeof strongBibleLexemes>
+export type StrongBibleIdentityRow = Kyselify<typeof strongBibleIdentities>
+export type StrongBibleSpanRow = Kyselify<typeof strongBibleSpans>
+export type StrongBibleSpanIdentityRow = Kyselify<typeof strongBibleSpanIdentities>
 
 export type ResourceDatabase = {
   resource_publications: ResourcePublicationRow
   bible_verses: BibleVerseRow
   nave_topics: NaveTopicRow
   nave_verse_links: NaveVerseLinkRow
+  strong_bible_verses: StrongBibleVerseRow
+  strong_bible_lexemes: StrongBibleLexemeRow
+  strong_bible_identities: StrongBibleIdentityRow
+  strong_bible_spans: StrongBibleSpanRow
+  strong_bible_span_identities: StrongBibleSpanIdentityRow
 }

--- a/resource-service/src/domain/bibleChapter.ts
+++ b/resource-service/src/domain/bibleChapter.ts
@@ -21,6 +21,7 @@ export type BibleChapterLocation = {
 export type ActiveBibleChapter = BibleChapterLocation & {
   revision: string
   textRevision: string
+  textSha256?: string
   verses: readonly {
     number: number
     text: string
@@ -32,6 +33,7 @@ export type ActiveBibleCoverage = {
   versionId: string
   revision: string
   textRevision: string
+  textSha256?: string
   canon: { id: string; orderedBooks: readonly number[] }
   versification: string
   books: readonly number[]
@@ -43,6 +45,7 @@ export type ActiveBiblePericopeIndex = {
   versionId: string
   revision: string
   textRevision: string
+  textSha256?: string
   verses: readonly {
     book: number
     chapter: number
@@ -113,6 +116,7 @@ export const readBibleChapter = (
         versionId: chapter.versionId,
         revision: chapter.revision,
         textRevision: chapter.textRevision,
+        ...(chapter.textSha256 ? { textSha256: chapter.textSha256 } : {}),
       }),
       book: chapter.book,
       chapter: chapter.chapter,
@@ -146,6 +150,7 @@ export const readBibleCoverage = (
         versionId,
         revision: coverage.revision,
         textRevision: coverage.textRevision,
+        ...(coverage.textSha256 ? { textSha256: coverage.textSha256 } : {}),
       }),
       books: [...coverage.books],
       canon: { id: coverage.canon.id, orderedBooks: [...coverage.canon.orderedBooks] },
@@ -176,6 +181,7 @@ export const readBiblePericopes = (
         versionId,
         revision: index.revision,
         textRevision: index.textRevision,
+        ...(index.textSha256 ? { textSha256: index.textSha256 } : {}),
       }),
       verses: index.verses.map(verse => new BiblePericopeVerseDto(verse)),
     })

--- a/resource-service/src/domain/strongBible.ts
+++ b/resource-service/src/domain/strongBible.ts
@@ -1,0 +1,225 @@
+import { Context, Data, Effect } from 'effect'
+
+import {
+  StrongBibleBookCountDto,
+  StrongBibleChapterDto,
+  StrongBibleChapterVerseDto,
+  StrongBibleCountsDto,
+  StrongBibleCoverageDto,
+  StrongBibleIdentityDto,
+  StrongBibleLemmaStatDto,
+  StrongBibleLemmaStatsDto,
+  StrongBibleOccurrencesDto,
+  StrongBibleOccurrenceVerseDto,
+  StrongBibleRevisionDto,
+  StrongBibleSpanDto,
+} from '../../../src/features/resources/strongBibleContract'
+import type { StrongBibleSpan } from '../../../src/helpers/canonicalStrongVerse'
+
+const SUPPORTED_STRONG_BIBLE_VERSIONS = new Set([
+  'LSG',
+  'DBY',
+  'DBR',
+  'KJV',
+  'NASB2020',
+  'NASB1995',
+  'BSB',
+  'ASV',
+  'DARBY',
+  'RLT',
+  'RWEBSTER',
+  'RV1895',
+])
+
+export type StrongBibleResourceRevision = {
+  versionId: string
+  datasetId: string
+  revision: string
+  textRevision: string
+  textSha256: string
+  strongRevision: string
+}
+
+export type StrongBibleLocation = { versionId: string; book: number; chapter: number }
+export type StrongBibleIdentityLookup = {
+  versionId: string
+  book: number
+  reference: string
+}
+export type StrongBibleOccurrencesLookup = StrongBibleIdentityLookup & {
+  limit?: number
+  offset?: number
+  allBooks?: boolean
+  lexemeId?: number
+}
+
+export type ActiveStrongBibleCoverage = StrongBibleResourceRevision & {
+  books: readonly number[]
+  chaptersByBook: Record<string, readonly number[]>
+  verseCountByBookChapter: Record<string, number>
+}
+export type ActiveStrongBibleChapter = StrongBibleResourceRevision & {
+  book: number
+  chapter: number
+  verses: readonly { number: number; spans: readonly StrongBibleSpan[] }[]
+}
+export type ActiveStrongBibleCounts = StrongBibleResourceRevision & {
+  identity?: { id: number; kind: StrongBibleIdentityDto['kind']; code: string }
+  counts: readonly { book: number; verseCount: number }[]
+}
+export type ActiveStrongBibleOccurrences = StrongBibleResourceRevision & {
+  identity?: { id: number; kind: StrongBibleIdentityDto['kind']; code: string }
+  verses: readonly {
+    book: number
+    chapter: number
+    verse: number
+    spans: readonly StrongBibleSpan[]
+  }[]
+  nextOffset?: number
+}
+export type ActiveStrongBibleLemmaStats = StrongBibleResourceRevision & {
+  identity?: { id: number; kind: StrongBibleIdentityDto['kind']; code: string }
+  lemmas: readonly { id: number; lemma: string; partOfSpeech: string; occurrenceCount: number }[]
+}
+
+export class UnsupportedStrongBibleVersion extends Data.TaggedError(
+  'UnsupportedStrongBibleVersion'
+)<{ readonly versionId: string }> {}
+export class ActiveStrongBiblePublicationUnavailable extends Data.TaggedError(
+  'ActiveStrongBiblePublicationUnavailable'
+)<{ readonly versionId: string }> {}
+export class StrongBibleChapterNotFound extends Data.TaggedError(
+  'StrongBibleChapterNotFound'
+)<StrongBibleLocation> {}
+export class StrongBibleRepositoryFailure extends Data.TaggedError('StrongBibleRepositoryFailure')<{
+  readonly cause: unknown
+}> {}
+
+export type StrongBibleRepositoryError =
+  | ActiveStrongBiblePublicationUnavailable
+  | StrongBibleChapterNotFound
+  | StrongBibleRepositoryFailure
+
+export type StrongBibleRepositoryService = {
+  findActiveCoverage: (
+    versionId: string
+  ) => Effect.Effect<ActiveStrongBibleCoverage, StrongBibleRepositoryError>
+  findActiveChapter: (
+    input: StrongBibleLocation
+  ) => Effect.Effect<ActiveStrongBibleChapter, StrongBibleRepositoryError>
+  findCountsByBook: (
+    input: StrongBibleIdentityLookup
+  ) => Effect.Effect<ActiveStrongBibleCounts, StrongBibleRepositoryError>
+  findOccurrences: (
+    input: StrongBibleOccurrencesLookup
+  ) => Effect.Effect<ActiveStrongBibleOccurrences, StrongBibleRepositoryError>
+  findLemmaStats: (
+    input: StrongBibleIdentityLookup
+  ) => Effect.Effect<ActiveStrongBibleLemmaStats, StrongBibleRepositoryError>
+}
+
+export class StrongBibleRepository extends Context.Tag('StrongBibleRepository')<
+  StrongBibleRepository,
+  StrongBibleRepositoryService
+>() {}
+
+const assertSupported = (versionId: string) =>
+  SUPPORTED_STRONG_BIBLE_VERSIONS.has(versionId)
+    ? Effect.void
+    : Effect.fail(new UnsupportedStrongBibleVersion({ versionId }))
+
+const revisionDto = (active: StrongBibleResourceRevision) =>
+  new StrongBibleRevisionDto({
+    kind: 'strong-bible-index',
+    versionId: active.versionId,
+    datasetId: active.datasetId,
+    revision: active.revision,
+    textRevision: active.textRevision,
+    textSha256: active.textSha256,
+    strongRevision: active.strongRevision,
+  })
+
+const identityDto = (identity: ActiveStrongBibleCounts['identity']) =>
+  identity ? new StrongBibleIdentityDto(identity) : undefined
+const spanDto = (span: StrongBibleSpan) =>
+  new StrongBibleSpanDto({
+    ...span,
+    identities: span.identities.map(identity => new StrongBibleIdentityDto(identity)),
+  })
+
+export const readStrongBibleCoverage = (versionId: string) =>
+  Effect.gen(function* () {
+    yield* assertSupported(versionId)
+    const repository = yield* StrongBibleRepository
+    const active = yield* repository.findActiveCoverage(versionId)
+    return new StrongBibleCoverageDto({
+      resource: revisionDto(active),
+      books: [...active.books],
+      chaptersByBook: Object.fromEntries(
+        Object.entries(active.chaptersByBook).map(([book, chapters]) => [book, [...chapters]])
+      ),
+      verseCountByBookChapter: active.verseCountByBookChapter,
+    })
+  })
+
+export const readStrongBibleChapter = (input: StrongBibleLocation) =>
+  Effect.gen(function* () {
+    yield* assertSupported(input.versionId)
+    const repository = yield* StrongBibleRepository
+    const active = yield* repository.findActiveChapter(input)
+    return new StrongBibleChapterDto({
+      resource: revisionDto(active),
+      book: active.book,
+      chapter: active.chapter,
+      verses: active.verses.map(
+        verse =>
+          new StrongBibleChapterVerseDto({
+            number: verse.number,
+            spans: verse.spans.map(spanDto),
+          })
+      ),
+    })
+  })
+
+export const readStrongBibleCounts = (input: StrongBibleIdentityLookup) =>
+  Effect.gen(function* () {
+    yield* assertSupported(input.versionId)
+    const repository = yield* StrongBibleRepository
+    const active = yield* repository.findCountsByBook(input)
+    return new StrongBibleCountsDto({
+      resource: revisionDto(active),
+      identity: identityDto(active.identity),
+      counts: active.counts.map(count => new StrongBibleBookCountDto(count)),
+    })
+  })
+
+export const readStrongBibleOccurrences = (input: StrongBibleOccurrencesLookup) =>
+  Effect.gen(function* () {
+    yield* assertSupported(input.versionId)
+    const repository = yield* StrongBibleRepository
+    const active = yield* repository.findOccurrences(input)
+    return new StrongBibleOccurrencesDto({
+      resource: revisionDto(active),
+      identity: identityDto(active.identity),
+      verses: active.verses.map(
+        verse =>
+          new StrongBibleOccurrenceVerseDto({
+            ...verse,
+            spans: verse.spans.map(spanDto),
+          })
+      ),
+      nextOffset: active.nextOffset,
+    })
+  })
+
+export const readStrongBibleLemmaStats = (input: StrongBibleIdentityLookup) =>
+  Effect.gen(function* () {
+    yield* assertSupported(input.versionId)
+    const repository = yield* StrongBibleRepository
+    const active = yield* repository.findLemmaStats(input)
+    return new StrongBibleLemmaStatsDto({
+      resource: revisionDto(active),
+      identity: identityDto(active.identity),
+      lemmas: active.lemmas.map(lemma => new StrongBibleLemmaStatDto(lemma)),
+    })
+  })

--- a/resource-service/src/domain/strongBible.ts
+++ b/resource-service/src/domain/strongBible.ts
@@ -15,21 +15,7 @@ import {
   StrongBibleSpanDto,
 } from '../../../src/features/resources/strongBibleContract'
 import type { StrongBibleSpan } from '../../../src/helpers/canonicalStrongVerse'
-
-const SUPPORTED_STRONG_BIBLE_VERSIONS = new Set([
-  'LSG',
-  'DBY',
-  'DBR',
-  'KJV',
-  'NASB2020',
-  'NASB1995',
-  'BSB',
-  'ASV',
-  'DARBY',
-  'RLT',
-  'RWEBSTER',
-  'RV1895',
-])
+import { isStrongBibleVersionId } from '../../../src/helpers/strongBibleCatalog'
 
 export type StrongBibleResourceRevision = {
   versionId: string
@@ -124,7 +110,7 @@ export class StrongBibleRepository extends Context.Tag('StrongBibleRepository')<
 >() {}
 
 const assertSupported = (versionId: string) =>
-  SUPPORTED_STRONG_BIBLE_VERSIONS.has(versionId)
+  isStrongBibleVersionId(versionId)
     ? Effect.void
     : Effect.fail(new UnsupportedStrongBibleVersion({ versionId }))
 

--- a/resource-service/src/http/__tests__/strongBibleApi.node-test.ts
+++ b/resource-service/src/http/__tests__/strongBibleApi.node-test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Effect } from 'effect'
+
+import { makeResourceWebHandler, type ResourceRepositoryOverrides } from '../app'
+
+const resource = {
+  versionId: 'LSG',
+  datasetId: 'LSG',
+  revision: 'strong-publication-v1',
+  textRevision: 'lsg-text-v1',
+  textSha256: '1'.repeat(64),
+  strongRevision: 'strong-content-v1',
+}
+
+const span = {
+  ordinal: 0,
+  startOffset: 0,
+  length: 4,
+  stepTokenIds: [7],
+  identities: [{ kind: 'strong' as const, code: 'H0430' }],
+}
+
+const repositories: ResourceRepositoryOverrides = {
+  strongBible: {
+    findActiveCoverage: () =>
+      Effect.succeed({
+        ...resource,
+        books: [1],
+        chaptersByBook: { 1: [1] },
+        verseCountByBookChapter: { '1-1': 1 },
+      }),
+    findActiveChapter: () =>
+      Effect.succeed({
+        ...resource,
+        book: 1,
+        chapter: 1,
+        verses: [{ number: 1, spans: [span] }],
+      }),
+    findCountsByBook: () =>
+      Effect.succeed({
+        ...resource,
+        identity: { id: 1, kind: 'strong' as const, code: 'H0430' },
+        counts: [{ book: 1, verseCount: 1 }],
+      }),
+    findOccurrences: () =>
+      Effect.succeed({
+        ...resource,
+        identity: { id: 1, kind: 'strong' as const, code: 'H0430' },
+        verses: [{ book: 1, chapter: 1, verse: 1, spans: [span] }],
+        nextOffset: 1,
+      }),
+    findLemmaStats: () =>
+      Effect.succeed({
+        ...resource,
+        identity: { id: 1, kind: 'strong' as const, code: 'H0430' },
+        lemmas: [{ id: 1, lemma: 'Dieu', partOfSpeech: 'N', occurrenceCount: 1 }],
+      }),
+  },
+}
+
+describe('Strong Bible API', () => {
+  it('serves a typed Strong chapter without duplicating Bible text', async () => {
+    const web = makeResourceWebHandler(undefined, undefined, repositories)
+    try {
+      const response = await web.handler(
+        new Request('http://localhost/v1/strong-bibles/LSG/books/1/chapters/1')
+      )
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(await response.json(), {
+        resource: {
+          kind: 'strong-bible-index',
+          ...resource,
+        },
+        book: 1,
+        chapter: 1,
+        verses: [{ number: 1, spans: [span] }],
+      })
+    } finally {
+      await web.dispose()
+    }
+  })
+
+  it('serves paginated concordance occurrences with their aligned spans', async () => {
+    const web = makeResourceWebHandler(undefined, undefined, repositories)
+    try {
+      const response = await web.handler(
+        new Request(
+          'http://localhost/v1/strong-bibles/LSG/books/1/identities/H0430/occurrences?limit=1&offset=0&allBooks=true'
+        )
+      )
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(await response.json(), {
+        resource: {
+          kind: 'strong-bible-index',
+          ...resource,
+        },
+        identity: { id: 1, kind: 'strong', code: 'H0430' },
+        verses: [{ book: 1, chapter: 1, verse: 1, spans: [span] }],
+        nextOffset: 1,
+      })
+    } finally {
+      await web.dispose()
+    }
+  })
+})

--- a/resource-service/src/http/api.ts
+++ b/resource-service/src/http/api.ts
@@ -18,6 +18,17 @@ import {
   NaveVerseTopicsResponseDto,
 } from '../../../src/features/resources/naveContract'
 import {
+  StrongBibleChapterDto,
+  StrongBibleChapterPath,
+  StrongBibleCountsDto,
+  StrongBibleCoverageDto,
+  StrongBibleIdentityPath,
+  StrongBibleLemmaStatsDto,
+  StrongBibleOccurrencesDto,
+  StrongBibleOccurrencesQuery,
+  StrongBibleVersionPath,
+} from '../../../src/features/resources/strongBibleContract'
+import {
   InvalidResourceRequestProblem,
   ResourceInternalProblem,
   ResourceNotFoundProblem,
@@ -100,7 +111,68 @@ const NaveApi = HttpApiGroup.make('naves')
       .addError(ResourceInternalProblem, { status: 500 })
   )
 
+const StrongBibleApi = HttpApiGroup.make('strongBibles')
+  .add(
+    HttpApiEndpoint.get('getStrongBibleCoverage', '/v1/strong-bibles/:version/coverage')
+      .setPath(StrongBibleVersionPath)
+      .addSuccess(StrongBibleCoverageDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getStrongBibleChapter',
+      '/v1/strong-bibles/:version/books/:book/chapters/:chapter'
+    )
+      .setPath(StrongBibleChapterPath)
+      .addSuccess(StrongBibleChapterDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getStrongBibleCounts',
+      '/v1/strong-bibles/:version/books/:book/identities/:reference/counts'
+    )
+      .setPath(StrongBibleIdentityPath)
+      .addSuccess(StrongBibleCountsDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getStrongBibleOccurrences',
+      '/v1/strong-bibles/:version/books/:book/identities/:reference/occurrences'
+    )
+      .setPath(StrongBibleIdentityPath)
+      .setUrlParams(StrongBibleOccurrencesQuery)
+      .addSuccess(StrongBibleOccurrencesDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getStrongBibleLemmaStats',
+      '/v1/strong-bibles/:version/books/:book/identities/:reference/lemmas'
+    )
+      .setPath(StrongBibleIdentityPath)
+      .addSuccess(StrongBibleLemmaStatsDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+
 export class ResourceApi extends HttpApi.make('resource-api')
   .add(SystemApi)
   .add(BibleApi)
-  .add(NaveApi) {}
+  .add(NaveApi)
+  .add(StrongBibleApi) {}

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -24,6 +24,19 @@ import {
   UnsupportedNaveLanguage,
   type NaveRepositoryService,
 } from '../domain/nave'
+import {
+  ActiveStrongBiblePublicationUnavailable,
+  readStrongBibleChapter,
+  readStrongBibleCounts,
+  readStrongBibleCoverage,
+  readStrongBibleLemmaStats,
+  readStrongBibleOccurrences,
+  StrongBibleChapterNotFound,
+  StrongBibleRepository,
+  StrongBibleRepositoryFailure,
+  UnsupportedStrongBibleVersion,
+  type StrongBibleRepositoryService,
+} from '../domain/strongBible'
 import { HealthResponse, ResourceApi } from './api'
 import {
   InvalidResourceRequestProblem,
@@ -55,7 +68,11 @@ const toHttpProblem = (
     | UnsupportedNaveLanguage
     | ActiveNavePublicationUnavailable
     | NaveTopicNotFound
-    | NaveRepositoryFailure,
+    | NaveRepositoryFailure
+    | UnsupportedStrongBibleVersion
+    | ActiveStrongBiblePublicationUnavailable
+    | StrongBibleChapterNotFound
+    | StrongBibleRepositoryFailure,
   requestId: string
 ) => {
   switch (cause._tag) {
@@ -80,6 +97,7 @@ const toHttpProblem = (
       })
     case 'BibleChapterRepositoryFailure':
     case 'NaveRepositoryFailure':
+    case 'StrongBibleRepositoryFailure':
       return new ResourceInternalProblem({
         ...problemFields(requestId, 'The Resource service could not complete the request.'),
         status: 500,
@@ -102,6 +120,25 @@ const toHttpProblem = (
         ...problemFields(requestId, 'The Nave publication is temporarily unavailable.'),
         status: 503,
         code: 'NAVE_PUBLICATION_INACTIVE',
+        retryAfterSeconds: 30,
+      })
+    case 'UnsupportedStrongBibleVersion':
+      return new ResourceNotFoundProblem({
+        ...problemFields(requestId, 'This Strong Bible index is not available from this service.'),
+        status: 404,
+        code: 'STRONG_BIBLE_UNSUPPORTED',
+      })
+    case 'StrongBibleChapterNotFound':
+      return new ResourceNotFoundProblem({
+        ...problemFields(requestId, 'This Strong Bible chapter does not exist.'),
+        status: 404,
+        code: 'STRONG_BIBLE_CHAPTER_NOT_FOUND',
+      })
+    case 'ActiveStrongBiblePublicationUnavailable':
+      return new ResourceUnavailableProblem({
+        ...problemFields(requestId, 'The Strong Bible publication is temporarily unavailable.'),
+        status: 503,
+        code: 'STRONG_BIBLE_PUBLICATION_INACTIVE',
         retryAfterSeconds: 30,
       })
   }
@@ -179,7 +216,7 @@ const BibleApiLive = HttpApiBuilder.group(ResourceApi, 'bibles', handlers =>
     })
 )
 
-const serveNaveResponse = <A extends { resource: { revision: string } }, E, R>(
+const serveRevisionedResponse = <A extends { resource: { revision: string } }, E, R>(
   effect: Effect.Effect<A, E, R>,
   requestId: string,
   ifNoneMatch: string | undefined,
@@ -206,7 +243,7 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
   handlers
     .handle('getNaveTopic', ({ path, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
-      return serveNaveResponse(
+      return serveRevisionedResponse(
         readNaveTopic(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
         requestId,
         request.headers['if-none-match'],
@@ -215,7 +252,7 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
     })
     .handle('listNaveTopics', ({ path, urlParams, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
-      return serveNaveResponse(
+      return serveRevisionedResponse(
         browseNaveTopics({ ...path, initial: urlParams.initial, search: urlParams.search }).pipe(
           Effect.mapError(cause => toHttpProblem(cause, requestId))
         ),
@@ -226,7 +263,7 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
     })
     .handle('getNaveVerseTopics', ({ path, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
-      return serveNaveResponse(
+      return serveRevisionedResponse(
         readNaveVerseTopics(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
         requestId,
         request.headers['if-none-match'],
@@ -235,7 +272,7 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
     })
     .handle('getRandomNaveTopic', ({ path, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
-      return serveNaveResponse(
+      return serveRevisionedResponse(
         readRandomNaveTopic(path.language).pipe(
           Effect.mapError(cause => toHttpProblem(cause, requestId))
         ),
@@ -245,10 +282,81 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
     })
 )
 
+const StrongBibleApiLive = HttpApiBuilder.group(ResourceApi, 'strongBibles', handlers =>
+  handlers
+    .handle('getStrongBibleCoverage', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readStrongBibleCoverage(path.version).pipe(
+          Effect.mapError(cause => toHttpProblem(cause, requestId))
+        ),
+        requestId,
+        request.headers['if-none-match'],
+        ['strong-bible', path.version, 'coverage']
+      )
+    })
+    .handle('getStrongBibleChapter', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readStrongBibleChapter({
+          versionId: path.version,
+          book: path.book,
+          chapter: path.chapter,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['strong-bible', path.version, path.book, path.chapter]
+      )
+    })
+    .handle('getStrongBibleCounts', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readStrongBibleCounts({
+          versionId: path.version,
+          book: path.book,
+          reference: path.reference,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['strong-bible', path.version, path.book, path.reference, 'counts']
+      )
+    })
+    .handle('getStrongBibleOccurrences', ({ path, urlParams, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readStrongBibleOccurrences({
+          versionId: path.version,
+          book: path.book,
+          reference: path.reference,
+          limit: urlParams.limit,
+          offset: urlParams.offset,
+          allBooks: urlParams.allBooks === 'true',
+          lexemeId: urlParams.lexemeId,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match']
+      )
+    })
+    .handle('getStrongBibleLemmaStats', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readStrongBibleLemmaStats({
+          versionId: path.version,
+          book: path.book,
+          reference: path.reference,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['strong-bible', path.version, path.book, path.reference, 'lemmas']
+      )
+    })
+)
+
 export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(SystemApiLive),
   Layer.provide(BibleApiLive),
-  Layer.provide(NaveApiLive)
+  Layer.provide(NaveApiLive),
+  Layer.provide(StrongBibleApiLive)
 )
 
 const unavailableRepository: BibleChapterRepositoryService = {
@@ -270,25 +378,48 @@ const unavailableNaveRepository: NaveRepositoryService = {
   findRandomTopic: language => Effect.fail(new ActiveNavePublicationUnavailable({ language })),
 }
 
+const unavailableStrongBibleRepository: StrongBibleRepositoryService = {
+  findActiveCoverage: versionId =>
+    Effect.fail(new ActiveStrongBiblePublicationUnavailable({ versionId })),
+  findActiveChapter: input =>
+    Effect.fail(new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })),
+  findCountsByBook: input =>
+    Effect.fail(new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })),
+  findOccurrences: input =>
+    Effect.fail(new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })),
+  findLemmaStats: input =>
+    Effect.fail(new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })),
+}
+
 export const provideResourceRepositories = (
   repository: BibleChapterRepositoryService,
-  naveRepository: NaveRepositoryService
+  naveRepository: NaveRepositoryService,
+  strongBibleRepository: StrongBibleRepositoryService = unavailableStrongBibleRepository
 ) =>
   ResourceApiLive.pipe(
     Layer.provide(
-      Layer.merge(
+      Layer.mergeAll(
         Layer.succeed(BibleChapterRepository, repository),
-        Layer.succeed(NaveRepository, naveRepository)
+        Layer.succeed(NaveRepository, naveRepository),
+        Layer.succeed(StrongBibleRepository, strongBibleRepository)
       )
     )
   )
 
 export const makeResourceWebHandler = (
   repository: BibleChapterRepositoryService = unavailableRepository,
-  naveRepository: NaveRepositoryService = unavailableNaveRepository
+  naveRepository: NaveRepositoryService = unavailableNaveRepository,
+  overrides: ResourceRepositoryOverrides = {}
 ) => {
   const web = HttpApiBuilder.toWebHandler(
-    Layer.mergeAll(provideResourceRepositories(repository, naveRepository), HttpServer.layerContext)
+    Layer.mergeAll(
+      provideResourceRepositories(
+        repository,
+        naveRepository,
+        overrides.strongBible ?? unavailableStrongBibleRepository
+      ),
+      HttpServer.layerContext
+    )
   )
   return {
     ...web,
@@ -317,4 +448,8 @@ export const makeResourceWebHandler = (
       return new Response(response.body, { status: response.status, headers })
     },
   }
+}
+
+export type ResourceRepositoryOverrides = {
+  strongBible?: StrongBibleRepositoryService
 }

--- a/resource-service/src/http/problems.ts
+++ b/resource-service/src/http/problems.ts
@@ -25,7 +25,9 @@ export class ResourceNotFoundProblem extends Schema.TaggedError<ResourceNotFound
       'BIBLE_UNSUPPORTED',
       'BIBLE_CHAPTER_NOT_FOUND',
       'NAVE_UNSUPPORTED',
-      'NAVE_TOPIC_NOT_FOUND'
+      'NAVE_TOPIC_NOT_FOUND',
+      'STRONG_BIBLE_UNSUPPORTED',
+      'STRONG_BIBLE_CHAPTER_NOT_FOUND'
     ),
   }
 ) {}
@@ -35,7 +37,11 @@ export class ResourceUnavailableProblem extends Schema.TaggedError<ResourceUnava
   {
     ...ProblemFields,
     status: Schema.Literal(503),
-    code: Schema.Literal('BIBLE_PUBLICATION_INACTIVE', 'NAVE_PUBLICATION_INACTIVE'),
+    code: Schema.Literal(
+      'BIBLE_PUBLICATION_INACTIVE',
+      'NAVE_PUBLICATION_INACTIVE',
+      'STRONG_BIBLE_PUBLICATION_INACTIVE'
+    ),
     retryAfterSeconds: Schema.Int.pipe(Schema.positive()),
   }
 ) {}

--- a/resource-service/src/publication/__tests__/completeStrongBiblePublications.integration.node-test.ts
+++ b/resource-service/src/publication/__tests__/completeStrongBiblePublications.integration.node-test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+
+import { Effect } from 'effect'
+
+import { getMobileStrongBibleVersionIds } from '../../../../src/helpers/mobileResourceCatalog'
+import {
+  getStrongBibleCatalogIdentity,
+  type StrongBibleVersionId,
+} from '../../../../src/helpers/strongBibleCatalog'
+import { createIsolatedPostgres } from '../../database/__tests__/isolatedPostgresTestSupport'
+import { makeKyselyStrongBibleRepository } from '../../repositories/strongBibleRepository'
+import { importPublicationBundle } from '../../repositories/publicationImporter'
+import {
+  isStrongBiblePublicationBundleManifest,
+  validatePublicationBundle,
+  type CanonicalStrongBiblePublication,
+  type StrongBiblePublicationBundleManifest,
+} from '../publicationBundle'
+
+const root = process.env.RESOURCE_STRONG_BIBLE_BUNDLES_ROOT
+const runIntegration = process.env.RESOURCE_INTEGRATION === '1' && Boolean(root)
+const connectionString =
+  process.env.RESOURCE_DATABASE_URL ??
+  'postgresql://bible_strong:bible_strong@127.0.0.1:54329/bible_strong'
+
+describe('Complete Strong Bible publications', { skip: !runIntegration }, () => {
+  it('validates, activates, imports, and queries all 12 current Strong indexes', async () => {
+    const bundlePaths = (await readdir(path.resolve(root!), { withFileTypes: true }))
+      .filter(entry => entry.isDirectory())
+      .map(entry => path.join(path.resolve(root!), entry.name))
+      .sort()
+    const expectedVersions = getMobileStrongBibleVersionIds()
+    const isolated = await createIsolatedPostgres(connectionString, 'strong_complete')
+    try {
+      const publications: {
+        bundlePath: string
+        manifest: StrongBiblePublicationBundleManifest
+        canonical: CanonicalStrongBiblePublication
+      }[] = []
+      for (const bundlePath of bundlePaths) {
+        const validated = await validatePublicationBundle(bundlePath)
+        assert.ok(isStrongBiblePublicationBundleManifest(validated.manifest))
+        assert.equal(validated.canonical.format, 'bible-strong-canonical-strong-index')
+        if (
+          !isStrongBiblePublicationBundleManifest(validated.manifest) ||
+          validated.canonical.format !== 'bible-strong-canonical-strong-index'
+        ) {
+          assert.fail('Expected a Strong Bible publication')
+        }
+        publications.push({
+          bundlePath,
+          manifest: validated.manifest,
+          canonical: validated.canonical,
+        })
+      }
+      assert.equal(publications.length, 12)
+      assert.deepEqual(
+        publications.map(publication => publication.manifest.identity.versionId).sort(),
+        expectedVersions
+      )
+      for (const publication of publications) {
+        const identity = getStrongBibleCatalogIdentity(
+          publication.manifest.identity.versionId as StrongBibleVersionId
+        )
+        assert.equal(publication.manifest.identity.datasetId, identity.datasetId)
+        assert.equal(publication.manifest.identity.language, identity.language)
+      }
+
+      for (const publication of publications) {
+        await isolated.database
+          .insertInto('resource_publications')
+          .values({
+            resource_identity: publication.manifest.dependencies.bible.resourceIdentity,
+            resource_kind: 'bible-text',
+            revision: publication.manifest.dependencies.bible.revision,
+            language: publication.manifest.identity.language,
+            status: 'active',
+            canonical_sha256: '4'.repeat(64),
+            offline_artifact_sha256: '5'.repeat(64),
+            provenance: { source: 'integration-test', imported_at: new Date(0).toISOString() },
+            rights: { holder: 'integration-test', online: true, offline: true },
+            metadata: {
+              text_revision: publication.manifest.dependencies.bible.revision,
+              text_sha256: publication.manifest.dependencies.bible.textSha256,
+            },
+            activated_at: new Date(0),
+          })
+          .executeTakeFirstOrThrow()
+        const imported = await Effect.runPromise(
+          importPublicationBundle(publication.bundlePath, isolated.database, {
+            activateForLocalDevelopment: true,
+          })
+        )
+        assert.ok(imported.status === 'activated' || imported.status === 'unchanged')
+      }
+
+      const repository = makeKyselyStrongBibleRepository(isolated.database)
+      for (const publication of publications) {
+        const versionId = publication.manifest.identity.versionId
+        const coverage = await Effect.runPromise(repository.findActiveCoverage(versionId))
+        assert.equal(
+          Object.values(coverage.verseCountByBookChapter).reduce(
+            (count, chapterCount) => count + chapterCount,
+            0
+          ),
+          publication.manifest.counts.verses
+        )
+        const firstVerse = publication.canonical.verses[0]!
+        const chapter = await Effect.runPromise(
+          repository.findActiveChapter({
+            versionId,
+            book: firstVerse.book,
+            chapter: firstVerse.chapter,
+          })
+        )
+        const expectedSpans = publication.canonical.spans.filter(
+          span => span.book === firstVerse.book && span.chapter === firstVerse.chapter
+        )
+        assert.equal(
+          chapter.verses.reduce((count, verse) => count + verse.spans.length, 0),
+          expectedSpans.length
+        )
+      }
+    } finally {
+      await isolated.dispose()
+    }
+  })
+})

--- a/resource-service/src/publication/__tests__/completeStrongBiblePublications.integration.node-test.ts
+++ b/resource-service/src/publication/__tests__/completeStrongBiblePublications.integration.node-test.ts
@@ -33,82 +33,65 @@ describe('Complete Strong Bible publications', { skip: !runIntegration }, () => 
       .map(entry => path.join(path.resolve(root!), entry.name))
       .sort()
     const expectedVersions = getMobileStrongBibleVersionIds()
-    const isolated = await createIsolatedPostgres(connectionString, 'strong_complete')
-    try {
-      const publications: {
-        bundlePath: string
-        manifest: StrongBiblePublicationBundleManifest
-        canonical: CanonicalStrongBiblePublication
-      }[] = []
-      for (const bundlePath of bundlePaths) {
-        const validated = await validatePublicationBundle(bundlePath)
-        assert.ok(isStrongBiblePublicationBundleManifest(validated.manifest))
-        assert.equal(validated.canonical.format, 'bible-strong-canonical-strong-index')
-        if (
-          !isStrongBiblePublicationBundleManifest(validated.manifest) ||
-          validated.canonical.format !== 'bible-strong-canonical-strong-index'
-        ) {
-          assert.fail('Expected a Strong Bible publication')
-        }
-        publications.push({
-          bundlePath,
-          manifest: validated.manifest,
-          canonical: validated.canonical,
-        })
+    const importedVersions: string[] = []
+    for (const bundlePath of bundlePaths) {
+      const validated = await validatePublicationBundle(bundlePath)
+      assert.ok(isStrongBiblePublicationBundleManifest(validated.manifest))
+      assert.equal(validated.canonical.format, 'bible-strong-canonical-strong-index')
+      if (
+        !isStrongBiblePublicationBundleManifest(validated.manifest) ||
+        validated.canonical.format !== 'bible-strong-canonical-strong-index'
+      ) {
+        assert.fail('Expected a Strong Bible publication')
       }
-      assert.equal(publications.length, 12)
-      assert.deepEqual(
-        publications.map(publication => publication.manifest.identity.versionId).sort(),
-        expectedVersions
-      )
-      for (const publication of publications) {
-        const identity = getStrongBibleCatalogIdentity(
-          publication.manifest.identity.versionId as StrongBibleVersionId
-        )
-        assert.equal(publication.manifest.identity.datasetId, identity.datasetId)
-        assert.equal(publication.manifest.identity.language, identity.language)
-      }
+      const manifest: StrongBiblePublicationBundleManifest = validated.manifest
+      const canonical: CanonicalStrongBiblePublication = validated.canonical
+      const versionId = manifest.identity.versionId
+      const identity = getStrongBibleCatalogIdentity(versionId as StrongBibleVersionId)
+      assert.equal(manifest.identity.datasetId, identity.datasetId)
+      assert.equal(manifest.identity.language, identity.language)
+      importedVersions.push(versionId)
 
-      for (const publication of publications) {
+      const isolated = await createIsolatedPostgres(
+        connectionString,
+        `strong_complete_${versionId.toLowerCase()}`
+      )
+      try {
+        const repository = makeKyselyStrongBibleRepository(isolated.database)
         await isolated.database
           .insertInto('resource_publications')
           .values({
-            resource_identity: publication.manifest.dependencies.bible.resourceIdentity,
+            resource_identity: manifest.dependencies.bible.resourceIdentity,
             resource_kind: 'bible-text',
-            revision: publication.manifest.dependencies.bible.revision,
-            language: publication.manifest.identity.language,
+            revision: manifest.dependencies.bible.revision,
+            language: manifest.identity.language,
             status: 'active',
             canonical_sha256: '4'.repeat(64),
             offline_artifact_sha256: '5'.repeat(64),
             provenance: { source: 'integration-test', imported_at: new Date(0).toISOString() },
             rights: { holder: 'integration-test', online: true, offline: true },
             metadata: {
-              text_revision: publication.manifest.dependencies.bible.revision,
-              text_sha256: publication.manifest.dependencies.bible.textSha256,
+              text_revision: manifest.dependencies.bible.revision,
+              text_sha256: manifest.dependencies.bible.textSha256,
             },
             activated_at: new Date(0),
           })
           .executeTakeFirstOrThrow()
         const imported = await Effect.runPromise(
-          importPublicationBundle(publication.bundlePath, isolated.database, {
+          importPublicationBundle(bundlePath, isolated.database, {
             activateForLocalDevelopment: true,
           })
         )
         assert.ok(imported.status === 'activated' || imported.status === 'unchanged')
-      }
-
-      const repository = makeKyselyStrongBibleRepository(isolated.database)
-      for (const publication of publications) {
-        const versionId = publication.manifest.identity.versionId
         const coverage = await Effect.runPromise(repository.findActiveCoverage(versionId))
         assert.equal(
           Object.values(coverage.verseCountByBookChapter).reduce(
             (count, chapterCount) => count + chapterCount,
             0
           ),
-          publication.manifest.counts.verses
+          manifest.counts.verses
         )
-        const firstVerse = publication.canonical.verses[0]!
+        const firstVerse = canonical.verses[0]!
         const chapter = await Effect.runPromise(
           repository.findActiveChapter({
             versionId,
@@ -116,16 +99,18 @@ describe('Complete Strong Bible publications', { skip: !runIntegration }, () => 
             chapter: firstVerse.chapter,
           })
         )
-        const expectedSpans = publication.canonical.spans.filter(
+        const expectedSpans = canonical.spans.filter(
           span => span.book === firstVerse.book && span.chapter === firstVerse.chapter
         )
         assert.equal(
           chapter.verses.reduce((count, verse) => count + verse.spans.length, 0),
           expectedSpans.length
         )
+      } finally {
+        await isolated.dispose()
       }
-    } finally {
-      await isolated.dispose()
     }
+    assert.equal(importedVersions.length, 12)
+    assert.deepEqual(importedVersions.sort(), expectedVersions)
   })
 })

--- a/resource-service/src/publication/__tests__/publicationBundle.node-test.ts
+++ b/resource-service/src/publication/__tests__/publicationBundle.node-test.ts
@@ -207,7 +207,7 @@ describe('Resource publication bundle', () => {
       })
       await writeFile(path.join(root, 'manifest.json'), `${JSON.stringify(manifest)}\n`)
 
-      await assert.rejects(validatePublicationBundle(root), /OFFLINE_ARTIFACT_ENTRY_MISSING/)
+      await assert.rejects(validatePublicationBundle(root), /OFFLINE_ARTIFACT_INVALID/)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/resource-service/src/publication/__tests__/publicationImporter.integration.node-test.ts
+++ b/resource-service/src/publication/__tests__/publicationImporter.integration.node-test.ts
@@ -109,7 +109,7 @@ const writeBundle = async ({
     publicationRevision,
   }
   await writeFile(path.join(root, 'manifest.json'), `${JSON.stringify(manifest)}\n`)
-  return { publicationRevision, textRevision }
+  return { publicationRevision, textRevision, textSha256 }
 }
 
 describe('Atomic publication import', { skip: !runIntegration }, () => {
@@ -151,6 +151,28 @@ describe('Atomic publication import', { skip: !runIntegration }, () => {
       )
       const unchanged = await Effect.runPromise(importPublicationBundle(firstBundle, database))
       assert.equal(unchanged.status, 'unchanged')
+      const preHashMetadata = await database
+        .selectFrom('resource_publications')
+        .select('metadata')
+        .where('resource_identity', '=', identity)
+        .where('revision', '=', firstPublication.publicationRevision)
+        .executeTakeFirstOrThrow()
+      const { text_sha256: _removedTextSha256, ...legacyMetadata } = preHashMetadata.metadata
+      await database
+        .updateTable('resource_publications')
+        .set({ metadata: legacyMetadata })
+        .where('resource_identity', '=', identity)
+        .where('revision', '=', firstPublication.publicationRevision)
+        .executeTakeFirstOrThrow()
+      const backfilled = await Effect.runPromise(importPublicationBundle(firstBundle, database))
+      assert.equal(backfilled.status, 'unchanged')
+      const backfilledPublication = await database
+        .selectFrom('resource_publications')
+        .select('metadata')
+        .where('resource_identity', '=', identity)
+        .where('revision', '=', firstPublication.publicationRevision)
+        .executeTakeFirstOrThrow()
+      assert.equal(backfilledPublication.metadata.text_sha256, firstPublication.textSha256)
       await writeBundle({
         root: firstBundle,
         versionId,

--- a/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, it } from 'node:test'
@@ -53,15 +53,17 @@ describe('Strong Bible publication bundle', () => {
     }
   })
 
-  it('rejects zero verse identities and additional Offline entries', async () => {
+  it('preserves verse-zero superscriptions and rejects additional Offline entries', async () => {
     const zeroRoot = await mkdtemp(path.join(tmpdir(), 'strong-publication-zero-'))
     const zipRoot = await mkdtemp(path.join(tmpdir(), 'strong-publication-zip-'))
     try {
       await writeStrongPublicationFixture(zeroRoot, { zeroVerse: true })
-      await assert.rejects(
-        validatePublicationBundle(zeroRoot),
-        /CANONICAL_STRONG_BIBLE_VERSE_INVALID/
-      )
+      const validated = await validatePublicationBundle(zeroRoot)
+      assert.equal(validated.canonical.format, 'bible-strong-canonical-strong-index')
+      if (validated.canonical.format !== 'bible-strong-canonical-strong-index') {
+        assert.fail('Expected a Strong Bible publication')
+      }
+      assert.equal(validated.canonical.verses[0]?.verse, 0)
       await writeStrongPublicationFixture(zipRoot, { extraOfflineEntry: true })
       await assert.rejects(validatePublicationBundle(zipRoot), /OFFLINE_ARTIFACT_INVALID/)
     } finally {
@@ -83,6 +85,18 @@ describe('Strong Bible publication bundle', () => {
       await symlink(external, canonicalPath)
       await assert.rejects(validatePublicationBundle(root), /CANONICAL_ARTIFACT_PATH_INVALID/)
       await rm(external, { force: true })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an oversized sparse archive before hashing or decompression', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'strong-publication-oversized-'))
+    try {
+      const result = await writeStrongPublicationFixture(root)
+      const archivePath = path.join(root, result.manifest.offlineArtifact.path)
+      await truncate(archivePath, 512 * 1024 * 1024 + 1)
+      await assert.rejects(validatePublicationBundle(root), /OFFLINE_ARTIFACT_SIZE_LIMIT_EXCEEDED/)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, it } from 'node:test'
@@ -34,6 +34,55 @@ describe('Strong Bible publication bundle', () => {
         validatePublicationBundle(root),
         /CANONICAL_STRONG_BIBLE_IDENTITY_DUPLICATE/
       )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a non-content-derived Resource revision', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'strong-publication-revision-'))
+    try {
+      await writeStrongPublicationFixture(root)
+      const manifestPath = path.join(root, 'manifest.json')
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+      manifest.revision = 'lsg-strong-00000000000000000000'
+      await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`)
+      await assert.rejects(validatePublicationBundle(root), /PUBLICATION_BUNDLE_IDENTITY_MISMATCH/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects zero verse identities and additional Offline entries', async () => {
+    const zeroRoot = await mkdtemp(path.join(tmpdir(), 'strong-publication-zero-'))
+    const zipRoot = await mkdtemp(path.join(tmpdir(), 'strong-publication-zip-'))
+    try {
+      await writeStrongPublicationFixture(zeroRoot, { zeroVerse: true })
+      await assert.rejects(
+        validatePublicationBundle(zeroRoot),
+        /CANONICAL_STRONG_BIBLE_VERSE_INVALID/
+      )
+      await writeStrongPublicationFixture(zipRoot, { extraOfflineEntry: true })
+      await assert.rejects(validatePublicationBundle(zipRoot), /OFFLINE_ARTIFACT_INVALID/)
+    } finally {
+      await Promise.all([
+        rm(zeroRoot, { recursive: true, force: true }),
+        rm(zipRoot, { recursive: true, force: true }),
+      ])
+    }
+  })
+
+  it('rejects canonical artifacts replaced by symlinks', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'strong-publication-symlink-'))
+    try {
+      const result = await writeStrongPublicationFixture(root)
+      const canonicalPath = path.join(root, result.manifest.canonical.path)
+      const external = path.join(path.dirname(root), `${path.basename(root)}-canonical.json`)
+      await writeFile(external, await readFile(canonicalPath))
+      await rm(canonicalPath)
+      await symlink(external, canonicalPath)
+      await assert.rejects(validatePublicationBundle(root), /CANONICAL_ARTIFACT_PATH_INVALID/)
+      await rm(external, { force: true })
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationBundle.node-test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+  isStrongBiblePublicationBundleManifest,
+  validatePublicationBundle,
+} from '../publicationBundle'
+import { writeStrongPublicationFixture } from './strongPublicationFixture'
+
+describe('Strong Bible publication bundle', () => {
+  it('validates canonical Strong identities, alignment, lexical references, and Offline-copy parity', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'strong-publication-'))
+    try {
+      await writeStrongPublicationFixture(root)
+
+      const validated = await validatePublicationBundle(root)
+
+      assert.ok(isStrongBiblePublicationBundleManifest(validated.manifest))
+      assert.equal(validated.canonical.format, 'bible-strong-canonical-strong-index')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects duplicate semantic Strong identities before PostgreSQL import', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'strong-publication-duplicate-'))
+    try {
+      await writeStrongPublicationFixture(root, { duplicateIdentityCode: true })
+
+      await assert.rejects(
+        validatePublicationBundle(root),
+        /CANONICAL_STRONG_BIBLE_IDENTITY_DUPLICATE/
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/resource-service/src/publication/__tests__/strongPublicationFixture.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationFixture.ts
@@ -1,0 +1,202 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { zipSync } from 'fflate'
+import initSqlJs from 'sql.js'
+
+import type {
+  CanonicalStrongBiblePublication,
+  StrongBiblePublicationBundleManifest,
+} from '../publicationBundle'
+
+const sha256 = (value: string | Uint8Array) => createHash('sha256').update(value).digest('hex')
+
+export const canonicalStrongFixture: CanonicalStrongBiblePublication = {
+  format: 'bible-strong-canonical-strong-index',
+  schemaVersion: 1,
+  applicationVersionId: 'LSG',
+  datasetId: 'LSG',
+  textRevision: 'lsg-text-v1',
+  textSha256: '1'.repeat(64),
+  strongRevision: '2'.repeat(64),
+  verses: [{ book: 1, chapter: 1, verse: 1 }],
+  lexemes: [{ id: 1, lemma: 'Dieu', partOfSpeech: 'N' }],
+  identities: [{ id: 1, kind: 'strong', code: 'H0430' }],
+  spans: [
+    {
+      book: 1,
+      chapter: 1,
+      verse: 1,
+      ordinal: 0,
+      startOffset: 0,
+      length: 4,
+      isAligned: true,
+      lexemeId: 1,
+      stepTokenIds: [7, 8],
+    },
+  ],
+  spanIdentities: [
+    {
+      book: 1,
+      chapter: 1,
+      verse: 1,
+      ordinal: 0,
+      identityOrder: 0,
+      identityId: 1,
+    },
+  ],
+}
+
+const makeOfflineSqlite = async (canonical: CanonicalStrongBiblePublication) => {
+  const SQL = await initSqlJs()
+  const database = new SQL.Database()
+  database.run(`
+    CREATE TABLE ResourceMetadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE Verses(id INTEGER PRIMARY KEY, bookOrder INTEGER, chapter INTEGER, verse INTEGER);
+    CREATE TABLE FrenchLexemes(id INTEGER PRIMARY KEY, lemma TEXT, partOfSpeech TEXT);
+    CREATE TABLE WordSpans(
+      verseId INTEGER, ordinal INTEGER, startOffset INTEGER, length INTEGER,
+      isAligned INTEGER, openOrder INTEGER, closeOrder INTEGER, lexemeId INTEGER,
+      stepTokenId INTEGER, PRIMARY KEY(verseId, ordinal)
+    );
+    CREATE TABLE StrongCodes(id INTEGER PRIMARY KEY, kind INTEGER, code TEXT);
+    CREATE TABLE WordStrongCodes(
+      verseId INTEGER, ordinal INTEGER, identityOrder INTEGER, codeId INTEGER,
+      PRIMARY KEY(verseId, ordinal, identityOrder)
+    );
+    CREATE TABLE WordStepTokenExtras(
+      verseId INTEGER, targetOrdinal INTEGER, sourceOrder INTEGER, stepTokenId INTEGER,
+      PRIMARY KEY(verseId, targetOrdinal, sourceOrder)
+    );
+  `)
+  for (const [key, value] of Object.entries({
+    applicationVersionId: canonical.applicationVersionId,
+    datasetId: canonical.datasetId,
+    textRevision: canonical.textRevision,
+    textSha256: canonical.textSha256,
+    strongRevision: canonical.strongRevision,
+    schemaVersion: 3,
+    verseCount: canonical.verses.length,
+    occurrenceCount: canonical.spans.length,
+    unalignedOccurrenceCount: canonical.spans.filter(span => !span.isAligned).length,
+    identityCount: canonical.spanIdentities.length,
+    lexemeAssignmentCount: canonical.spans.filter(span => span.lexemeId !== undefined).length,
+    lexemeCount: canonical.lexemes.length,
+  })) {
+    database.run('INSERT INTO ResourceMetadata(key, value) VALUES (?, ?)', [key, String(value)])
+  }
+  database.run('INSERT INTO Verses VALUES (1, 1, 1, 1)')
+  database.run("INSERT INTO FrenchLexemes VALUES (1, 'Dieu', 'N')")
+  database.run('INSERT INTO WordSpans VALUES (1, 0, 0, 4, 1, 0, 1, 1, 7)')
+  database.run("INSERT INTO StrongCodes VALUES (1, 0, 'H0430')")
+  database.run('INSERT INTO WordStrongCodes VALUES (1, 0, 0, 1)')
+  database.run('INSERT INTO WordStepTokenExtras VALUES (1, 0, 0, 8)')
+  const bytes = database.export()
+  database.close()
+  return bytes
+}
+
+export const writeStrongPublicationFixture = async (
+  root: string,
+  options: {
+    localDevelopmentAccess?: boolean
+    onlineAccess?: boolean
+    strongRevision?: string
+    textRevision?: string
+    textSha256?: string
+    duplicateIdentityCode?: boolean
+  } = {}
+) => {
+  const canonical: CanonicalStrongBiblePublication = {
+    ...canonicalStrongFixture,
+    strongRevision: options.strongRevision ?? canonicalStrongFixture.strongRevision,
+    textRevision: options.textRevision ?? canonicalStrongFixture.textRevision,
+    textSha256: options.textSha256 ?? canonicalStrongFixture.textSha256,
+    identities: options.duplicateIdentityCode
+      ? [
+          ...canonicalStrongFixture.identities,
+          { id: 2, kind: 'strong', code: canonicalStrongFixture.identities[0]!.code },
+        ]
+      : canonicalStrongFixture.identities,
+  }
+  const canonicalJson = `${JSON.stringify(canonical)}\n`
+  const sqlite = await makeOfflineSqlite(canonical)
+  const offline = zipSync({ 'bible-lsg-strong.sqlite': sqlite })
+  const onlineAccess = options.onlineAccess ?? true
+  const manifest: StrongBiblePublicationBundleManifest = {
+    format: 'bible-strong-resource-publication',
+    schemaVersion: 1,
+    identity: {
+      kind: 'strong-bible-index',
+      versionId: canonical.applicationVersionId,
+      datasetId: canonical.datasetId,
+      language: 'fr',
+    },
+    revision: canonical.strongRevision,
+    canonical: {
+      path: 'canonical/bible-lsg-strong.json',
+      mediaType: 'application/json',
+      schemaVersion: 1,
+      sha256: sha256(canonicalJson),
+      bytes: Buffer.byteLength(canonicalJson),
+    },
+    offlineArtifact: {
+      path: 'offline/bible-lsg-strong.sqlite.zip',
+      mediaType: 'application/zip',
+      entry: 'bible-lsg-strong.sqlite',
+      sha256: sha256(offline),
+      bytes: offline.byteLength,
+      contentSha256: sha256(sqlite),
+    },
+    provenance: {
+      generator: 'bible-lexicon-maker',
+      sourceVersion: 'SG1910',
+      sourceSha256: '3'.repeat(64),
+      generatedAt: '2026-08-16T00:00:00.000Z',
+    },
+    rights: {
+      holder: 'Public domain',
+      termsReference: 'Segond 1910',
+      attribution: 'Louis Segond',
+      online: onlineAccess,
+      offline: true,
+    },
+    deliveryCapabilities: {
+      onlineAccess,
+      offlineDownload: true,
+      localDevelopmentAccess: options.localDevelopmentAccess,
+    },
+    dependencies: {
+      bible: {
+        resourceIdentity: 'bible-text:LSG',
+        revision: canonical.textRevision,
+        textSha256: canonical.textSha256,
+        online: 'required',
+        offline: 'required',
+      },
+      strongLexiconModules: [
+        {
+          resourceIdentity: 'strong-lexicon:core',
+          online: 'required-for-lexical-details',
+          offline: 'required-for-lexical-details',
+        },
+      ],
+    },
+    counts: {
+      verses: 1,
+      occurrences: 1,
+      unalignedOccurrences: 0,
+      identities: 1,
+      lexemeAssignments: 1,
+      lexemes: 1,
+    },
+  }
+
+  await mkdir(path.join(root, 'canonical'), { recursive: true })
+  await mkdir(path.join(root, 'offline'), { recursive: true })
+  await writeFile(path.join(root, manifest.canonical.path), canonicalJson)
+  await writeFile(path.join(root, manifest.offlineArtifact.path), offline)
+  await writeFile(path.join(root, 'manifest.json'), `${JSON.stringify(manifest)}\n`)
+  return { canonical, manifest }
+}

--- a/resource-service/src/publication/__tests__/strongPublicationFixture.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationFixture.ts
@@ -5,9 +5,10 @@ import path from 'node:path'
 import { zipSync } from 'fflate'
 import initSqlJs from 'sql.js'
 
-import type {
-  CanonicalStrongBiblePublication,
-  StrongBiblePublicationBundleManifest,
+import {
+  deriveStrongBibleResourceRevision,
+  type CanonicalStrongBiblePublication,
+  type StrongBiblePublicationBundleManifest,
 } from '../publicationBundle'
 
 const sha256 = (value: string | Uint8Array) => createHash('sha256').update(value).digest('hex')
@@ -86,7 +87,12 @@ const makeOfflineSqlite = async (canonical: CanonicalStrongBiblePublication) => 
   })) {
     database.run('INSERT INTO ResourceMetadata(key, value) VALUES (?, ?)', [key, String(value)])
   }
-  database.run('INSERT INTO Verses VALUES (1, 1, 1, 1)')
+  const firstVerse = canonical.verses[0]!
+  database.run('INSERT INTO Verses VALUES (1, ?, ?, ?)', [
+    firstVerse.book,
+    firstVerse.chapter,
+    firstVerse.verse,
+  ])
   database.run("INSERT INTO FrenchLexemes VALUES (1, 'Dieu', 'N')")
   database.run('INSERT INTO WordSpans VALUES (1, 0, 0, 4, 1, 0, 1, 1, 7)')
   database.run("INSERT INTO StrongCodes VALUES (1, 0, 'H0430')")
@@ -106,6 +112,8 @@ export const writeStrongPublicationFixture = async (
     textRevision?: string
     textSha256?: string
     duplicateIdentityCode?: boolean
+    extraOfflineEntry?: boolean
+    zeroVerse?: boolean
   } = {}
 ) => {
   const canonical: CanonicalStrongBiblePublication = {
@@ -119,10 +127,23 @@ export const writeStrongPublicationFixture = async (
           { id: 2, kind: 'strong', code: canonicalStrongFixture.identities[0]!.code },
         ]
       : canonicalStrongFixture.identities,
+    ...(options.zeroVerse
+      ? {
+          verses: canonicalStrongFixture.verses.map(verse => ({ ...verse, verse: 0 })),
+          spans: canonicalStrongFixture.spans.map(span => ({ ...span, verse: 0 })),
+          spanIdentities: canonicalStrongFixture.spanIdentities.map(identity => ({
+            ...identity,
+            verse: 0,
+          })),
+        }
+      : {}),
   }
   const canonicalJson = `${JSON.stringify(canonical)}\n`
   const sqlite = await makeOfflineSqlite(canonical)
-  const offline = zipSync({ 'bible-lsg-strong.sqlite': sqlite })
+  const offline = zipSync({
+    'bible-lsg-strong.sqlite': sqlite,
+    ...(options.extraOfflineEntry ? { 'unexpected.txt': new TextEncoder().encode('bad') } : {}),
+  })
   const onlineAccess = options.onlineAccess ?? true
   const manifest: StrongBiblePublicationBundleManifest = {
     format: 'bible-strong-resource-publication',
@@ -133,7 +154,7 @@ export const writeStrongPublicationFixture = async (
       datasetId: canonical.datasetId,
       language: 'fr',
     },
-    revision: canonical.strongRevision,
+    revision: deriveStrongBibleResourceRevision(canonical),
     canonical: {
       path: 'canonical/bible-lsg-strong.json',
       mediaType: 'application/json',

--- a/resource-service/src/publication/__tests__/strongPublicationImporter.integration.node-test.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationImporter.integration.node-test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+
+import { Effect } from 'effect'
+
+import { createIsolatedPostgres } from '../../database/__tests__/isolatedPostgresTestSupport'
+import { makeKyselyStrongBibleRepository } from '../../repositories/strongBibleRepository'
+import { importPublicationBundle } from '../../repositories/publicationImporter'
+import { writeStrongPublicationFixture } from './strongPublicationFixture'
+
+const runIntegration = process.env.RESOURCE_INTEGRATION === '1'
+const connectionString =
+  process.env.RESOURCE_DATABASE_URL ??
+  'postgresql://bible_strong:bible_strong@127.0.0.1:54329/bible_strong'
+
+describe('Strong Bible publication import', { skip: !runIntegration }, () => {
+  it('atomically imports, idempotently reimports, replaces, and queries the Strong domain', async () => {
+    const bundle = await mkdtemp(path.join(tmpdir(), 'strong-publication-import-'))
+    const isolated = await createIsolatedPostgres(connectionString, 'strong_publication')
+    try {
+      await writeStrongPublicationFixture(bundle)
+      await isolated.database
+        .insertInto('resource_publications')
+        .values({
+          resource_identity: 'bible-text:LSG',
+          resource_kind: 'bible-text',
+          revision: 'lsg-text-v1',
+          language: 'fr',
+          status: 'active',
+          canonical_sha256: '4'.repeat(64),
+          offline_artifact_sha256: '5'.repeat(64),
+          provenance: { source: 'integration-test', imported_at: new Date(0).toISOString() },
+          rights: { holder: 'integration-test', online: true, offline: true },
+          metadata: { text_revision: 'lsg-text-v1', text_sha256: '1'.repeat(64) },
+          activated_at: new Date(0),
+        })
+        .executeTakeFirstOrThrow()
+      const first = await Effect.runPromise(importPublicationBundle(bundle, isolated.database))
+      const second = await Effect.runPromise(importPublicationBundle(bundle, isolated.database))
+
+      assert.equal(first.status, 'activated')
+      assert.equal(second.status, 'unchanged')
+      const repository = makeKyselyStrongBibleRepository(isolated.database)
+      const coverage = await Effect.runPromise(repository.findActiveCoverage('LSG'))
+      const chapter = await Effect.runPromise(
+        repository.findActiveChapter({ versionId: 'LSG', book: 1, chapter: 1 })
+      )
+      const counts = await Effect.runPromise(
+        repository.findCountsByBook({ versionId: 'LSG', book: 1, reference: 'H0430' })
+      )
+      const occurrences = await Effect.runPromise(
+        repository.findOccurrences({
+          versionId: 'LSG',
+          book: 1,
+          reference: 'H0430',
+          limit: 1,
+          allBooks: true,
+        })
+      )
+      const lemmas = await Effect.runPromise(
+        repository.findLemmaStats({ versionId: 'LSG', book: 1, reference: 'H0430' })
+      )
+
+      assert.deepEqual(coverage.books, [1])
+      assert.deepEqual(chapter.verses[0]?.spans[0], {
+        ordinal: 0,
+        startOffset: 0,
+        length: 4,
+        stepTokenIds: [7, 8],
+        identities: [{ kind: 'strong', code: 'H0430' }],
+      })
+      assert.deepEqual(counts.counts, [{ book: 1, verseCount: 1 }])
+      assert.deepEqual(
+        occurrences.verses.map(verse => [verse.book, verse.chapter, verse.verse]),
+        [[1, 1, 1]]
+      )
+      assert.deepEqual(lemmas.lemmas, [
+        { id: 1, lemma: 'Dieu', partOfSpeech: 'N', occurrenceCount: 1 },
+      ])
+
+      await isolated.database
+        .updateTable('resource_publications')
+        .set({
+          metadata: {
+            text_revision: 'different-bible-revision',
+            text_sha256: '1'.repeat(64),
+          },
+        })
+        .where('resource_identity', '=', 'bible-text:LSG')
+        .executeTakeFirstOrThrow()
+      const mismatchedDependency = await Effect.runPromise(
+        Effect.either(repository.findActiveCoverage('LSG'))
+      )
+      assert.equal(mismatchedDependency._tag, 'Left')
+      if (mismatchedDependency._tag === 'Left') {
+        assert.equal(mismatchedDependency.left._tag, 'ActiveStrongBiblePublicationUnavailable')
+      }
+
+      await isolated.database
+        .updateTable('resource_publications')
+        .set({ metadata: { text_revision: 'lsg-text-v1', text_sha256: '0'.repeat(64) } })
+        .where('resource_identity', '=', 'bible-text:LSG')
+        .executeTakeFirstOrThrow()
+      const mismatchedHash = await Effect.runPromise(
+        Effect.either(repository.findActiveCoverage('LSG'))
+      )
+      assert.equal(mismatchedHash._tag, 'Left')
+
+      await isolated.database
+        .updateTable('resource_publications')
+        .set({ metadata: { text_revision: 'lsg-text-v1', text_sha256: '1'.repeat(64) } })
+        .where('resource_identity', '=', 'bible-text:LSG')
+        .executeTakeFirstOrThrow()
+      await writeStrongPublicationFixture(bundle, { strongRevision: '6'.repeat(64) })
+      const replacement = await Effect.runPromise(
+        importPublicationBundle(bundle, isolated.database)
+      )
+      const activePublications = await isolated.database
+        .selectFrom('resource_publications')
+        .select(['revision', 'status'])
+        .where('resource_identity', '=', 'strong-bible-index:LSG')
+        .execute()
+
+      assert.equal(replacement.status, 'activated')
+      assert.deepEqual(activePublications, [{ revision: '6'.repeat(64), status: 'active' }])
+      await Effect.runPromise(repository.findActiveCoverage('LSG'))
+    } finally {
+      await isolated.dispose()
+      await rm(bundle, { recursive: true, force: true })
+    }
+  })
+})

--- a/resource-service/src/publication/__tests__/strongPublicationImporter.integration.node-test.ts
+++ b/resource-service/src/publication/__tests__/strongPublicationImporter.integration.node-test.ts
@@ -114,7 +114,9 @@ describe('Strong Bible publication import', { skip: !runIntegration }, () => {
         .set({ metadata: { text_revision: 'lsg-text-v1', text_sha256: '1'.repeat(64) } })
         .where('resource_identity', '=', 'bible-text:LSG')
         .executeTakeFirstOrThrow()
-      await writeStrongPublicationFixture(bundle, { strongRevision: '6'.repeat(64) })
+      const replacementFixture = await writeStrongPublicationFixture(bundle, {
+        strongRevision: '6'.repeat(64),
+      })
       const replacement = await Effect.runPromise(
         importPublicationBundle(bundle, isolated.database)
       )
@@ -125,8 +127,11 @@ describe('Strong Bible publication import', { skip: !runIntegration }, () => {
         .execute()
 
       assert.equal(replacement.status, 'activated')
-      assert.deepEqual(activePublications, [{ revision: '6'.repeat(64), status: 'active' }])
-      await Effect.runPromise(repository.findActiveCoverage('LSG'))
+      assert.deepEqual(activePublications, [
+        { revision: replacementFixture.manifest.revision, status: 'active' },
+      ])
+      const replacementCoverage = await Effect.runPromise(repository.findActiveCoverage('LSG'))
+      assert.equal(replacementCoverage.strongRevision, '6'.repeat(64))
     } finally {
       await isolated.dispose()
       await rm(bundle, { recursive: true, force: true })

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { readFile, stat } from 'node:fs/promises'
+import { lstat, readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
 
 import { Schema } from 'effect'
@@ -15,6 +15,7 @@ import {
   getStrongBibleCatalogIdentity,
   isStrongBibleVersionId,
 } from '../../../src/helpers/strongBibleCatalog'
+import { STRONG_IDENTITY_KINDS } from '../../../src/helpers/strongIdentities'
 
 const Sha256 = Schema.String.pipe(Schema.pattern(/^[a-f0-9]{64}$/))
 const Language = Schema.String.pipe(Schema.pattern(/^[a-z]{2,3}(?:-[A-Za-z0-9]+)*$/))
@@ -390,9 +391,17 @@ const fileSha256 = async (filePath: string): Promise<string> =>
 const assertArtifact = async (
   filePath: string,
   artifact: { sha256: string; bytes: number },
-  label: string
+  label: string,
+  bundleRoot: string
 ) => {
-  const fileStat = await stat(filePath)
+  const [fileStat, resolvedFile, resolvedRoot] = await Promise.all([
+    lstat(filePath),
+    realpath(filePath),
+    realpath(bundleRoot),
+  ])
+  if (!fileStat.isFile() || !resolvedFile.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`${label}_PATH_INVALID`)
+  }
   if (fileStat.size !== artifact.bytes) throw new Error(`${label}_SIZE_MISMATCH`)
   if ((await fileSha256(filePath)) !== artifact.sha256) {
     throw new Error(`${label}_CHECKSUM_MISMATCH`)
@@ -516,7 +525,7 @@ export const decodeCanonicalStrongBible = (value: unknown): CanonicalStrongBible
       !verse ||
       !isPositiveInteger(verse.book) ||
       !isPositiveInteger(verse.chapter) ||
-      !isNonNegativeInteger(verse.verse)
+      !isPositiveInteger(verse.verse)
     ) {
       throw new Error('CANONICAL_STRONG_BIBLE_VERSE_INVALID')
     }
@@ -676,6 +685,15 @@ export const countCanonicalStrongBibleContent = (publication: CanonicalStrongBib
   lexemes: publication.lexemes.length,
 })
 
+export const deriveStrongBibleResourceRevision = (
+  publication: CanonicalStrongBiblePublication
+): string => {
+  const digest = createHash('sha256')
+    .update(JSON.stringify(normalizeJson(publication)))
+    .digest('hex')
+  return `${publication.applicationVersionId.toLowerCase()}-strong-${digest.slice(0, 20)}`
+}
+
 export const getCanonicalNaveAlphabeticalBrowse = (publication: CanonicalNavePublication) => {
   const topicCountByInitial: Record<string, number> = {}
   for (const topic of publication.topics) {
@@ -785,8 +803,6 @@ const validateNaveOfflineParity = async (
     database?.close()
   }
 }
-
-const STRONG_IDENTITY_KINDS = ['strong', 'estrong', 'dstrong', 'ustrong'] as const
 
 const requireSqliteInteger = (value: unknown) => {
   if (!Number.isSafeInteger(value)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
@@ -949,19 +965,44 @@ const validateStrongBibleOfflineParity = async (
 
 export const validatePublicationBundle = async (bundlePath: string) => {
   const root = path.resolve(bundlePath)
-  const manifestRaw = await readFile(path.join(root, 'manifest.json'), 'utf8')
+  const manifestPath = path.join(root, 'manifest.json')
+  const [manifestStat, resolvedManifest, resolvedRoot] = await Promise.all([
+    lstat(manifestPath),
+    realpath(manifestPath),
+    realpath(root),
+  ])
+  if (!manifestStat.isFile() || !resolvedManifest.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error('PUBLICATION_BUNDLE_MANIFEST_PATH_INVALID')
+  }
+  const manifestRaw = await readFile(manifestPath, 'utf8')
   const manifest = decodePublicationBundleManifest(JSON.parse(manifestRaw))
   const canonicalPath = path.resolve(root, manifest.canonical.path)
   const offlineArtifactPath = path.resolve(root, manifest.offlineArtifact.path)
 
   await Promise.all([
-    assertArtifact(canonicalPath, manifest.canonical, 'CANONICAL_ARTIFACT'),
-    assertArtifact(offlineArtifactPath, manifest.offlineArtifact, 'OFFLINE_ARTIFACT'),
+    assertArtifact(canonicalPath, manifest.canonical, 'CANONICAL_ARTIFACT', root),
+    assertArtifact(offlineArtifactPath, manifest.offlineArtifact, 'OFFLINE_ARTIFACT', root),
   ])
 
   let offlineEntries: ReturnType<typeof unzipSync>
   try {
-    offlineEntries = unzipSync(await readFile(offlineArtifactPath))
+    const archive = await readFile(offlineArtifactPath)
+    if (archive.byteLength > 512 * 1024 * 1024) throw new Error('archive-too-large')
+    const seenEntries: string[] = []
+    offlineEntries = unzipSync(archive, {
+      filter: entry => {
+        seenEntries.push(entry.name)
+        if (
+          entry.name !== manifest.offlineArtifact.entry ||
+          entry.originalSize > 512 * 1024 * 1024 ||
+          entry.originalSize > Math.max(entry.size * 250, 1024 * 1024)
+        ) {
+          throw new Error('archive-entry-invalid')
+        }
+        return true
+      },
+    })
+    if (seenEntries.length !== 1) throw new Error('archive-entries-invalid')
   } catch (cause) {
     throw new Error('OFFLINE_ARTIFACT_INVALID', { cause })
   }
@@ -1084,7 +1125,7 @@ export const validatePublicationBundle = async (bundlePath: string) => {
     if (
       canonical.applicationVersionId !== manifest.identity.versionId ||
       canonical.datasetId !== manifest.identity.datasetId ||
-      canonical.strongRevision !== manifest.revision ||
+      deriveStrongBibleResourceRevision(canonical) !== manifest.revision ||
       canonical.textRevision !== manifest.dependencies.bible.revision ||
       canonical.textSha256 !== manifest.dependencies.bible.textSha256
     ) {

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -989,11 +989,18 @@ export const validatePublicationBundle = async (bundlePath: string) => {
     const archive = await readFile(offlineArtifactPath)
     if (archive.byteLength > 512 * 1024 * 1024) throw new Error('archive-too-large')
     const seenEntries: string[] = []
+    const expectedEntries = new Set(
+      manifest.offlineArtifact.entries
+        ? Object.values(manifest.offlineArtifact.entries)
+            .filter(entry => entry !== undefined)
+            .map(entry => entry.entry)
+        : [manifest.offlineArtifact.entry]
+    )
     offlineEntries = unzipSync(archive, {
       filter: entry => {
         seenEntries.push(entry.name)
         if (
-          entry.name !== manifest.offlineArtifact.entry ||
+          !expectedEntries.has(entry.name) ||
           entry.originalSize > 512 * 1024 * 1024 ||
           entry.originalSize > Math.max(entry.size * 250, 1024 * 1024)
         ) {
@@ -1002,7 +1009,12 @@ export const validatePublicationBundle = async (bundlePath: string) => {
         return true
       },
     })
-    if (seenEntries.length !== 1) throw new Error('archive-entries-invalid')
+    if (
+      seenEntries.length !== expectedEntries.size ||
+      seenEntries.some(entry => !expectedEntries.has(entry))
+    ) {
+      throw new Error('archive-entries-invalid')
+    }
   } catch (cause) {
     throw new Error('OFFLINE_ARTIFACT_INVALID', { cause })
   }

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -11,6 +11,10 @@ import {
   BibleVersePresentationDto,
   type BibleVersePresentation,
 } from '../../../src/features/resources/bibleChapterContract'
+import {
+  getStrongBibleCatalogIdentity,
+  isStrongBibleVersionId,
+} from '../../../src/helpers/strongBibleCatalog'
 
 const Sha256 = Schema.String.pipe(Schema.pattern(/^[a-f0-9]{64}$/))
 const Language = Schema.String.pipe(Schema.pattern(/^[a-z]{2,3}(?:-[A-Za-z0-9]+)*$/))
@@ -135,16 +139,54 @@ const NavePublicationBundleManifestSchema = Schema.Struct({
   }),
 })
 
+const StrongBiblePublicationBundleManifestSchema = Schema.Struct({
+  ...PublicationBundleCommonFields,
+  identity: Schema.Struct({
+    kind: Schema.Literal('strong-bible-index'),
+    versionId: Schema.NonEmptyString,
+    datasetId: Schema.NonEmptyString,
+    language: Language,
+  }),
+  dependencies: Schema.Struct({
+    bible: Schema.Struct({
+      resourceIdentity: Schema.NonEmptyString,
+      revision: Schema.NonEmptyString,
+      textSha256: Sha256,
+      online: Schema.Literal('required'),
+      offline: Schema.Literal('required'),
+    }),
+    strongLexiconModules: Schema.Array(
+      Schema.Struct({
+        resourceIdentity: Schema.NonEmptyString,
+        online: Schema.Literal('required-for-lexical-details'),
+        offline: Schema.Literal('required-for-lexical-details'),
+      })
+    ),
+  }),
+  counts: Schema.Struct({
+    verses: Schema.NonNegativeInt,
+    occurrences: Schema.NonNegativeInt,
+    unalignedOccurrences: Schema.NonNegativeInt,
+    identities: Schema.NonNegativeInt,
+    lexemeAssignments: Schema.NonNegativeInt,
+    lexemes: Schema.NonNegativeInt,
+  }),
+})
+
 const PublicationBundleManifestSchema = Schema.Union(
   BiblePublicationBundleManifestSchema,
-  NavePublicationBundleManifestSchema
+  NavePublicationBundleManifestSchema,
+  StrongBiblePublicationBundleManifestSchema
 )
 
 export type BiblePublicationBundleManifest = typeof BiblePublicationBundleManifestSchema.Type
 export type NavePublicationBundleManifest = typeof NavePublicationBundleManifestSchema.Type
+export type StrongBiblePublicationBundleManifest =
+  typeof StrongBiblePublicationBundleManifestSchema.Type
 export type PublicationBundleManifest =
   | BiblePublicationBundleManifest
   | NavePublicationBundleManifest
+  | StrongBiblePublicationBundleManifest
 
 export const isBiblePublicationBundleManifest = (
   manifest: PublicationBundleManifest
@@ -153,6 +195,11 @@ export const isBiblePublicationBundleManifest = (
 export const isNavePublicationBundleManifest = (
   manifest: PublicationBundleManifest
 ): manifest is NavePublicationBundleManifest => manifest.identity.kind === 'nave'
+
+export const isStrongBiblePublicationBundleManifest = (
+  manifest: PublicationBundleManifest
+): manifest is StrongBiblePublicationBundleManifest =>
+  manifest.identity.kind === 'strong-bible-index'
 
 export type CanonicalBibleVerse = BibleVersePresentation & {
   text: string
@@ -195,7 +242,45 @@ export type CanonicalNavePublication = {
   verseAnchors: CanonicalNaveVerseAnchor[]
 }
 
-export type CanonicalPublication = CanonicalBiblePublication | CanonicalNavePublication
+export type CanonicalStrongBibleVerse = { book: number; chapter: number; verse: number }
+export type CanonicalStrongBibleLexeme = { id: number; lemma: string; partOfSpeech: string }
+export type CanonicalStrongBibleIdentity = {
+  id: number
+  kind: 'strong' | 'estrong' | 'dstrong' | 'ustrong'
+  code: string
+}
+export type CanonicalStrongBibleSpan = CanonicalStrongBibleVerse & {
+  ordinal: number
+  startOffset: number
+  length: number
+  isAligned: boolean
+  lexemeId?: number
+  stepTokenIds?: number[]
+}
+export type CanonicalStrongBibleSpanIdentity = CanonicalStrongBibleVerse & {
+  ordinal: number
+  identityOrder: number
+  identityId: number
+}
+export type CanonicalStrongBiblePublication = {
+  format: 'bible-strong-canonical-strong-index'
+  schemaVersion: 1
+  applicationVersionId: string
+  datasetId: string
+  textRevision: string
+  textSha256: string
+  strongRevision: string
+  verses: CanonicalStrongBibleVerse[]
+  lexemes: CanonicalStrongBibleLexeme[]
+  identities: CanonicalStrongBibleIdentity[]
+  spans: CanonicalStrongBibleSpan[]
+  spanIdentities: CanonicalStrongBibleSpanIdentity[]
+}
+
+export type CanonicalPublication =
+  | CanonicalBiblePublication
+  | CanonicalNavePublication
+  | CanonicalStrongBiblePublication
 
 const normalizeJson = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(normalizeJson)
@@ -212,9 +297,9 @@ const normalizeJson = (value: unknown): unknown => {
 export const derivePublicationRevision = (manifest: PublicationBundleManifest): string => {
   const { publicationRevision, ...envelope } = manifest
   const resourceId =
-    manifest.identity.kind === 'bible-text'
-      ? manifest.identity.versionId.toLowerCase()
-      : manifest.identity.resourceId.toLowerCase()
+    manifest.identity.kind === 'nave'
+      ? manifest.identity.resourceId.toLowerCase()
+      : manifest.identity.versionId.toLowerCase()
   const digest = createHash('sha256')
     .update(JSON.stringify(normalizeJson(envelope)))
     .digest('hex')
@@ -277,6 +362,21 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
       Object.values(manifest.alphabeticalBrowse.topicCountByInitial).some(count => count === 0))
   ) {
     throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_INVALID')
+  }
+  if (
+    isStrongBiblePublicationBundleManifest(manifest) &&
+    (!isStrongBibleVersionId(manifest.identity.versionId) ||
+      manifest.identity.datasetId !==
+        getStrongBibleCatalogIdentity(manifest.identity.versionId).datasetId ||
+      manifest.identity.language !==
+        getStrongBibleCatalogIdentity(manifest.identity.versionId).language ||
+      manifest.dependencies.bible.resourceIdentity !==
+        `bible-text:${manifest.identity.versionId}` ||
+      !manifest.dependencies.strongLexiconModules.some(
+        dependency => dependency.resourceIdentity === 'strong-lexicon:core'
+      ))
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_DEPENDENCY_INVALID')
   }
 
   return manifest
@@ -380,6 +480,131 @@ export const decodeCanonicalNave = (value: unknown): CanonicalNavePublication =>
   return candidate as CanonicalNavePublication
 }
 
+const isPositiveInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && Number(value) > 0
+const isNonNegativeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && Number(value) >= 0
+const strongLocationKey = (location: CanonicalStrongBibleVerse) =>
+  `${location.book}-${location.chapter}-${location.verse}`
+const strongSpanKey = (span: CanonicalStrongBibleVerse & { ordinal: number }) =>
+  `${strongLocationKey(span)}-${span.ordinal}`
+
+export const decodeCanonicalStrongBible = (value: unknown): CanonicalStrongBiblePublication => {
+  if (!value || typeof value !== 'object') throw new Error('CANONICAL_STRONG_BIBLE_INVALID')
+  const candidate = value as Partial<CanonicalStrongBiblePublication>
+  if (
+    candidate.format !== 'bible-strong-canonical-strong-index' ||
+    candidate.schemaVersion !== 1 ||
+    !isNonEmptyString(candidate.applicationVersionId) ||
+    !isNonEmptyString(candidate.datasetId) ||
+    !isNonEmptyString(candidate.textRevision) ||
+    !isNonEmptyString(candidate.textSha256) ||
+    !/^[a-f0-9]{64}$/.test(candidate.textSha256) ||
+    !isNonEmptyString(candidate.strongRevision) ||
+    !Array.isArray(candidate.verses) ||
+    !Array.isArray(candidate.lexemes) ||
+    !Array.isArray(candidate.identities) ||
+    !Array.isArray(candidate.spans) ||
+    !Array.isArray(candidate.spanIdentities)
+  ) {
+    throw new Error('CANONICAL_STRONG_BIBLE_INVALID')
+  }
+
+  const verseKeys = new Set<string>()
+  for (const verse of candidate.verses) {
+    if (
+      !verse ||
+      !isPositiveInteger(verse.book) ||
+      !isPositiveInteger(verse.chapter) ||
+      !isNonNegativeInteger(verse.verse)
+    ) {
+      throw new Error('CANONICAL_STRONG_BIBLE_VERSE_INVALID')
+    }
+    const key = strongLocationKey(verse)
+    if (verseKeys.has(key)) throw new Error('CANONICAL_STRONG_BIBLE_VERSE_DUPLICATE')
+    verseKeys.add(key)
+  }
+
+  const lexemeIds = new Set<number>()
+  for (const lexeme of candidate.lexemes) {
+    if (
+      !lexeme ||
+      !isPositiveInteger(lexeme.id) ||
+      !isNonEmptyString(lexeme.lemma) ||
+      !isNonEmptyString(lexeme.partOfSpeech)
+    ) {
+      throw new Error('CANONICAL_STRONG_BIBLE_LEXEME_INVALID')
+    }
+    if (lexemeIds.has(lexeme.id)) throw new Error('CANONICAL_STRONG_BIBLE_LEXEME_DUPLICATE')
+    lexemeIds.add(lexeme.id)
+  }
+
+  const identityIds = new Set<number>()
+  const identityCodes = new Set<string>()
+  const identityKinds = new Set(['strong', 'estrong', 'dstrong', 'ustrong'])
+  for (const identity of candidate.identities) {
+    if (
+      !identity ||
+      !isPositiveInteger(identity.id) ||
+      !identityKinds.has(identity.kind) ||
+      !isNonEmptyString(identity.code)
+    ) {
+      throw new Error('CANONICAL_STRONG_BIBLE_IDENTITY_INVALID')
+    }
+    if (identityIds.has(identity.id)) {
+      throw new Error('CANONICAL_STRONG_BIBLE_IDENTITY_DUPLICATE')
+    }
+    const semanticKey = `${identity.kind}:${identity.code}`
+    if (identityCodes.has(semanticKey)) {
+      throw new Error('CANONICAL_STRONG_BIBLE_IDENTITY_DUPLICATE')
+    }
+    identityIds.add(identity.id)
+    identityCodes.add(semanticKey)
+  }
+
+  const spanKeys = new Set<string>()
+  for (const span of candidate.spans) {
+    if (
+      !span ||
+      !verseKeys.has(strongLocationKey(span)) ||
+      !isNonNegativeInteger(span.ordinal) ||
+      !isNonNegativeInteger(span.startOffset) ||
+      !isNonNegativeInteger(span.length) ||
+      typeof span.isAligned !== 'boolean' ||
+      span.isAligned !== span.length > 0 ||
+      (span.lexemeId !== undefined && !lexemeIds.has(span.lexemeId)) ||
+      (span.stepTokenIds !== undefined &&
+        (!Array.isArray(span.stepTokenIds) ||
+          span.stepTokenIds.some(stepTokenId => !isPositiveInteger(stepTokenId))))
+    ) {
+      throw new Error('CANONICAL_STRONG_BIBLE_SPAN_INVALID')
+    }
+    const key = strongSpanKey(span)
+    if (spanKeys.has(key)) throw new Error('CANONICAL_STRONG_BIBLE_SPAN_DUPLICATE')
+    spanKeys.add(key)
+  }
+
+  const spanIdentityKeys = new Set<string>()
+  for (const spanIdentity of candidate.spanIdentities) {
+    const spanKey = strongSpanKey(spanIdentity)
+    if (
+      !spanIdentity ||
+      !spanKeys.has(spanKey) ||
+      !isNonNegativeInteger(spanIdentity.identityOrder) ||
+      !identityIds.has(spanIdentity.identityId)
+    ) {
+      throw new Error('CANONICAL_STRONG_BIBLE_SPAN_IDENTITY_INVALID')
+    }
+    const key = `${spanKey}-${spanIdentity.identityOrder}`
+    if (spanIdentityKeys.has(key)) {
+      throw new Error('CANONICAL_STRONG_BIBLE_SPAN_IDENTITY_DUPLICATE')
+    }
+    spanIdentityKeys.add(key)
+  }
+
+  return candidate as CanonicalStrongBiblePublication
+}
+
 export const countCanonicalContent = (publication: CanonicalBiblePublication) => {
   let chapters = 0
   let verses = 0
@@ -440,6 +665,15 @@ export const countCanonicalNaveContent = (publication: CanonicalNavePublication)
     (count, anchor) => count + anchor.topicNormalizedNames.length,
     0
   ),
+})
+
+export const countCanonicalStrongBibleContent = (publication: CanonicalStrongBiblePublication) => ({
+  verses: publication.verses.length,
+  occurrences: publication.spans.length,
+  unalignedOccurrences: publication.spans.filter(span => !span.isAligned).length,
+  identities: publication.spanIdentities.length,
+  lexemeAssignments: publication.spans.filter(span => span.lexemeId !== undefined).length,
+  lexemes: publication.lexemes.length,
 })
 
 export const getCanonicalNaveAlphabeticalBrowse = (publication: CanonicalNavePublication) => {
@@ -552,6 +786,167 @@ const validateNaveOfflineParity = async (
   }
 }
 
+const STRONG_IDENTITY_KINDS = ['strong', 'estrong', 'dstrong', 'ustrong'] as const
+
+const requireSqliteInteger = (value: unknown) => {
+  if (!Number.isSafeInteger(value)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+  return Number(value)
+}
+
+const compareStrongLocation = (
+  left: CanonicalStrongBibleVerse & { ordinal?: number; identityOrder?: number },
+  right: CanonicalStrongBibleVerse & { ordinal?: number; identityOrder?: number }
+) =>
+  left.book - right.book ||
+  left.chapter - right.chapter ||
+  left.verse - right.verse ||
+  (left.ordinal ?? -1) - (right.ordinal ?? -1) ||
+  (left.identityOrder ?? -1) - (right.identityOrder ?? -1)
+
+const validateStrongBibleOfflineParity = async (
+  offlineContent: Uint8Array,
+  canonical: CanonicalStrongBiblePublication
+) => {
+  const SQL = await initSqlJs()
+  let database: Database | undefined
+  try {
+    database = new SQL.Database(offlineContent)
+    const metadata = Object.fromEntries(
+      readSqliteRows(database, 'SELECT key, value FROM ResourceMetadata').map(row => [
+        requireSqliteString(row.key),
+        requireSqliteString(row.value),
+      ])
+    )
+    if (
+      metadata.applicationVersionId !== canonical.applicationVersionId ||
+      metadata.datasetId !== canonical.datasetId ||
+      metadata.textRevision !== canonical.textRevision ||
+      metadata.textSha256 !== canonical.textSha256 ||
+      metadata.strongRevision !== canonical.strongRevision
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+
+    const verses = readSqliteRows(
+      database,
+      'SELECT bookOrder AS book, chapter, verse FROM Verses ORDER BY bookOrder, chapter, verse'
+    ).map(row => ({
+      book: requireSqliteInteger(row.book),
+      chapter: requireSqliteInteger(row.chapter),
+      verse: requireSqliteInteger(row.verse),
+    }))
+    const lexemes = readSqliteRows(
+      database,
+      'SELECT id, lemma, partOfSpeech FROM FrenchLexemes ORDER BY id'
+    ).map(row => ({
+      id: requireSqliteInteger(row.id),
+      lemma: requireSqliteString(row.lemma),
+      partOfSpeech: requireSqliteString(row.partOfSpeech),
+    }))
+    const identities = readSqliteRows(
+      database,
+      'SELECT id, kind, code FROM StrongCodes ORDER BY id'
+    ).map(row => {
+      const kind = STRONG_IDENTITY_KINDS[requireSqliteInteger(row.kind)]
+      if (!kind) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+      return {
+        id: requireSqliteInteger(row.id),
+        kind,
+        code: requireSqliteString(row.code),
+      }
+    })
+    const wordSpanColumns = new Set(
+      readSqliteRows(database, 'PRAGMA table_info(WordSpans)').map(row =>
+        requireSqliteString(row.name)
+      )
+    )
+    const extrasTable = readSqliteRows(
+      database,
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='WordStepTokenExtras'"
+    )
+    const extrasBySpan = new Map<string, number[]>()
+    if (extrasTable.length > 0) {
+      for (const row of readSqliteRows(
+        database,
+        `SELECT verseId, targetOrdinal, stepTokenId
+         FROM WordStepTokenExtras ORDER BY verseId, targetOrdinal, sourceOrder`
+      )) {
+        const key = `${requireSqliteInteger(row.verseId)}-${requireSqliteInteger(
+          row.targetOrdinal
+        )}`
+        const stepTokenIds = extrasBySpan.get(key) ?? []
+        stepTokenIds.push(requireSqliteInteger(row.stepTokenId))
+        extrasBySpan.set(key, stepTokenIds)
+      }
+    }
+    const spans = readSqliteRows(
+      database,
+      `SELECT v.id AS verseId, v.bookOrder AS book, v.chapter, v.verse,
+              s.ordinal, s.startOffset, s.length, s.isAligned, s.lexemeId${
+                wordSpanColumns.has('stepTokenId') ? ', s.stepTokenId' : ''
+              }
+         FROM WordSpans s JOIN Verses v ON v.id=s.verseId
+        ORDER BY v.bookOrder, v.chapter, v.verse, s.ordinal`
+    ).map(row => {
+      const verseId = requireSqliteInteger(row.verseId)
+      const ordinal = requireSqliteInteger(row.ordinal)
+      const primaryStepTokenId = wordSpanColumns.has('stepTokenId')
+        ? row.stepTokenId == null
+          ? undefined
+          : requireSqliteInteger(row.stepTokenId)
+        : undefined
+      const stepTokenIds = [
+        ...(primaryStepTokenId === undefined ? [] : [primaryStepTokenId]),
+        ...(extrasBySpan.get(`${verseId}-${ordinal}`) ?? []),
+      ]
+      return {
+        book: requireSqliteInteger(row.book),
+        chapter: requireSqliteInteger(row.chapter),
+        verse: requireSqliteInteger(row.verse),
+        ordinal,
+        startOffset: requireSqliteInteger(row.startOffset),
+        length: requireSqliteInteger(row.length),
+        isAligned: requireSqliteInteger(row.isAligned) === 1,
+        ...(row.lexemeId == null ? {} : { lexemeId: requireSqliteInteger(row.lexemeId) }),
+        ...(stepTokenIds.length ? { stepTokenIds } : {}),
+      }
+    })
+    const spanIdentities = readSqliteRows(
+      database,
+      `SELECT v.bookOrder AS book, v.chapter, v.verse, w.ordinal,
+              w.identityOrder, w.codeId AS identityId
+         FROM WordStrongCodes w JOIN Verses v ON v.id=w.verseId
+        ORDER BY v.bookOrder, v.chapter, v.verse, w.ordinal, w.identityOrder`
+    ).map(row => ({
+      book: requireSqliteInteger(row.book),
+      chapter: requireSqliteInteger(row.chapter),
+      verse: requireSqliteInteger(row.verse),
+      ordinal: requireSqliteInteger(row.ordinal),
+      identityOrder: requireSqliteInteger(row.identityOrder),
+      identityId: requireSqliteInteger(row.identityId),
+    }))
+
+    const expected = {
+      verses: [...canonical.verses].sort(compareStrongLocation),
+      lexemes: [...canonical.lexemes].sort((left, right) => left.id - right.id),
+      identities: [...canonical.identities].sort((left, right) => left.id - right.id),
+      spans: [...canonical.spans].sort(compareStrongLocation),
+      spanIdentities: [...canonical.spanIdentities].sort(compareStrongLocation),
+    }
+    if (
+      JSON.stringify({ verses, lexemes, identities, spans, spanIdentities }) !==
+      JSON.stringify(expected)
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.startsWith('OFFLINE_ARTIFACT_')) throw cause
+    throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+  } finally {
+    database?.close()
+  }
+}
+
 export const validatePublicationBundle = async (bundlePath: string) => {
   const root = path.resolve(bundlePath)
   const manifestRaw = await readFile(path.join(root, 'manifest.json'), 'utf8')
@@ -579,7 +974,8 @@ export const validatePublicationBundle = async (bundlePath: string) => {
     throw new Error('OFFLINE_ARTIFACT_ENTRY_CHECKSUM_MISMATCH')
   }
   if (
-    isNavePublicationBundleManifest(manifest) &&
+    (isNavePublicationBundleManifest(manifest) ||
+      isStrongBiblePublicationBundleManifest(manifest)) &&
     !Buffer.from(offlineContent)
       .subarray(0, 16)
       .equals(Buffer.from('SQLite format 3\u0000', 'utf8'))
@@ -663,7 +1059,7 @@ export const validatePublicationBundle = async (bundlePath: string) => {
     if (JSON.stringify(archivedCanonical.verses) !== JSON.stringify(canonical.verses)) {
       throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
     }
-  } else {
+  } else if (isNavePublicationBundleManifest(manifest)) {
     canonical = decodeCanonicalNave(canonicalValue)
     if (
       canonical.resourceId !== manifest.identity.resourceId ||
@@ -683,6 +1079,24 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_MISMATCH')
     }
     await validateNaveOfflineParity(offlineContent, canonical)
+  } else {
+    canonical = decodeCanonicalStrongBible(canonicalValue)
+    if (
+      canonical.applicationVersionId !== manifest.identity.versionId ||
+      canonical.datasetId !== manifest.identity.datasetId ||
+      canonical.strongRevision !== manifest.revision ||
+      canonical.textRevision !== manifest.dependencies.bible.revision ||
+      canonical.textSha256 !== manifest.dependencies.bible.textSha256
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
+    }
+    if (
+      JSON.stringify(countCanonicalStrongBibleContent(canonical)) !==
+      JSON.stringify(manifest.counts)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_COUNT_MISMATCH')
+    }
+    await validateStrongBibleOfflineParity(offlineContent, canonical)
   }
 
   return { manifest, canonical, canonicalPath, offlineArtifactPath }

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
 import { lstat, readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
 
@@ -384,9 +385,13 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
 }
 
 const fileSha256 = async (filePath: string): Promise<string> =>
-  createHash('sha256')
-    .update(await readFile(filePath))
-    .digest('hex')
+  new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(filePath)
+    stream.on('data', chunk => hash.update(chunk))
+    stream.on('error', reject)
+    stream.on('end', () => resolve(hash.digest('hex')))
+  })
 
 const assertArtifact = async (
   filePath: string,
@@ -402,6 +407,7 @@ const assertArtifact = async (
   if (!fileStat.isFile() || !resolvedFile.startsWith(`${resolvedRoot}${path.sep}`)) {
     throw new Error(`${label}_PATH_INVALID`)
   }
+  if (fileStat.size > 512 * 1024 * 1024) throw new Error(`${label}_SIZE_LIMIT_EXCEEDED`)
   if (fileStat.size !== artifact.bytes) throw new Error(`${label}_SIZE_MISMATCH`)
   if ((await fileSha256(filePath)) !== artifact.sha256) {
     throw new Error(`${label}_CHECKSUM_MISMATCH`)
@@ -525,7 +531,7 @@ export const decodeCanonicalStrongBible = (value: unknown): CanonicalStrongBible
       !verse ||
       !isPositiveInteger(verse.book) ||
       !isPositiveInteger(verse.chapter) ||
-      !isPositiveInteger(verse.verse)
+      !isNonNegativeInteger(verse.verse)
     ) {
       throw new Error('CANONICAL_STRONG_BIBLE_VERSE_INVALID')
     }
@@ -550,7 +556,7 @@ export const decodeCanonicalStrongBible = (value: unknown): CanonicalStrongBible
 
   const identityIds = new Set<number>()
   const identityCodes = new Set<string>()
-  const identityKinds = new Set(['strong', 'estrong', 'dstrong', 'ustrong'])
+  const identityKinds = new Set<string>(STRONG_IDENTITY_KINDS)
   for (const identity of candidate.identities) {
     if (
       !identity ||
@@ -971,7 +977,11 @@ export const validatePublicationBundle = async (bundlePath: string) => {
     realpath(manifestPath),
     realpath(root),
   ])
-  if (!manifestStat.isFile() || !resolvedManifest.startsWith(`${resolvedRoot}${path.sep}`)) {
+  if (
+    !manifestStat.isFile() ||
+    manifestStat.size > 1024 * 1024 ||
+    !resolvedManifest.startsWith(`${resolvedRoot}${path.sep}`)
+  ) {
     throw new Error('PUBLICATION_BUNDLE_MANIFEST_PATH_INVALID')
   }
   const manifestRaw = await readFile(manifestPath, 'utf8')

--- a/resource-service/src/repositories/bibleChapterRepository.ts
+++ b/resource-service/src/repositories/bibleChapterRepository.ts
@@ -16,6 +16,7 @@ type BiblePublicationMetadata = {
   versification: string
   resource_revision?: string
   text_revision?: string
+  text_sha256?: string
 }
 
 const bibleMetadata = (value: Record<string, unknown>): BiblePublicationMetadata =>
@@ -63,6 +64,9 @@ export const makeKyselyBibleChapterRepository = (
           bibleMetadata(rows[0]!.metadata).text_revision ??
           bibleMetadata(rows[0]!.metadata).resource_revision ??
           rows[0]!.revision,
+        ...(bibleMetadata(rows[0]!.metadata).text_sha256
+          ? { textSha256: bibleMetadata(rows[0]!.metadata).text_sha256 }
+          : {}),
         verses: rows.map(row => ({
           number: row.verse!,
           text: row.text!,
@@ -114,6 +118,7 @@ export const makeKyselyBibleChapterRepository = (
         versionId,
         revision: metadata.resource_revision ?? metadata.text_revision ?? publication.revision,
         textRevision: metadata.resource_revision ?? metadata.text_revision ?? publication.revision,
+        ...(metadata.text_sha256 ? { textSha256: metadata.text_sha256 } : {}),
         canon: metadata.canon,
         versification: metadata.versification,
         books,
@@ -152,6 +157,7 @@ export const makeKyselyBibleChapterRepository = (
         versionId,
         revision: metadata.resource_revision ?? metadata.text_revision ?? publication.revision,
         textRevision: metadata.resource_revision ?? metadata.text_revision ?? publication.revision,
+        ...(metadata.text_sha256 ? { textSha256: metadata.text_sha256 } : {}),
         verses: rows.flatMap(row =>
           row.presentation!.headings.length > 0
             ? [

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -1,12 +1,13 @@
 import { createHash } from 'node:crypto'
 
 import { Data, Effect } from 'effect'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 
 import { tryDatabasePromise, type DatabaseFailure } from '../database/databaseEffect'
 import type { ResourceDatabase } from '../database/types'
 import {
   isBiblePublicationBundleManifest,
+  isNavePublicationBundleManifest,
   validatePublicationBundle,
 } from '../publication/publicationBundle'
 
@@ -70,7 +71,9 @@ export const importPublicationBundle = (
       const { canonical, manifest } = validated
       const resourceIdentity = isBiblePublicationBundleManifest(manifest)
         ? `bible-text:${manifest.identity.versionId}`
-        : `nave:${manifest.identity.language}`
+        : isNavePublicationBundleManifest(manifest)
+          ? `nave:${manifest.identity.language}`
+          : `strong-bible-index:${manifest.identity.versionId}`
       const publicationStatus =
         manifest.deliveryCapabilities.onlineAccess ||
         (options.activateForLocalDevelopment &&
@@ -100,16 +103,34 @@ export const importPublicationBundle = (
             canonical_schema_version: manifest.canonical.schemaVersion,
             resource_revision: manifest.revision,
             text_revision: manifest.revision,
+            text_sha256:
+              canonical.format === 'bible-strong-canonical-bible'
+                ? canonical.textSha256
+                : undefined,
             offline_entry: manifest.offlineArtifact.entry,
           }
-        : {
-            resource_id: manifest.identity.resourceId,
-            alphabetical_browse: manifest.alphabeticalBrowse,
-            delivery_capabilities: manifest.deliveryCapabilities,
-            counts: manifest.counts,
-            canonical_schema_version: manifest.canonical.schemaVersion,
-            offline_entry: manifest.offlineArtifact.entry,
-          }
+        : isNavePublicationBundleManifest(manifest)
+          ? {
+              resource_id: manifest.identity.resourceId,
+              alphabetical_browse: manifest.alphabeticalBrowse,
+              delivery_capabilities: manifest.deliveryCapabilities,
+              counts: manifest.counts,
+              canonical_schema_version: manifest.canonical.schemaVersion,
+              offline_entry: manifest.offlineArtifact.entry,
+            }
+          : {
+              version_id: manifest.identity.versionId,
+              dataset_id: manifest.identity.datasetId,
+              delivery_capabilities: manifest.deliveryCapabilities,
+              dependencies: manifest.dependencies,
+              counts: manifest.counts,
+              canonical_schema_version: manifest.canonical.schemaVersion,
+              resource_revision: manifest.revision,
+              text_revision: manifest.dependencies.bible.revision,
+              text_sha256: manifest.dependencies.bible.textSha256,
+              strong_revision: manifest.revision,
+              offline_entry: manifest.offlineArtifact.entry,
+            }
       const publicationMetadata = { ...metadata, manifest_sha256: manifestSha256 }
       const makeResult = (status: PublicationImportResult['status']): PublicationImportResult =>
         isBiblePublicationBundleManifest(manifest)
@@ -119,12 +140,19 @@ export const importPublicationBundle = (
               revision: manifest.revision,
               verseCount: manifest.counts.verses,
             }
-          : {
-              status,
-              resourceIdentity,
-              revision: manifest.revision,
-              itemCount: manifest.counts.topics,
-            }
+          : isNavePublicationBundleManifest(manifest)
+            ? {
+                status,
+                resourceIdentity,
+                revision: manifest.revision,
+                itemCount: manifest.counts.topics,
+              }
+            : {
+                status,
+                resourceIdentity,
+                revision: manifest.revision,
+                itemCount: manifest.counts.occurrences,
+              }
 
       return tryDatabasePromise(
         'publication.import',
@@ -148,11 +176,16 @@ export const importPublicationBundle = (
 
             if (existing) {
               const { manifest_sha256: storedManifestSha256, ...storedMetadata } = existing.metadata
+              const expectedStoredMetadata = { ...metadata } as Record<string, unknown>
+              const canBackfillTextSha256 =
+                storedMetadata.text_sha256 === undefined &&
+                expectedStoredMetadata.text_sha256 !== undefined
+              if (canBackfillTextSha256) delete expectedStoredMetadata.text_sha256
               if (
                 existing.canonical_sha256 !== manifest.canonical.sha256 ||
                 existing.offline_artifact_sha256 !== manifest.offlineArtifact.sha256 ||
                 (storedManifestSha256 !== undefined && storedManifestSha256 !== manifestSha256) ||
-                !jsonEquals(storedMetadata, metadata) ||
+                !jsonEquals(storedMetadata, expectedStoredMetadata) ||
                 !jsonEquals(existing.rights, rights) ||
                 existing.provenance.source !== provenance.source ||
                 existing.provenance.attribution !== provenance.attribution
@@ -162,7 +195,7 @@ export const importPublicationBundle = (
                   message: 'PUBLICATION_REVISION_COLLISION',
                 })
               }
-              if (storedManifestSha256 === undefined) {
+              if (storedManifestSha256 === undefined || canBackfillTextSha256) {
                 await transaction
                   .updateTable('resource_publications')
                   .set({ metadata: publicationMetadata })
@@ -227,7 +260,7 @@ export const importPublicationBundle = (
                   .values(rows.slice(offset, offset + 1_000))
                   .execute()
               }
-            } else {
+            } else if (canonical.format === 'bible-strong-canonical-nave') {
               for (let offset = 0; offset < canonical.topics.length; offset += 1_000) {
                 assertNotInterrupted(signal)
                 await transaction
@@ -255,6 +288,88 @@ export const importPublicationBundle = (
                 await transaction
                   .insertInto('nave_verse_links')
                   .values(links.slice(offset, offset + 1_000))
+                  .execute()
+              }
+            } else {
+              for (let offset = 0; offset < canonical.verses.length; offset += 1_000) {
+                assertNotInterrupted(signal)
+                await transaction
+                  .insertInto('strong_bible_verses')
+                  .values(
+                    canonical.verses.slice(offset, offset + 1_000).map(verse => ({
+                      publication_id: publication.id,
+                      book: verse.book,
+                      chapter: verse.chapter,
+                      verse: verse.verse,
+                    }))
+                  )
+                  .execute()
+              }
+              for (let offset = 0; offset < canonical.lexemes.length; offset += 1_000) {
+                assertNotInterrupted(signal)
+                await transaction
+                  .insertInto('strong_bible_lexemes')
+                  .values(
+                    canonical.lexemes.slice(offset, offset + 1_000).map(lexeme => ({
+                      publication_id: publication.id,
+                      lexeme_id: lexeme.id,
+                      lemma: lexeme.lemma,
+                      part_of_speech: lexeme.partOfSpeech,
+                    }))
+                  )
+                  .execute()
+              }
+              for (let offset = 0; offset < canonical.identities.length; offset += 1_000) {
+                assertNotInterrupted(signal)
+                await transaction
+                  .insertInto('strong_bible_identities')
+                  .values(
+                    canonical.identities.slice(offset, offset + 1_000).map(identity => ({
+                      publication_id: publication.id,
+                      identity_id: identity.id,
+                      kind: identity.kind,
+                      code: identity.code,
+                    }))
+                  )
+                  .execute()
+              }
+              for (let offset = 0; offset < canonical.spans.length; offset += 1_000) {
+                assertNotInterrupted(signal)
+                await transaction
+                  .insertInto('strong_bible_spans')
+                  .values(
+                    canonical.spans.slice(offset, offset + 1_000).map(span => ({
+                      publication_id: publication.id,
+                      book: span.book,
+                      chapter: span.chapter,
+                      verse: span.verse,
+                      ordinal: span.ordinal,
+                      start_offset: span.startOffset,
+                      length: span.length,
+                      is_aligned: span.isAligned,
+                      lexeme_id: span.lexemeId ?? null,
+                      step_token_ids: sql<number[]>`${JSON.stringify(
+                        span.stepTokenIds ?? []
+                      )}::jsonb`,
+                    }))
+                  )
+                  .execute()
+              }
+              for (let offset = 0; offset < canonical.spanIdentities.length; offset += 1_000) {
+                assertNotInterrupted(signal)
+                await transaction
+                  .insertInto('strong_bible_span_identities')
+                  .values(
+                    canonical.spanIdentities.slice(offset, offset + 1_000).map(spanIdentity => ({
+                      publication_id: publication.id,
+                      book: spanIdentity.book,
+                      chapter: spanIdentity.chapter,
+                      verse: spanIdentity.verse,
+                      ordinal: spanIdentity.ordinal,
+                      identity_order: spanIdentity.identityOrder,
+                      identity_id: spanIdentity.identityId,
+                    }))
+                  )
                   .execute()
               }
             }

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -128,7 +128,10 @@ export const importPublicationBundle = (
               resource_revision: manifest.revision,
               text_revision: manifest.dependencies.bible.revision,
               text_sha256: manifest.dependencies.bible.textSha256,
-              strong_revision: manifest.revision,
+              strong_revision:
+                canonical.format === 'bible-strong-canonical-strong-index'
+                  ? canonical.strongRevision
+                  : undefined,
               offline_entry: manifest.offlineArtifact.entry,
             }
       const publicationMetadata = { ...metadata, manifest_sha256: manifestSha256 }

--- a/resource-service/src/repositories/strongBibleRepository.ts
+++ b/resource-service/src/repositories/strongBibleRepository.ts
@@ -1,0 +1,458 @@
+import { Effect } from 'effect'
+import { sql, type Kysely } from 'kysely'
+
+import { getStrongBibleConcordanceCandidates } from '../../../src/helpers/strongBibleConcordance'
+import type { StrongBibleSpan } from '../../../src/helpers/canonicalStrongVerse'
+import { tryDatabasePromise } from '../database/databaseEffect'
+import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
+import type { ResourceDatabase } from '../database/types'
+import {
+  ActiveStrongBiblePublicationUnavailable,
+  StrongBibleChapterNotFound,
+  StrongBibleRepositoryFailure,
+  type StrongBibleRepositoryService,
+  type StrongBibleResourceRevision,
+} from '../domain/strongBible'
+
+type StrongBiblePublicationMetadata = {
+  dataset_id: string
+  resource_revision?: string
+  text_revision: string
+  text_sha256: string
+  strong_revision: string
+}
+
+type BiblePublicationMetadata = {
+  resource_revision?: string
+  text_revision?: string
+  text_sha256?: string
+}
+
+const metadataFrom = (value: Record<string, unknown>) => value as StrongBiblePublicationMetadata
+
+const revisionFrom = (publication: {
+  revision: string
+  metadata: Record<string, unknown>
+  resource_identity: string
+}): StrongBibleResourceRevision => {
+  const metadata = metadataFrom(publication.metadata)
+  return {
+    versionId: publication.resource_identity.slice('strong-bible-index:'.length),
+    datasetId: metadata.dataset_id,
+    revision: metadata.resource_revision ?? publication.revision,
+    textRevision: metadata.text_revision,
+    textSha256: metadata.text_sha256,
+    strongRevision: metadata.strong_revision,
+  }
+}
+
+type SpanRow = {
+  book: number
+  chapter: number
+  verse: number
+  ordinal: number
+  start_offset: number
+  length: number
+  step_token_ids: number[]
+  identity_order: number | null
+  identity_id: number | null
+  kind: string | null
+  code: string | null
+}
+
+const groupSpans = (rows: readonly SpanRow[]) => {
+  const spansByVerse = new Map<string, StrongBibleSpan[]>()
+  const spans = new Map<string, StrongBibleSpan>()
+  for (const row of rows) {
+    const verseKey = `${row.book}-${row.chapter}-${row.verse}`
+    const spanKey = `${verseKey}-${row.ordinal}`
+    let span = spans.get(spanKey)
+    if (!span) {
+      span = {
+        ordinal: row.ordinal,
+        startOffset: row.start_offset,
+        length: row.length,
+        ...(row.step_token_ids.length ? { stepTokenIds: [...row.step_token_ids] } : {}),
+        identities: [],
+      }
+      spans.set(spanKey, span)
+      const verseSpans = spansByVerse.get(verseKey) ?? []
+      verseSpans.push(span)
+      spansByVerse.set(verseKey, verseSpans)
+    }
+    if (
+      row.kind &&
+      row.code &&
+      ['strong', 'estrong', 'dstrong', 'ustrong'].includes(row.kind) &&
+      !span.identities.some(identity => identity.kind === row.kind && identity.code === row.code)
+    ) {
+      span.identities.push({
+        kind: row.kind as StrongBibleSpan['identities'][number]['kind'],
+        code: row.code,
+      })
+    }
+  }
+  return spansByVerse
+}
+
+export const makeKyselyStrongBibleRepository = (
+  database: Kysely<ResourceDatabase>
+): StrongBibleRepositoryService => {
+  const findActivePublication = (versionId: string) =>
+    Effect.gen(function* () {
+      const publication = yield* tryDatabasePromise('strong-bible.publication.read-active', () =>
+        database
+          .selectFrom('resource_publications')
+          .select(['id', 'revision', 'metadata', 'resource_identity'])
+          .where('resource_identity', '=', `strong-bible-index:${versionId}`)
+          .where('status', '=', 'active')
+          .executeTakeFirst()
+      ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+      if (!publication) return undefined
+
+      const biblePublication = yield* tryDatabasePromise(
+        'strong-bible.publication.read-bible-dependency',
+        () =>
+          database
+            .selectFrom('resource_publications')
+            .select(['revision', 'metadata'])
+            .where('resource_identity', '=', `bible-text:${versionId}`)
+            .where('status', '=', 'active')
+            .executeTakeFirst()
+      ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+      if (!biblePublication) return undefined
+
+      const bibleMetadata = biblePublication.metadata as BiblePublicationMetadata
+      const bibleTextRevision =
+        bibleMetadata.text_revision ?? bibleMetadata.resource_revision ?? biblePublication.revision
+      const strongMetadata = metadataFrom(publication.metadata)
+      return bibleTextRevision === strongMetadata.text_revision &&
+        bibleMetadata.text_sha256 === strongMetadata.text_sha256
+        ? publication
+        : undefined
+    })
+
+  const loadSpanRows = (
+    publicationId: number,
+    locations: readonly { book: number; chapter: number; verse?: number }[]
+  ) =>
+    tryDatabasePromise('strong-bible.spans.read', () => {
+      let query = database
+        .selectFrom('strong_bible_spans')
+        .leftJoin('strong_bible_span_identities', join =>
+          join
+            .onRef(
+              'strong_bible_span_identities.publication_id',
+              '=',
+              'strong_bible_spans.publication_id'
+            )
+            .onRef('strong_bible_span_identities.book', '=', 'strong_bible_spans.book')
+            .onRef('strong_bible_span_identities.chapter', '=', 'strong_bible_spans.chapter')
+            .onRef('strong_bible_span_identities.verse', '=', 'strong_bible_spans.verse')
+            .onRef('strong_bible_span_identities.ordinal', '=', 'strong_bible_spans.ordinal')
+        )
+        .leftJoin('strong_bible_identities', join =>
+          join
+            .onRef(
+              'strong_bible_identities.publication_id',
+              '=',
+              'strong_bible_span_identities.publication_id'
+            )
+            .onRef(
+              'strong_bible_identities.identity_id',
+              '=',
+              'strong_bible_span_identities.identity_id'
+            )
+        )
+        .select([
+          'strong_bible_spans.book',
+          'strong_bible_spans.chapter',
+          'strong_bible_spans.verse',
+          'strong_bible_spans.ordinal',
+          'strong_bible_spans.start_offset',
+          'strong_bible_spans.length',
+          'strong_bible_spans.step_token_ids',
+          'strong_bible_span_identities.identity_order',
+          'strong_bible_span_identities.identity_id',
+          'strong_bible_identities.kind',
+          'strong_bible_identities.code',
+        ])
+        .where('strong_bible_spans.publication_id', '=', publicationId)
+      if (locations.length > 0) {
+        query = query.where(expression =>
+          expression.or(
+            locations.map(location =>
+              expression.and([
+                expression('strong_bible_spans.book', '=', location.book),
+                expression('strong_bible_spans.chapter', '=', location.chapter),
+                ...(location.verse === undefined
+                  ? []
+                  : [expression('strong_bible_spans.verse', '=', location.verse)]),
+              ])
+            )
+          )
+        )
+      }
+      return query
+        .orderBy('strong_bible_spans.book')
+        .orderBy('strong_bible_spans.chapter')
+        .orderBy('strong_bible_spans.verse')
+        .orderBy('strong_bible_spans.ordinal')
+        .orderBy('strong_bible_span_identities.identity_order')
+        .execute() as Promise<SpanRow[]>
+    }).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+
+  const resolveIdentity = (publicationId: number, book: number, reference: string | number) =>
+    Effect.gen(function* () {
+      const kindNames = ['strong', 'estrong', 'dstrong', 'ustrong'] as const
+      for (const candidate of getStrongBibleConcordanceCandidates(book, reference)) {
+        const kind = kindNames[candidate.kind]
+        if (!kind) continue
+        const identity = yield* tryDatabasePromise('strong-bible.identity.resolve', () =>
+          database
+            .selectFrom('strong_bible_identities')
+            .select(['identity_id', 'kind', 'code'])
+            .where('publication_id', '=', publicationId)
+            .where('kind', '=', kind)
+            .where('code', '=', candidate.code)
+            .executeTakeFirst()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        if (identity) {
+          return {
+            id: identity.identity_id,
+            kind: identity.kind as (typeof kindNames)[number],
+            code: identity.code,
+          }
+        }
+      }
+      return undefined
+    })
+
+  return {
+    findActiveCoverage: versionId =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(versionId)
+        if (!publication) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId })
+        }
+        const rows = yield* tryDatabasePromise('strong-bible.coverage.read', () =>
+          database
+            .selectFrom('strong_bible_verses')
+            .select(['book', 'chapter'])
+            .select(expression => expression.fn.count('verse').as('verse_count'))
+            .where('publication_id', '=', publication.id)
+            .groupBy(['book', 'chapter'])
+            .orderBy('book')
+            .orderBy('chapter')
+            .execute()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        if (rows.length === 0) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId })
+        }
+        const chaptersByBook: Record<string, number[]> = {}
+        const verseCountByBookChapter: Record<string, number> = {}
+        for (const row of rows) {
+          chaptersByBook[row.book] ??= []
+          chaptersByBook[row.book]!.push(row.chapter)
+          verseCountByBookChapter[`${row.book}-${row.chapter}`] = Number(row.verse_count)
+        }
+        return {
+          ...revisionFrom(publication),
+          books: Object.keys(chaptersByBook).map(Number),
+          chaptersByBook,
+          verseCountByBookChapter,
+        }
+      }),
+    findActiveChapter: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(input.versionId)
+        if (!publication) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })
+        }
+        const verses = yield* tryDatabasePromise('strong-bible.chapter.verses', () =>
+          database
+            .selectFrom('strong_bible_verses')
+            .select('verse')
+            .where('publication_id', '=', publication.id)
+            .where('book', '=', input.book)
+            .where('chapter', '=', input.chapter)
+            .orderBy('verse')
+            .execute()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        if (verses.length === 0) return yield* new StrongBibleChapterNotFound(input)
+        const spanRows = yield* loadSpanRows(publication.id, [input])
+        const spansByVerse = groupSpans(spanRows)
+        return {
+          ...revisionFrom(publication),
+          book: input.book,
+          chapter: input.chapter,
+          verses: verses.map(row => ({
+            number: row.verse,
+            spans: spansByVerse.get(`${input.book}-${input.chapter}-${row.verse}`) ?? [],
+          })),
+        }
+      }),
+    findCountsByBook: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(input.versionId)
+        if (!publication) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })
+        }
+        const identity = yield* resolveIdentity(publication.id, input.book, input.reference)
+        if (!identity) return { ...revisionFrom(publication), counts: [] }
+        const rows = yield* tryDatabasePromise('strong-bible.counts.read', () =>
+          database
+            .selectFrom('strong_bible_span_identities')
+            .select('book')
+            .select(
+              sql<number>`count(distinct (${sql.ref('book')}, ${sql.ref('chapter')}, ${sql.ref(
+                'verse'
+              )}))`.as('verse_count')
+            )
+            .where('publication_id', '=', publication.id)
+            .where('identity_id', '=', identity.id)
+            .groupBy('book')
+            .orderBy('book')
+            .execute()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        return {
+          ...revisionFrom(publication),
+          identity,
+          counts: rows.map(row => ({ book: row.book, verseCount: Number(row.verse_count) })),
+        }
+      }),
+    findOccurrences: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(input.versionId)
+        if (!publication) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })
+        }
+        const identity = yield* resolveIdentity(publication.id, input.book, input.reference)
+        if (!identity) return { ...revisionFrom(publication), verses: [] }
+        let query = database
+          .selectFrom('strong_bible_span_identities')
+          .innerJoin('strong_bible_spans', join =>
+            join
+              .onRef(
+                'strong_bible_spans.publication_id',
+                '=',
+                'strong_bible_span_identities.publication_id'
+              )
+              .onRef('strong_bible_spans.book', '=', 'strong_bible_span_identities.book')
+              .onRef('strong_bible_spans.chapter', '=', 'strong_bible_span_identities.chapter')
+              .onRef('strong_bible_spans.verse', '=', 'strong_bible_span_identities.verse')
+              .onRef('strong_bible_spans.ordinal', '=', 'strong_bible_span_identities.ordinal')
+          )
+          .select([
+            'strong_bible_span_identities.book',
+            'strong_bible_span_identities.chapter',
+            'strong_bible_span_identities.verse',
+          ])
+          .distinct()
+          .where('strong_bible_span_identities.publication_id', '=', publication.id)
+          .where('strong_bible_span_identities.identity_id', '=', identity.id)
+        if (!input.allBooks)
+          query = query.where('strong_bible_span_identities.book', '=', input.book)
+        if (input.lexemeId !== undefined) {
+          query = query.where('strong_bible_spans.lexeme_id', '=', input.lexemeId)
+        }
+        const limit = input.limit ?? 100
+        const locations = yield* tryDatabasePromise('strong-bible.occurrences.read', () =>
+          query
+            .orderBy('strong_bible_span_identities.book')
+            .orderBy('strong_bible_span_identities.chapter')
+            .orderBy('strong_bible_span_identities.verse')
+            .limit(limit)
+            .offset(input.offset ?? 0)
+            .execute()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        const spanRows = locations.length ? yield* loadSpanRows(publication.id, locations) : []
+        const spansByVerse = groupSpans(spanRows)
+        return {
+          ...revisionFrom(publication),
+          identity,
+          verses: locations.map(location => ({
+            ...location,
+            spans: spansByVerse.get(`${location.book}-${location.chapter}-${location.verse}`) ?? [],
+          })),
+          ...(locations.length >= limit
+            ? { nextOffset: (input.offset ?? 0) + locations.length }
+            : {}),
+        }
+      }),
+    findLemmaStats: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(input.versionId)
+        if (!publication) {
+          return yield* new ActiveStrongBiblePublicationUnavailable({ versionId: input.versionId })
+        }
+        const identity = yield* resolveIdentity(publication.id, input.book, input.reference)
+        if (!identity) return { ...revisionFrom(publication), lemmas: [] }
+        const rows = yield* tryDatabasePromise('strong-bible.lemmas.read', () =>
+          database
+            .selectFrom('strong_bible_span_identities')
+            .innerJoin('strong_bible_spans', join =>
+              join
+                .onRef(
+                  'strong_bible_spans.publication_id',
+                  '=',
+                  'strong_bible_span_identities.publication_id'
+                )
+                .onRef('strong_bible_spans.book', '=', 'strong_bible_span_identities.book')
+                .onRef('strong_bible_spans.chapter', '=', 'strong_bible_span_identities.chapter')
+                .onRef('strong_bible_spans.verse', '=', 'strong_bible_span_identities.verse')
+                .onRef('strong_bible_spans.ordinal', '=', 'strong_bible_span_identities.ordinal')
+            )
+            .innerJoin('strong_bible_lexemes', join =>
+              join
+                .onRef(
+                  'strong_bible_lexemes.publication_id',
+                  '=',
+                  'strong_bible_spans.publication_id'
+                )
+                .onRef('strong_bible_lexemes.lexeme_id', '=', 'strong_bible_spans.lexeme_id')
+            )
+            .select([
+              'strong_bible_lexemes.lexeme_id',
+              'strong_bible_lexemes.lemma',
+              'strong_bible_lexemes.part_of_speech',
+            ])
+            .select(
+              sql<number>`count(distinct (${sql.ref(
+                'strong_bible_spans.book'
+              )}, ${sql.ref('strong_bible_spans.chapter')}, ${sql.ref(
+                'strong_bible_spans.verse'
+              )}))`.as('occurrence_count')
+            )
+            .where('strong_bible_span_identities.publication_id', '=', publication.id)
+            .where('strong_bible_span_identities.identity_id', '=', identity.id)
+            .groupBy([
+              'strong_bible_lexemes.lexeme_id',
+              'strong_bible_lexemes.lemma',
+              'strong_bible_lexemes.part_of_speech',
+            ])
+            .orderBy('occurrence_count', 'desc')
+            .orderBy('strong_bible_lexemes.lemma')
+            .execute()
+        ).pipe(Effect.mapError(cause => new StrongBibleRepositoryFailure({ cause })))
+        return {
+          ...revisionFrom(publication),
+          identity,
+          lemmas: rows.map(row => ({
+            id: row.lexeme_id,
+            lemma: row.lemma,
+            partOfSpeech: row.part_of_speech,
+            occurrenceCount: Number(row.occurrence_count),
+          })),
+        }
+      }),
+  }
+}
+
+export const makeNeonStrongBibleRepository = (config: NeonDatabaseConfig) => {
+  const database = makeNeonDatabase(config)
+  return {
+    repository: makeKyselyStrongBibleRepository(database),
+    dispose: () => database.destroy(),
+  }
+}

--- a/resource-service/src/repositories/strongBibleRepository.ts
+++ b/resource-service/src/repositories/strongBibleRepository.ts
@@ -3,6 +3,7 @@ import { sql, type Kysely } from 'kysely'
 
 import { getStrongBibleConcordanceCandidates } from '../../../src/helpers/strongBibleConcordance'
 import type { StrongBibleSpan } from '../../../src/helpers/canonicalStrongVerse'
+import { STRONG_IDENTITY_KINDS } from '../../../src/helpers/strongIdentities'
 import { tryDatabasePromise } from '../database/databaseEffect'
 import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
 import type { ResourceDatabase } from '../database/types'
@@ -204,9 +205,8 @@ export const makeKyselyStrongBibleRepository = (
 
   const resolveIdentity = (publicationId: number, book: number, reference: string | number) =>
     Effect.gen(function* () {
-      const kindNames = ['strong', 'estrong', 'dstrong', 'ustrong'] as const
       for (const candidate of getStrongBibleConcordanceCandidates(book, reference)) {
-        const kind = kindNames[candidate.kind]
+        const kind = STRONG_IDENTITY_KINDS[candidate.kind]
         if (!kind) continue
         const identity = yield* tryDatabasePromise('strong-bible.identity.resolve', () =>
           database
@@ -220,7 +220,7 @@ export const makeKyselyStrongBibleRepository = (
         if (identity) {
           return {
             id: identity.identity_id,
-            kind: identity.kind as (typeof kindNames)[number],
+            kind: identity.kind as (typeof STRONG_IDENTITY_KINDS)[number],
             code: identity.code,
           }
         }

--- a/resource-service/src/runtime/node.ts
+++ b/resource-service/src/runtime/node.ts
@@ -7,9 +7,11 @@ import { createServer } from 'node:http'
 import { makeLocalDatabase } from '../database/localDatabase'
 import { BibleChapterRepository } from '../domain/bibleChapter'
 import { NaveRepository } from '../domain/nave'
+import { StrongBibleRepository } from '../domain/strongBible'
 import { ResourceApiLive } from '../http/app'
 import { makeKyselyBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeKyselyNaveRepository } from '../repositories/naveRepository'
+import { makeKyselyStrongBibleRepository } from '../repositories/strongBibleRepository'
 
 const port = Number(process.env.RESOURCE_API_PORT ?? 8787)
 const database = makeLocalDatabase({
@@ -18,14 +20,15 @@ const database = makeLocalDatabase({
     'postgresql://bible_strong:bible_strong@127.0.0.1:54329/bible_strong',
 })
 
-const RepositoryLive = Layer.merge(
+const RepositoryLive = Layer.mergeAll(
   Layer.scoped(
     BibleChapterRepository,
     Effect.acquireRelease(Effect.succeed(makeKyselyBibleChapterRepository(database)), () =>
       Effect.promise(() => database.destroy())
     )
   ),
-  Layer.succeed(NaveRepository, makeKyselyNaveRepository(database))
+  Layer.succeed(NaveRepository, makeKyselyNaveRepository(database)),
+  Layer.succeed(StrongBibleRepository, makeKyselyStrongBibleRepository(database))
 )
 const ApiLive = ResourceApiLive.pipe(Layer.provide(RepositoryLive))
 

--- a/resource-service/src/runtime/worker.ts
+++ b/resource-service/src/runtime/worker.ts
@@ -1,8 +1,10 @@
 import { makeResourceWebHandler } from '../http/app'
 import type { BibleChapterRepositoryService } from '../domain/bibleChapter'
 import type { NaveRepositoryService } from '../domain/nave'
+import type { StrongBibleRepositoryService } from '../domain/strongBible'
 import { makeNeonBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeNeonNaveRepository } from '../repositories/naveRepository'
+import { makeNeonStrongBibleRepository } from '../repositories/strongBibleRepository'
 
 export type ResourceWorkerBindings = {
   RESOURCE_DATABASE_URL: string
@@ -10,8 +12,9 @@ export type ResourceWorkerBindings = {
 
 export const makeResourceWorkerHandler = (
   repository: BibleChapterRepositoryService,
-  naveRepository?: NaveRepositoryService
-) => makeResourceWebHandler(repository, naveRepository)
+  naveRepository?: NaveRepositoryService,
+  strongBibleRepository?: StrongBibleRepositoryService
+) => makeResourceWebHandler(repository, naveRepository, { strongBible: strongBibleRepository })
 
 let cached:
   | {
@@ -24,7 +27,8 @@ const getWorkerHandler = (connectionString: string) => {
   if (cached?.connectionString === connectionString) return cached.web
   const { repository } = makeNeonBibleChapterRepository({ connectionString })
   const { repository: naveRepository } = makeNeonNaveRepository({ connectionString })
-  const web = makeResourceWorkerHandler(repository, naveRepository)
+  const { repository: strongBibleRepository } = makeNeonStrongBibleRepository({ connectionString })
+  const web = makeResourceWorkerHandler(repository, naveRepository, strongBibleRepository)
   cached = { connectionString, web }
   return web
 }

--- a/src/features/resources/__tests__/bibleChapterSource-test.ts
+++ b/src/features/resources/__tests__/bibleChapterSource-test.ts
@@ -184,6 +184,7 @@ describe('HTTP Bible chapter adapter', () => {
     await expect(http.loadChapter('LSG', 1, 1)).resolves.toEqual({
       status: 'available',
       presentation: 'canonical',
+      textRevision: 'lsg-r1',
       verses: [
         {
           Livre: 1,
@@ -226,6 +227,7 @@ describe('HTTP Bible chapter adapter', () => {
 
     await expect(http.loadCoverage('LSG')).resolves.toEqual({
       status: 'available',
+      textRevision: 'lsg-r1',
       coverage: {
         canon: { id: 'protestant-66', orderedBooks: [1] },
         versification: 'bible-strong-default',

--- a/src/features/resources/__tests__/bibleContentAccess-test.ts
+++ b/src/features/resources/__tests__/bibleContentAccess-test.ts
@@ -44,43 +44,44 @@ const createDependencies = () => ({
   ...(() => {
     const getChapterVerses = jest.fn()
     const getIfVersionNeedsDownload = jest.fn(async (_version: string) => false)
+    const chapterAdapter: jest.Mocked<BibleChapterAdapter> = {
+      loadCoverage: jest.fn(),
+      loadChapter: jest.fn(async (version: string, book: number, chapter: number) => {
+        try {
+          const verses = await getChapterVerses(version, book, chapter)
+          if (verses.length > 0) return { status: 'available' as const, verses }
+          if (await getIfVersionNeedsDownload(version)) {
+            return {
+              status: 'unavailable' as const,
+              reason: 'publication-not-available' as const,
+              recoveries: ['acquire-offline-copy' as const],
+            }
+          }
+          return { status: 'unavailable' as const, reason: 'chapter-not-available' as const }
+        } catch (error) {
+          if (error instanceof BibleLoadingError && error.type === 'BIBLE_NOT_FOUND') {
+            return {
+              status: 'unavailable' as const,
+              reason: 'publication-not-available' as const,
+              recoveries: ['acquire-offline-copy' as const],
+            }
+          }
+          const message = String(error)
+          if (message.includes('no such table') || message.includes('corrupted')) {
+            return {
+              status: 'unavailable' as const,
+              reason: 'offline-copy-invalid' as const,
+              recoveries: ['manage-offline-copies' as const, 'reset-offline-store' as const],
+            }
+          }
+          throw error
+        }
+      }),
+    }
     return {
       getChapterVerses,
       getIfVersionNeedsDownload,
-      chapterAdapter: {
-        loadCoverage: jest.fn(),
-        loadChapter: jest.fn(async (version: string, book: number, chapter: number) => {
-          try {
-            const verses = await getChapterVerses(version, book, chapter)
-            if (verses.length > 0) return { status: 'available' as const, verses }
-            if (await getIfVersionNeedsDownload(version)) {
-              return {
-                status: 'unavailable' as const,
-                reason: 'publication-not-available' as const,
-                recoveries: ['acquire-offline-copy' as const],
-              }
-            }
-            return { status: 'unavailable' as const, reason: 'chapter-not-available' as const }
-          } catch (error) {
-            if (error instanceof BibleLoadingError && error.type === 'BIBLE_NOT_FOUND') {
-              return {
-                status: 'unavailable' as const,
-                reason: 'publication-not-available' as const,
-                recoveries: ['acquire-offline-copy' as const],
-              }
-            }
-            const message = String(error)
-            if (message.includes('no such table') || message.includes('corrupted')) {
-              return {
-                status: 'unavailable' as const,
-                reason: 'offline-copy-invalid' as const,
-                recoveries: ['manage-offline-copies' as const, 'reset-offline-store' as const],
-              }
-            }
-            throw error
-          }
-        }),
-      },
+      chapterAdapter,
     }
   })(),
   strongLexicon: {
@@ -91,6 +92,34 @@ const createDependencies = () => ({
 })
 
 describe('BibleContentAccess', () => {
+  it('does not overlay Strong spans onto a Bible chapter with a different revision or hash', async () => {
+    const dependencies = createDependencies()
+    dependencies.chapterAdapter.loadChapter.mockResolvedValue({
+      status: 'available',
+      textRevision: 'stale-local-revision',
+      textSha256: '0'.repeat(64),
+      verses: [{ Livre: 1, Chapitre: 1, Verset: 1, Texte: 'Texte local ancien' }],
+    } as Awaited<ReturnType<BibleChapterAdapter['loadChapter']>>)
+    const loadStrongBibleChapterSpans = jest.fn().mockResolvedValue({
+      spansByVerse: { 1: [] },
+      textRevision: 'lsg-text-v1',
+      textSha256: '1'.repeat(64),
+    })
+
+    const result = await loadBibleContentChapter(
+      { book: 1, chapter: 1, version: 'LSG', strongMode: 'visible' },
+      { ...dependencies, loadStrongBibleChapterSpans }
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({ success: true, data: expect.objectContaining({ kind: 'plain' }) })
+    )
+    expect(dependencies.logError).toHaveBeenCalledWith(
+      '[BibleContentAccess] Strong sidecar unavailable:',
+      expect.objectContaining({ code: 'INTEGRITY_FAILURE' })
+    )
+  })
+
   it('classifies a missing canonical chapter in an installed Bible as an invalid copy', async () => {
     ;(getChapterVerses as jest.MockedFunction<typeof getChapterVerses>).mockResolvedValue([])
     ;(

--- a/src/features/resources/__tests__/resourceModel-test.ts
+++ b/src/features/resources/__tests__/resourceModel-test.ts
@@ -52,7 +52,7 @@ describe('Resource model', () => {
     expect(getResourceActions(state)).toEqual(['open', 'make-available-offline'])
   })
 
-  it('declares only explicitly served Bible and Nave publications remotely readable', () => {
+  it('declares only explicitly served Bible, Strong Bible, and Nave publications remotely readable', () => {
     expect(
       getResourceOnlineAccess({ kind: 'bible-text', versionId: 'LSG' }, new Set(['LSG']))
     ).toEqual({ status: 'remotely-readable' })
@@ -61,6 +61,14 @@ describe('Resource model', () => {
     ).toEqual({ status: 'unsupported' })
     expect(
       getResourceOnlineAccess({ kind: 'nave', language: 'fr' }, new Set(['LSG']), new Set(['fr']))
+    ).toEqual({ status: 'remotely-readable' })
+    expect(
+      getResourceOnlineAccess(
+        { kind: 'strong-bible-index', versionId: 'LSG' },
+        new Set(['LSG']),
+        new Set(['fr']),
+        new Set(['LSG'])
+      )
     ).toEqual({ status: 'remotely-readable' })
     expect(
       getResourceOnlineAccess({ kind: 'nave', language: 'en' }, new Set(['LSG']), new Set(['fr']))

--- a/src/features/resources/__tests__/strongBibleHttpAccess-test.ts
+++ b/src/features/resources/__tests__/strongBibleHttpAccess-test.ts
@@ -1,0 +1,407 @@
+import {
+  createHttpStrongBibleResourceAdapter,
+  createHybridStrongBibleResourceAdapter,
+  createStrongBibleResourceAccess,
+  type StrongBibleResourceAdapter,
+} from '../strongBibleResourceAccess'
+import { ResourceAccessError } from '../resourceAccessError'
+
+jest.mock('~helpers/firebase', () => ({
+  cdnUrl: (path: string) => `https://assets.example/${path}`,
+}))
+
+jest.mock('~helpers/biblesDb', () => ({
+  getMultipleVerses: jest.fn(),
+  getVerseText: jest.fn(),
+}))
+
+jest.mock('~helpers/strongBibleSidecar', () => ({
+  getStrongBibleSidecarAvailability: jest.fn(),
+  getResolvedStrongBibleConcordanceIdentity: jest.fn(),
+  loadStrongBibleLemmaStats: jest.fn(),
+  loadStrongBibleChapterSpans: jest.fn(),
+  loadStrongBibleOccurrenceLocations: jest.fn(),
+  loadStrongBibleVerseCountsByBook: jest.fn(),
+  loadStrongBibleVerseSpans: jest.fn(),
+  loadStrongBibleVersesSpans: jest.fn(),
+}))
+
+const resource = {
+  kind: 'strong-bible-index',
+  versionId: 'LSG',
+  datasetId: 'LSG',
+  revision: 'strong-publication-v1',
+  textRevision: 'lsg-text-v1',
+  textSha256: '1'.repeat(64),
+  strongRevision: 'strong-content-v1',
+}
+const span = {
+  ordinal: 0,
+  startOffset: 0,
+  length: 4,
+  stepTokenIds: [7],
+  identities: [{ kind: 'strong' as const, code: 'H0430' }],
+}
+
+const jsonResponse = (value: unknown, status = 200) =>
+  Promise.resolve(
+    new Response(JSON.stringify(value), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  )
+
+const unavailableAdapter = (): jest.Mocked<StrongBibleResourceAdapter> => ({
+  getAvailability: jest.fn().mockResolvedValue({ status: 'missing' }),
+  loadChapterSpans: jest.fn(),
+  loadVerse: jest.fn(),
+  loadCountsByBook: jest.fn(),
+  loadFoundVersesByBook: jest.fn(),
+  loadLemmaStats: jest.fn(),
+})
+
+describe('Strong Bible HTTP resource access', () => {
+  it('renders Strong from HTTP when no Offline copy exists', async () => {
+    const fetcher = jest.fn((url: string) => {
+      if (url.endsWith('/coverage')) {
+        return jsonResponse({
+          resource,
+          books: [1],
+          chaptersByBook: { 1: [1] },
+          verseCountByBookChapter: { '1-1': 1 },
+        })
+      }
+      return jsonResponse({
+        resource,
+        book: 1,
+        chapter: 1,
+        verses: [{ number: 1, spans: [span] }],
+      })
+    }) as jest.MockedFunction<typeof fetch>
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => true,
+      bibleChapterAdapter: {
+        loadChapter: async () => ({
+          status: 'available',
+          textRevision: resource.textRevision,
+          textSha256: resource.textSha256,
+          verses: [
+            {
+              Livre: 1,
+              Chapitre: 1,
+              Verset: 1,
+              Texte: 'Dieu créa',
+              TextRevision: 'lsg-text-v1',
+            },
+          ],
+        }),
+        loadCoverage: async () => ({
+          status: 'available',
+          coverage: {
+            canon: { id: 'protestant-66', orderedBooks: [1] },
+            versification: 'protestant-66',
+            books: [1],
+            chaptersByBook: { 1: [1] },
+            verseCountByBookChapter: { '1-1': 1 },
+          },
+          textRevision: resource.textRevision,
+          textSha256: resource.textSha256,
+        }),
+      },
+    })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline: unavailableAdapter(),
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => true,
+    })
+    const access = createStrongBibleResourceAccess(hybrid)
+
+    await expect(access.getAvailability('LSG')).resolves.toMatchObject({
+      status: 'available',
+      versionId: 'LSG',
+    })
+    await expect(
+      access.loadVerse({
+        currentVersionId: 'LSG',
+        defaultVersionId: 'LSG',
+        book: 1,
+        chapter: 1,
+        verse: 1,
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: 'available',
+        verse: expect.objectContaining({ Texte: 'Dieu créa', StrongSpans: [span] }),
+      })
+    )
+  })
+
+  it('prefers installed SQLite, then returns to HTTP after that copy is removed', async () => {
+    const offline = unavailableAdapter()
+    let installed = true
+    offline.getAvailability.mockImplementation(async () =>
+      installed
+        ? {
+            status: 'available',
+            versionId: 'LSG',
+            datasetId: 'LSG',
+            textRevision: 'lsg-text-v1',
+            strongRevision: 'strong-content-v1',
+          }
+        : { status: 'missing' }
+    )
+    offline.loadChapterSpans.mockResolvedValue({ spansByVerse: { 1: [] } })
+    const online = unavailableAdapter()
+    online.getAvailability.mockResolvedValue({
+      status: 'available',
+      versionId: 'LSG',
+      datasetId: 'LSG',
+      textRevision: 'lsg-text-v1',
+      strongRevision: 'strong-content-v1',
+    })
+    online.loadChapterSpans.mockResolvedValue({ spansByVerse: { 1: [span] } })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline,
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => true,
+    })
+
+    await expect(hybrid.loadChapterSpans('LSG', { book: 1, chapter: 1 })).resolves.toEqual({
+      spansByVerse: { 1: [] },
+    })
+    expect(online.loadChapterSpans).not.toHaveBeenCalled()
+
+    installed = false
+    await expect(hybrid.loadChapterSpans('LSG', { book: 1, chapter: 1 })).resolves.toEqual({
+      spansByVerse: { 1: [span] },
+    })
+  })
+
+  it('recovers from a corrupt local copy through HTTP without requiring a new download', async () => {
+    const offline = unavailableAdapter()
+    offline.getAvailability.mockResolvedValue({
+      status: 'corrupt',
+      reason: 'metadata-invalid',
+    })
+    const online = unavailableAdapter()
+    online.getAvailability.mockResolvedValue({
+      status: 'available',
+      versionId: 'LSG',
+      datasetId: 'LSG',
+      textRevision: 'lsg-text-v1',
+      strongRevision: 'strong-content-v1',
+    })
+    online.loadChapterSpans.mockResolvedValue({ spansByVerse: { 1: [span] } })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline,
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => true,
+    })
+
+    await expect(hybrid.getAvailability('LSG')).resolves.toMatchObject({ status: 'available' })
+    await expect(hybrid.loadChapterSpans('LSG', { book: 1, chapter: 1 })).resolves.toEqual({
+      spansByVerse: { 1: [span] },
+    })
+  })
+
+  it('reports malformed HTTP publications as integrity failures', async () => {
+    const fetcher: typeof fetch = () => jsonResponse({ resource: {} })
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => true,
+      bibleChapterAdapter: {
+        loadChapter: async () => ({ status: 'unavailable', reason: 'resource-unsupported' }),
+        loadCoverage: async () => ({ status: 'unavailable', reason: 'resource-unsupported' }),
+      },
+    })
+
+    await expect(online.getAvailability('LSG')).rejects.toMatchObject({
+      code: 'INTEGRITY_FAILURE',
+    })
+  })
+
+  it('reports a stale installed Bible as base-incompatible before Strong activation', async () => {
+    const fetcher: typeof fetch = () =>
+      jsonResponse({
+        resource,
+        books: [1],
+        chaptersByBook: { 1: [1] },
+        verseCountByBookChapter: { '1-1': 1 },
+      })
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => true,
+      bibleChapterAdapter: {
+        loadChapter: async () => ({ status: 'unavailable', reason: 'chapter-not-available' }),
+        loadCoverage: async () => ({
+          status: 'available',
+          coverage: {
+            canon: { id: 'protestant-66', orderedBooks: [1] },
+            versification: 'protestant-66',
+            books: [1],
+            chaptersByBook: { 1: [1] },
+            verseCountByBookChapter: { '1-1': 1 },
+          },
+          textRevision: 'stale-local-revision',
+          textSha256: '0'.repeat(64),
+        }),
+      },
+    })
+
+    await expect(online.getAvailability('LSG')).resolves.toEqual({
+      status: 'base-incompatible',
+      baseTextRevision: 'stale-local-revision',
+      requiredTextRevision: resource.textRevision,
+    })
+  })
+
+  it('returns the exact Bible dependency from the same HTTP Strong chapter response', async () => {
+    const fetcher: typeof fetch = () =>
+      jsonResponse({
+        resource,
+        book: 1,
+        chapter: 1,
+        verses: [{ number: 1, spans: [span] }],
+      })
+    const loadBibleChapter = jest.fn().mockResolvedValue({
+      status: 'available',
+      verses: [],
+    })
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => true,
+      bibleChapterAdapter: {
+        loadChapter: loadBibleChapter,
+        loadCoverage: async () => ({ status: 'unavailable', reason: 'resource-unsupported' }),
+      },
+    })
+
+    await expect(online.loadChapterSpans('LSG', { book: 1, chapter: 1 })).resolves.toEqual({
+      spansByVerse: { 1: [span] },
+      textRevision: resource.textRevision,
+      textSha256: resource.textSha256,
+    })
+    expect(loadBibleChapter).not.toHaveBeenCalled()
+  })
+
+  it('preserves an unavailable Bible source error instead of reporting a missing verse', async () => {
+    const fetcher: typeof fetch = () =>
+      jsonResponse({
+        resource,
+        book: 1,
+        chapter: 1,
+        verses: [{ number: 1, spans: [span] }],
+      })
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => false,
+      bibleChapterAdapter: {
+        loadChapter: async () => ({ status: 'unavailable', reason: 'network-offline' }),
+        loadCoverage: async () => ({ status: 'unavailable', reason: 'network-offline' }),
+      },
+    })
+
+    await expect(online.loadVerse('LSG', { book: 1, chapter: 1, verse: 1 })).rejects.toMatchObject({
+      code: 'NETWORK_OFFLINE',
+    })
+  })
+
+  it('keeps an absent copy unavailable while offline without attempting HTTP', async () => {
+    const offline = unavailableAdapter()
+    const online = unavailableAdapter()
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline,
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => false,
+    })
+
+    await expect(hybrid.getAvailability('LSG')).resolves.toEqual({ status: 'missing' })
+    expect(online.getAvailability).not.toHaveBeenCalled()
+  })
+
+  it('preserves an incompatible installed Bible instead of advertising remote Strong', async () => {
+    const offline = unavailableAdapter()
+    offline.getAvailability.mockResolvedValue({
+      status: 'base-incompatible',
+      baseTextRevision: 'stale-local-revision',
+      requiredTextRevision: 'lsg-text-v1',
+    })
+    const online = unavailableAdapter()
+    online.getAvailability.mockResolvedValue({
+      status: 'available',
+      versionId: 'LSG',
+      datasetId: 'LSG',
+      textRevision: 'lsg-text-v1',
+      strongRevision: 'strong-content-v1',
+    })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline,
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => true,
+    })
+
+    await expect(hybrid.getAvailability('LSG')).resolves.toMatchObject({
+      status: 'base-incompatible',
+    })
+    expect(online.getAvailability).not.toHaveBeenCalled()
+  })
+
+  it('keeps corrupt Offline state distinct when HTTP fallback cannot run', async () => {
+    const offline = unavailableAdapter()
+    offline.getAvailability.mockResolvedValue({ status: 'corrupt', reason: 'metadata-invalid' })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline,
+      online: unavailableAdapter(),
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => false,
+    })
+
+    await expect(hybrid.loadChapterSpans('LSG', { book: 1, chapter: 1 })).rejects.toMatchObject({
+      code: 'INVALID_OFFLINE_COPY',
+      recoveries: ['acquire-offline-copy', 'manage-offline-copies'],
+    })
+  })
+
+  it('continues to an installed fallback after a preferred remote availability failure', async () => {
+    const adapter = unavailableAdapter()
+    adapter.getAvailability.mockImplementation(async versionId => {
+      if (versionId === 'LSG') throw new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+      if (versionId === 'DBY') {
+        return {
+          status: 'available',
+          versionId: 'DBY',
+          datasetId: 'DBY',
+          textRevision: 'dby-text-v1',
+          strongRevision: 'dby-strong-v1',
+        }
+      }
+      return { status: 'missing' }
+    })
+    adapter.loadChapterSpans.mockResolvedValue({ spansByVerse: { 1: [] } })
+    const access = createStrongBibleResourceAccess(adapter)
+
+    await expect(
+      access.loadChapterSpans({
+        currentVersionId: 'LSG',
+        defaultVersionId: 'DBY',
+        fallbackVersionIds: [],
+        book: 1,
+        chapter: 1,
+      })
+    ).resolves.toMatchObject({
+      status: 'available',
+      provenance: { versionId: 'DBY', isFallback: true },
+    })
+  })
+})

--- a/src/features/resources/__tests__/strongBibleResourceAccess-test.ts
+++ b/src/features/resources/__tests__/strongBibleResourceAccess-test.ts
@@ -43,17 +43,19 @@ describe('strongBibleResourceAccess', () => {
     const dependencies = createDependencies()
     dependencies.getAvailability.mockResolvedValue(available('DBY'))
     dependencies.loadChapterSpans.mockResolvedValue({
-      1: [
-        {
-          ordinal: 0,
-          startOffset: 0,
-          length: 4,
-          identities: [
-            { kind: 'strong', code: 'H3068G' },
-            { kind: 'strong', code: 'H3068G' },
-          ],
-        },
-      ],
+      spansByVerse: {
+        1: [
+          {
+            ordinal: 0,
+            startOffset: 0,
+            length: 4,
+            identities: [
+              { kind: 'strong', code: 'H3068G' },
+              { kind: 'strong', code: 'H3068G' },
+            ],
+          },
+        ],
+      },
     })
     const access = createStrongBibleResourceAccess(dependencies)
 

--- a/src/features/resources/bibleChapterContract.ts
+++ b/src/features/resources/bibleChapterContract.ts
@@ -66,6 +66,7 @@ export class BibleTextRevisionDto extends Schema.Class<BibleTextRevisionDto>(
   versionId: Schema.NonEmptyString,
   revision: Schema.NonEmptyString,
   textRevision: Schema.optional(Schema.NonEmptyString),
+  textSha256: Schema.optional(Schema.String.pipe(Schema.pattern(/^[a-f0-9]{64}$/))),
 }) {}
 
 export class BibleChapterDto extends Schema.Class<BibleChapterDto>('BibleChapterDto')({

--- a/src/features/resources/bibleChapterSource.ts
+++ b/src/features/resources/bibleChapterSource.ts
@@ -19,6 +19,8 @@ export type BibleChapterSourceResult =
       status: 'available'
       verses: Verse[]
       presentation?: 'canonical' | 'legacy-sidecars'
+      textRevision?: string
+      textSha256?: string
     }
   | {
       status: 'unavailable'
@@ -32,7 +34,12 @@ export type BibleChapterAdapter = {
 }
 
 export type BibleCoverageSourceResult =
-  | { status: 'available'; coverage: BibleVersionCoverage }
+  | {
+      status: 'available'
+      coverage: BibleVersionCoverage
+      textRevision?: string
+      textSha256?: string
+    }
   | { status: 'unavailable'; reason: BibleChapterUnavailableReason }
 
 export class BibleVerseTextSourceError extends Error {
@@ -49,7 +56,9 @@ export const loadVerseTextsFromChapterAdapter = async (
   adapter: BibleChapterAdapter,
   version: string,
   verseKeys: string[],
-  shouldCancel?: () => boolean
+  shouldCancel?: () => boolean,
+  expectedTextRevision?: string,
+  expectedTextSha256?: string
 ): Promise<Record<string, string>> => {
   const chapters = new Map<string, { book: number; chapter: number; verseKeys: string[] }>()
 
@@ -81,6 +90,12 @@ export const loadVerseTextsFromChapterAdapter = async (
     if (chapterResult.status !== 'available') {
       firstUnavailable ??= chapterResult
       continue
+    }
+    if (
+      (expectedTextRevision !== undefined && chapterResult.textRevision !== expectedTextRevision) ||
+      (expectedTextSha256 !== undefined && chapterResult.textSha256 !== expectedTextSha256)
+    ) {
+      throw new BibleVerseTextSourceError('integrity-failure')
     }
 
     const requestedKeys = new Set(group.verseKeys)
@@ -221,6 +236,8 @@ export const createHttpBibleChapterAdapter = ({
           return {
             status: 'available',
             presentation: 'canonical',
+            textRevision: decoded.resource.textRevision ?? decoded.resource.revision,
+            ...(decoded.resource.textSha256 ? { textSha256: decoded.resource.textSha256 } : {}),
             verses: decoded.verses.map(verse =>
               toVerse(
                 decoded.book,
@@ -260,6 +277,8 @@ export const createHttpBibleChapterAdapter = ({
           const decoded = Schema.decodeUnknownSync(BibleVersionCoverageDto)(payload)
           return {
             status: 'available',
+            textRevision: decoded.resource.textRevision ?? decoded.resource.revision,
+            ...(decoded.resource.textSha256 ? { textSha256: decoded.resource.textSha256 } : {}),
             coverage: {
               canon: {
                 id: decoded.canon.id,

--- a/src/features/resources/bibleContentAccess.ts
+++ b/src/features/resources/bibleContentAccess.ts
@@ -58,6 +58,12 @@ import {
   loadVerseTextsFromChapterAdapter,
   BibleVerseTextSourceError,
 } from './bibleChapterSource'
+import {
+  localStrongBibleResourceAccess,
+  type StrongBibleChapterSpansPayload,
+  type StrongBibleResourceAccess,
+} from './strongBibleResourceAccess'
+import { ResourceAccessError } from './resourceAccessError'
 
 export type { BibleChapterAdapter, BibleChapterSourceResult } from './bibleChapterSource'
 
@@ -122,7 +128,14 @@ type BibleContentAccessDependencies = {
   getStrongResourceLanguage: () => ResourceLanguage
   chapterAdapter: BibleChapterAdapter
   logError: (message: string, error: unknown) => void
-  loadStrongBibleChapterSpans?: typeof loadStrongBibleChapterSpans
+  loadStrongBibleChapterSpans?: (
+    versionId: StrongBibleVersionId,
+    book: number,
+    chapter: number
+  ) => Promise<
+    | Record<number, import('~helpers/canonicalStrongVerse').StrongBibleSpan[]>
+    | StrongBibleChapterSpansPayload
+  >
   loadReverseInterlinearChapterSpans?: typeof loadReverseInterlinearChapterSpans
   loadInterlinearChapterTokens?: typeof loadInterlinearChapterTokens
 }
@@ -137,6 +150,8 @@ export const localBibleChapterAdapter: BibleChapterAdapter = {
           status: 'available',
           verses,
           presentation: metadata?.schemaVersion === 4 ? 'canonical' : 'legacy-sidecars',
+          ...(metadata?.textRevision ? { textRevision: metadata.textRevision } : {}),
+          ...(metadata?.textSha256 ? { textSha256: metadata.textSha256 } : {}),
         }
       }
 
@@ -192,7 +207,16 @@ export const localBibleChapterAdapter: BibleChapterAdapter = {
   },
   async loadCoverage(version) {
     try {
-      return { status: 'available', coverage: await loadLocalBibleCoverage(version) }
+      const [coverage, metadata] = await Promise.all([
+        loadLocalBibleCoverage(version),
+        getBibleVersionMetadata(version),
+      ])
+      return {
+        status: 'available',
+        coverage,
+        ...(metadata?.textRevision ? { textRevision: metadata.textRevision } : {}),
+        ...(metadata?.textSha256 ? { textSha256: metadata.textSha256 } : {}),
+      }
     } catch {
       return { status: 'unavailable', reason: 'offline-copy-invalid' }
     }
@@ -402,11 +426,21 @@ const loadRegularBibleChapter = async (
   }
 
   try {
-    const spansByVerse = await dependencies.loadStrongBibleChapterSpans(
+    const strongChapter = await dependencies.loadStrongBibleChapterSpans(
       request.version as StrongBibleVersionId,
       request.book,
       request.chapter
     )
+    const spansByVerse =
+      'spansByVerse' in strongChapter ? strongChapter.spansByVerse : strongChapter
+    if (
+      'spansByVerse' in strongChapter &&
+      ((strongChapter.textRevision !== undefined &&
+        chapter.textRevision !== strongChapter.textRevision) ||
+        (strongChapter.textSha256 !== undefined && chapter.textSha256 !== strongChapter.textSha256))
+    ) {
+      throw new ResourceAccessError('INTEGRITY_FAILURE')
+    }
     let alignedTokensByVerse: Awaited<ReturnType<typeof loadInterlinearChapterTokens>> = {}
     if (dependencies.loadInterlinearChapterTokens) {
       for (const locale of getInterlinearLocalePriority(request.interlinearLocale ?? 'fr')) {
@@ -495,11 +529,34 @@ export const localBibleContentAccess: BibleContentAccess = {
 }
 
 export const createBibleContentAccess = (
-  chapterAdapter: BibleChapterAdapter
+  chapterAdapter: BibleChapterAdapter,
+  strongBibleAccess: {
+    loadChapterSpans: NonNullable<StrongBibleResourceAccess['loadChapterSpans']>
+  } = localStrongBibleResourceAccess
 ): BibleContentAccess => ({
   ...localBibleContentAccess,
   loadChapter: request =>
-    loadBibleContentChapter(request, { ...defaultDependencies, chapterAdapter }),
+    loadBibleContentChapter(request, {
+      ...defaultDependencies,
+      chapterAdapter,
+      loadStrongBibleChapterSpans: async (versionId, book, chapter) => {
+        const result = await strongBibleAccess.loadChapterSpans({
+          currentVersionId: versionId,
+          defaultVersionId: versionId,
+          fallbackVersionIds: [],
+          book,
+          chapter,
+        })
+        if (result.status !== 'available') {
+          throw new ResourceAccessError('OFFLINE_COPY_REQUIRED', ['acquire-offline-copy'])
+        }
+        return {
+          spansByVerse: result.spansByVerse,
+          ...(result.textRevision ? { textRevision: result.textRevision } : {}),
+          ...(result.textSha256 ? { textSha256: result.textSha256 } : {}),
+        }
+      },
+    }),
   loadVerseTexts: async ({ version, verseKeys, shouldCancel }) => {
     try {
       return await loadVerseTextsFromChapterAdapter(

--- a/src/features/resources/lexiconBibleResourceAccess.ts
+++ b/src/features/resources/lexiconBibleResourceAccess.ts
@@ -93,7 +93,10 @@ export interface InterlinearLexiconAdapter {
 }
 
 export interface LexiconBibleResourceDependencies {
-  strongBible: StrongBibleResourceAccess
+  strongBible: Pick<
+    StrongBibleResourceAccess,
+    'loadVerse' | 'loadCountsByBook' | 'loadFoundVersesByBook' | 'loadLemmaStats'
+  >
   interlinear: InterlinearLexiconAdapter
 }
 

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -37,7 +37,10 @@ import {
   type StrongLexiconAccess,
 } from '~features/resources/strongLexiconAccess'
 import {
-  localStrongBibleResourceAccess,
+  createHttpStrongBibleResourceAdapter,
+  createHybridStrongBibleResourceAdapter,
+  createStrongBibleResourceAccess,
+  localStrongBibleResourceAdapter,
   type StrongBibleResourceAccess,
 } from '~features/resources/strongBibleResourceAccess'
 import {
@@ -63,6 +66,7 @@ import {
   getMobileBibleVersionIds,
 } from '~helpers/mobileResourceCatalog'
 import { PUBLIC_ONLINE_BIBLE_VERSION_IDS } from '~helpers/ordinaryBibleVersions'
+import { STRONG_BIBLE_FALLBACK_PRIORITY } from '~helpers/strongBiblePublications'
 
 export type ResourceAccessRegistry = {
   bibleContent: BibleContentAccess
@@ -97,12 +101,34 @@ const onlineBibleChapterAdapter = resourceApiBaseUrl
       isOnline: async () => onlineManager.isOnline(),
     })
   : unavailableHttpBibleChapterAdapter
+const bibleChapterAdapter = createHybridBibleChapterAdapter({
+  offline: localBibleChapterAdapter,
+  online: onlineBibleChapterAdapter,
+})
 const onlineNaveAccess = resourceApiBaseUrl
   ? createHttpNaveAccess({
       baseUrl: resourceApiBaseUrl,
       isOnline: async () => onlineManager.isOnline(),
     })
   : unavailableHttpNaveAccess
+const remotelyReadableStrongBibleVersions = new Set(
+  resourceApiBaseUrl ? STRONG_BIBLE_FALLBACK_PRIORITY : []
+)
+const onlineStrongBibleAdapter = resourceApiBaseUrl
+  ? createHttpStrongBibleResourceAdapter({
+      baseUrl: resourceApiBaseUrl,
+      isOnline: async () => onlineManager.isOnline(),
+      bibleChapterAdapter,
+    })
+  : localStrongBibleResourceAdapter
+const strongBibleAccess = createStrongBibleResourceAccess(
+  createHybridStrongBibleResourceAdapter({
+    offline: localStrongBibleResourceAdapter,
+    online: onlineStrongBibleAdapter,
+    remotelyReadableVersions: remotelyReadableStrongBibleVersions,
+    isOnline: async () => onlineManager.isOnline(),
+  })
+)
 const remotelyReadableBibleVersions = new Set(
   resourceApiBaseUrl ? (__DEV__ ? getMobileBibleVersionIds() : PUBLIC_ONLINE_BIBLE_VERSION_IDS) : []
 )
@@ -119,12 +145,7 @@ const onlineBibleReadingAccess = resourceApiBaseUrl
     }
 
 export const defaultResourceAccess: ResourceAccessRegistry = {
-  bibleContent: createBibleContentAccess(
-    createHybridBibleChapterAdapter({
-      offline: localBibleChapterAdapter,
-      online: onlineBibleChapterAdapter,
-    })
-  ),
+  bibleContent: createBibleContentAccess(bibleChapterAdapter, strongBibleAccess),
   bibleReading: createHybridBibleReadingResourceAccess({
     local: localBibleReadingResourceAccess,
     online: onlineBibleReadingAccess,
@@ -141,7 +162,7 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
     isOnline: async () => onlineManager.isOnline(),
   }),
   strongLexicon: localStrongLexiconAccess,
-  strongBible: localStrongBibleResourceAccess,
+  strongBible: strongBibleAccess,
   timeline: localTimelineAccess,
   commentary: defaultCommentaryAccess,
   offlineCopies: { isAvailable: isLocalResourceAvailable },
@@ -150,7 +171,8 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
       getResourceOnlineAccess(
         identity,
         remotelyReadableBibleVersions,
-        resourceApiBaseUrl ? new Set(['fr']) : new Set()
+        resourceApiBaseUrl ? new Set(['fr']) : new Set(),
+        remotelyReadableStrongBibleVersions
       ),
   },
 }

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -74,9 +74,12 @@ export type ResourceAction =
 export const getResourceOnlineAccess = (
   identity: ResourceIdentity,
   remotelyReadableBibleVersions: ReadonlySet<string>,
-  remotelyReadableNaveLanguages: ReadonlySet<ResourceLanguage> = new Set()
+  remotelyReadableNaveLanguages: ReadonlySet<ResourceLanguage> = new Set(),
+  remotelyReadableStrongBibleVersions: ReadonlySet<string> = new Set()
 ): OnlineAccessState =>
   (identity.kind === 'bible-text' && remotelyReadableBibleVersions.has(identity.versionId)) ||
+  (identity.kind === 'strong-bible-index' &&
+    remotelyReadableStrongBibleVersions.has(identity.versionId)) ||
   (identity.kind === 'nave' && remotelyReadableNaveLanguages.has(identity.language)) ||
   (identity.kind === 'commentary' && identity.collection === 'FIRESTORE')
     ? { status: 'remotely-readable' }

--- a/src/features/resources/strongBibleContract.ts
+++ b/src/features/resources/strongBibleContract.ts
@@ -1,0 +1,154 @@
+import { Schema } from 'effect'
+
+const VersionId = Schema.String.pipe(Schema.pattern(/^[A-Z0-9][A-Z0-9_-]{1,31}$/))
+const Book = Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 77))
+const Chapter = Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 200))
+const Reference = Schema.String.pipe(Schema.pattern(/^(?:[HG])?\d+[A-Z]*$/i))
+
+export class StrongBibleVersionPath extends Schema.Class<StrongBibleVersionPath>(
+  'StrongBibleVersionPath'
+)({
+  version: VersionId,
+}) {}
+
+export class StrongBibleChapterPath extends Schema.Class<StrongBibleChapterPath>(
+  'StrongBibleChapterPath'
+)({
+  version: VersionId,
+  book: Book,
+  chapter: Chapter,
+}) {}
+
+export class StrongBibleIdentityPath extends Schema.Class<StrongBibleIdentityPath>(
+  'StrongBibleIdentityPath'
+)({
+  version: VersionId,
+  book: Book,
+  reference: Reference,
+}) {}
+
+export class StrongBibleOccurrencesQuery extends Schema.Class<StrongBibleOccurrencesQuery>(
+  'StrongBibleOccurrencesQuery'
+)({
+  limit: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 500))),
+  offset: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative())),
+  allBooks: Schema.optional(Schema.Literal('true', 'false')),
+  lexemeId: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.positive())),
+}) {}
+
+export class StrongBibleRevisionDto extends Schema.Class<StrongBibleRevisionDto>(
+  'StrongBibleRevisionDto'
+)({
+  kind: Schema.Literal('strong-bible-index'),
+  versionId: Schema.NonEmptyString,
+  datasetId: Schema.NonEmptyString,
+  revision: Schema.NonEmptyString,
+  textRevision: Schema.NonEmptyString,
+  textSha256: Schema.String.pipe(Schema.pattern(/^[a-f0-9]{64}$/)),
+  strongRevision: Schema.NonEmptyString,
+}) {}
+
+export class StrongBibleIdentityDto extends Schema.Class<StrongBibleIdentityDto>(
+  'StrongBibleIdentityDto'
+)({
+  id: Schema.optional(Schema.Int.pipe(Schema.positive())),
+  kind: Schema.Literal('strong', 'estrong', 'dstrong', 'ustrong'),
+  code: Schema.NonEmptyString,
+}) {}
+
+export class StrongBibleMorphologyDto extends Schema.Class<StrongBibleMorphologyDto>(
+  'StrongBibleMorphologyDto'
+)({
+  identity: StrongBibleIdentityDto,
+  codes: Schema.Array(Schema.NonEmptyString),
+}) {}
+
+export class StrongBibleSpanDto extends Schema.Class<StrongBibleSpanDto>('StrongBibleSpanDto')({
+  ordinal: Schema.Int.pipe(Schema.nonNegative()),
+  startOffset: Schema.Int.pipe(Schema.nonNegative()),
+  length: Schema.Int.pipe(Schema.nonNegative()),
+  stepTokenIds: Schema.optional(Schema.Array(Schema.Int.pipe(Schema.positive()))),
+  identities: Schema.Array(StrongBibleIdentityDto),
+  morphologies: Schema.optional(Schema.Array(StrongBibleMorphologyDto)),
+}) {}
+
+export class StrongBibleChapterVerseDto extends Schema.Class<StrongBibleChapterVerseDto>(
+  'StrongBibleChapterVerseDto'
+)({
+  number: Schema.Int.pipe(Schema.nonNegative()),
+  spans: Schema.Array(StrongBibleSpanDto),
+}) {}
+
+export class StrongBibleChapterDto extends Schema.Class<StrongBibleChapterDto>(
+  'StrongBibleChapterDto'
+)({
+  resource: StrongBibleRevisionDto,
+  book: Schema.Int.pipe(Schema.positive()),
+  chapter: Schema.Int.pipe(Schema.positive()),
+  verses: Schema.Array(StrongBibleChapterVerseDto),
+}) {}
+
+export class StrongBibleCoverageDto extends Schema.Class<StrongBibleCoverageDto>(
+  'StrongBibleCoverageDto'
+)({
+  resource: StrongBibleRevisionDto,
+  books: Schema.Array(Schema.Int.pipe(Schema.positive())),
+  chaptersByBook: Schema.Record({
+    key: Schema.String,
+    value: Schema.Array(Schema.Int.pipe(Schema.positive())),
+  }),
+  verseCountByBookChapter: Schema.Record({
+    key: Schema.String,
+    value: Schema.Int.pipe(Schema.nonNegative()),
+  }),
+}) {}
+
+export class StrongBibleBookCountDto extends Schema.Class<StrongBibleBookCountDto>(
+  'StrongBibleBookCountDto'
+)({
+  book: Schema.Int.pipe(Schema.positive()),
+  verseCount: Schema.Int.pipe(Schema.nonNegative()),
+}) {}
+
+export class StrongBibleCountsDto extends Schema.Class<StrongBibleCountsDto>(
+  'StrongBibleCountsDto'
+)({
+  resource: StrongBibleRevisionDto,
+  identity: Schema.optional(StrongBibleIdentityDto),
+  counts: Schema.Array(StrongBibleBookCountDto),
+}) {}
+
+export class StrongBibleOccurrenceVerseDto extends Schema.Class<StrongBibleOccurrenceVerseDto>(
+  'StrongBibleOccurrenceVerseDto'
+)({
+  book: Schema.Int.pipe(Schema.positive()),
+  chapter: Schema.Int.pipe(Schema.positive()),
+  verse: Schema.Int.pipe(Schema.nonNegative()),
+  spans: Schema.Array(StrongBibleSpanDto),
+}) {}
+
+export class StrongBibleOccurrencesDto extends Schema.Class<StrongBibleOccurrencesDto>(
+  'StrongBibleOccurrencesDto'
+)({
+  resource: StrongBibleRevisionDto,
+  identity: Schema.optional(StrongBibleIdentityDto),
+  verses: Schema.Array(StrongBibleOccurrenceVerseDto),
+  nextOffset: Schema.optional(Schema.Int.pipe(Schema.nonNegative())),
+}) {}
+
+export class StrongBibleLemmaStatDto extends Schema.Class<StrongBibleLemmaStatDto>(
+  'StrongBibleLemmaStatDto'
+)({
+  id: Schema.Int.pipe(Schema.positive()),
+  lemma: Schema.NonEmptyString,
+  partOfSpeech: Schema.NonEmptyString,
+  occurrenceCount: Schema.Int.pipe(Schema.nonNegative()),
+}) {}
+
+export class StrongBibleLemmaStatsDto extends Schema.Class<StrongBibleLemmaStatsDto>(
+  'StrongBibleLemmaStatsDto'
+)({
+  resource: StrongBibleRevisionDto,
+  identity: Schema.optional(StrongBibleIdentityDto),
+  lemmas: Schema.Array(StrongBibleLemmaStatDto),
+}) {}

--- a/src/features/resources/strongBibleResourceAccess.ts
+++ b/src/features/resources/strongBibleResourceAccess.ts
@@ -1,4 +1,5 @@
 import type { Verse } from '~common/types'
+import { Schema } from 'effect'
 import { getMultipleVerses, getVerseText } from '~helpers/biblesDb'
 import type { StrongBibleSpan } from '~helpers/canonicalStrongVerse'
 import {
@@ -22,6 +23,16 @@ import {
   type StrongBibleDatasetId,
   type StrongBibleVersionId,
 } from '~helpers/strongBiblePublications'
+import {
+  StrongBibleChapterDto,
+  StrongBibleCountsDto,
+  StrongBibleCoverageDto,
+  StrongBibleLemmaStatsDto,
+  StrongBibleOccurrencesDto,
+} from './strongBibleContract'
+import type { BibleChapterAdapter } from './bibleChapterSource'
+import { loadVerseTextsFromChapterAdapter } from './bibleChapterSource'
+import { mapLocalResourceError, ResourceAccessError } from './resourceAccessError'
 
 export type { StrongBibleLemmaStat, StrongBibleVerseCountByBook } from '~helpers/strongBibleSidecar'
 
@@ -90,6 +101,22 @@ export type StrongBibleChapterCodesResult =
       codes: string[]
     }
 
+export type StrongBibleChapterSpansResult =
+  | StrongBibleUnavailable
+  | {
+      status: 'available'
+      provenance: StrongBibleProvenance
+      spansByVerse: Record<number, StrongBibleSpan[]>
+      textRevision?: string
+      textSha256?: string
+    }
+
+export type StrongBibleChapterSpansPayload = {
+  spansByVerse: Record<number, StrongBibleSpan[]>
+  textRevision?: string
+  textSha256?: string
+}
+
 export type StrongBibleCountsResult =
   | StrongBibleUnavailable
   | {
@@ -127,7 +154,7 @@ export interface StrongBibleResourceAdapter {
   loadChapterSpans: (
     versionId: StrongBibleVersionId,
     request: Pick<StrongBibleChapterRequest, 'book' | 'chapter'>
-  ) => Promise<Record<number, StrongBibleSpan[]>>
+  ) => Promise<StrongBibleChapterSpansPayload>
   loadCountsByBook: (
     versionId: StrongBibleVersionId,
     request: StrongBibleAdapterConcordanceRequest
@@ -175,6 +202,7 @@ export interface StrongBibleResourceAccess {
   getAvailability: (versionId: string) => Promise<StrongBibleSidecarAvailability>
   loadVerse: (request: StrongBibleVerseRequest) => Promise<StrongBibleVerseResult>
   loadChapterCodes: (request: StrongBibleChapterRequest) => Promise<StrongBibleChapterCodesResult>
+  loadChapterSpans: (request: StrongBibleChapterRequest) => Promise<StrongBibleChapterSpansResult>
   loadCountsByBook: (request: StrongBibleConcordanceRequest) => Promise<StrongBibleCountsResult>
   loadFoundVersesByBook: (
     request: StrongBibleConcordanceRequest
@@ -184,8 +212,20 @@ export interface StrongBibleResourceAccess {
 
 export const localStrongBibleResourceAdapter: StrongBibleResourceAdapter = {
   getAvailability: getStrongBibleSidecarAvailability,
-  loadChapterSpans(versionId, request) {
-    return loadStrongBibleChapterSpans(versionId, request.book, request.chapter)
+  async loadChapterSpans(versionId, request) {
+    const [spansByVerse, availability] = await Promise.all([
+      loadStrongBibleChapterSpans(versionId, request.book, request.chapter),
+      getStrongBibleSidecarAvailability(versionId),
+    ])
+    return {
+      spansByVerse,
+      ...(availability.status === 'available'
+        ? {
+            textRevision: availability.textRevision,
+            ...(availability.textSha256 ? { textSha256: availability.textSha256 } : {}),
+          }
+        : {}),
+    }
   },
   async loadVerse(versionId, request) {
     const [text, spans] = await Promise.all([
@@ -244,6 +284,390 @@ export const localStrongBibleResourceAdapter: StrongBibleResourceAdapter = {
   },
 }
 
+type HttpStrongBibleResourceAdapterOptions = {
+  baseUrl: string
+  fetcher?: typeof fetch
+  isOnline: () => Promise<boolean>
+  bibleChapterAdapter: BibleChapterAdapter
+  timeoutMs?: number
+}
+
+const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '')
+
+const problemCode = (payload: unknown) =>
+  payload && typeof payload === 'object' && 'code' in payload ? payload.code : undefined
+
+const mapHttpFailure = async (
+  response: Response,
+  payload: unknown
+): Promise<ResourceAccessError> => {
+  const code = problemCode(payload)
+  if (response.status === 404 && code === 'STRONG_BIBLE_CHAPTER_NOT_FOUND') {
+    return new ResourceAccessError('NOT_FOUND')
+  }
+  if (response.status === 404 && code === 'STRONG_BIBLE_UNSUPPORTED') {
+    return new ResourceAccessError('RESOURCE_UNSUPPORTED')
+  }
+  return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+}
+
+const toStrongBibleSpan = (
+  span: StrongBibleChapterDto['verses'][number]['spans'][number]
+): StrongBibleSpan => ({
+  ordinal: span.ordinal,
+  startOffset: span.startOffset,
+  length: span.length,
+  ...(span.stepTokenIds ? { stepTokenIds: [...span.stepTokenIds] } : {}),
+  identities: span.identities.map(identity => ({ kind: identity.kind, code: identity.code })),
+  ...(span.morphologies
+    ? {
+        morphologies: span.morphologies.map(morphology => ({
+          identity: {
+            kind: morphology.identity.kind,
+            code: morphology.identity.code,
+          },
+          codes: [...morphology.codes],
+        })),
+      }
+    : {}),
+})
+
+const assertBibleChapterRevision = (
+  chapter: Awaited<ReturnType<BibleChapterAdapter['loadChapter']>>,
+  expectedTextRevision: string,
+  expectedTextSha256: string
+) => {
+  if (
+    chapter.status !== 'available' ||
+    chapter.textRevision !== expectedTextRevision ||
+    chapter.textSha256 !== expectedTextSha256 ||
+    chapter.verses.some(verse => verse.TextRevision !== expectedTextRevision)
+  ) {
+    throw new ResourceAccessError('INTEGRITY_FAILURE')
+  }
+}
+
+const bibleChapterUnavailableError = (
+  chapter: Extract<
+    Awaited<ReturnType<BibleChapterAdapter['loadChapter']>>,
+    { status: 'unavailable' }
+  >
+) => {
+  switch (chapter.reason) {
+    case 'chapter-not-available':
+      return new ResourceAccessError('NOT_FOUND')
+    case 'publication-not-available':
+      return new ResourceAccessError('OFFLINE_COPY_REQUIRED', ['acquire-offline-copy'])
+    case 'offline-copy-invalid':
+      return new ResourceAccessError('INVALID_OFFLINE_COPY', [
+        'acquire-offline-copy',
+        'manage-offline-copies',
+      ])
+    case 'resource-unsupported':
+      return new ResourceAccessError('RESOURCE_UNSUPPORTED')
+    case 'network-offline':
+      return new ResourceAccessError('NETWORK_OFFLINE')
+    case 'integrity-failure':
+      return new ResourceAccessError('INTEGRITY_FAILURE')
+    case 'temporary-unavailable':
+      return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+  }
+}
+
+export const createHttpStrongBibleResourceAdapter = ({
+  baseUrl,
+  fetcher = fetch,
+  isOnline,
+  bibleChapterAdapter,
+  timeoutMs = 10_000,
+}: HttpStrongBibleResourceAdapterOptions): StrongBibleResourceAdapter => {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const get = async <A>(path: string, schema: Schema.Schema<A>): Promise<A> => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(`${normalizedBaseUrl}${path}`, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      })
+      const payload: unknown = await response.json().catch(() => undefined)
+      if (!response.ok) throw await mapHttpFailure(response, payload)
+      try {
+        return Schema.decodeUnknownSync(schema)(payload)
+      } catch {
+        throw new ResourceAccessError('INTEGRITY_FAILURE')
+      }
+    } catch (error) {
+      if (error instanceof ResourceAccessError) throw error
+      throw new ResourceAccessError(
+        (await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE'
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  const loadChapter = (versionId: StrongBibleVersionId, book: number, chapter: number) =>
+    get(
+      `/v1/strong-bibles/${encodeURIComponent(versionId)}/books/${book}/chapters/${chapter}`,
+      StrongBibleChapterDto
+    )
+
+  return {
+    async getAvailability(versionId) {
+      if (!isStrongCapableBibleVersion(versionId)) return { status: 'unsupported' }
+      try {
+        const coverage = await get(
+          `/v1/strong-bibles/${encodeURIComponent(versionId)}/coverage`,
+          StrongBibleCoverageDto
+        )
+        const bibleCoverage = await bibleChapterAdapter.loadCoverage(versionId)
+        if (bibleCoverage.status !== 'available') {
+          throw bibleChapterUnavailableError(bibleCoverage)
+        }
+        if (
+          bibleCoverage.textRevision !== coverage.resource.textRevision ||
+          bibleCoverage.textSha256 !== coverage.resource.textSha256
+        ) {
+          return {
+            status: 'base-incompatible',
+            baseTextRevision: bibleCoverage.textRevision,
+            requiredTextRevision: coverage.resource.textRevision,
+          }
+        }
+        return {
+          status: 'available',
+          versionId,
+          datasetId: coverage.resource.datasetId,
+          textRevision: coverage.resource.textRevision,
+          textSha256: coverage.resource.textSha256,
+          strongRevision: coverage.resource.strongRevision,
+        }
+      } catch (error) {
+        if (error instanceof ResourceAccessError && error.code === 'RESOURCE_UNSUPPORTED') {
+          return { status: 'unsupported' }
+        }
+        throw error
+      }
+    },
+    async loadChapterSpans(versionId, request) {
+      try {
+        const chapter = await loadChapter(versionId, request.book, request.chapter)
+        return {
+          spansByVerse: Object.fromEntries(
+            chapter.verses.map(verse => [verse.number, verse.spans.map(toStrongBibleSpan)])
+          ),
+          textRevision: chapter.resource.textRevision,
+          textSha256: chapter.resource.textSha256,
+        }
+      } catch (error) {
+        if (error instanceof ResourceAccessError && error.code === 'NOT_FOUND') {
+          return { spansByVerse: {} }
+        }
+        throw error
+      }
+    },
+    async loadVerse(versionId, request) {
+      try {
+        const [chapter, bibleChapter] = await Promise.all([
+          loadChapter(versionId, request.book, request.chapter),
+          bibleChapterAdapter.loadChapter(versionId, request.book, request.chapter),
+        ])
+        if (bibleChapter.status !== 'available') throw bibleChapterUnavailableError(bibleChapter)
+        assertBibleChapterRevision(
+          bibleChapter,
+          chapter.resource.textRevision,
+          chapter.resource.textSha256
+        )
+        const text = bibleChapter.verses.find(
+          verse => Number(verse.Verset) === request.verse
+        )?.Texte
+        if (text == null) return undefined
+        return {
+          text,
+          spans:
+            chapter.verses
+              .find(verse => verse.number === request.verse)
+              ?.spans.map(toStrongBibleSpan) ?? [],
+        }
+      } catch (error) {
+        if (error instanceof ResourceAccessError && error.code === 'NOT_FOUND') return undefined
+        throw error
+      }
+    },
+    async loadCountsByBook(versionId, request) {
+      const response = await get(
+        `/v1/strong-bibles/${encodeURIComponent(versionId)}/books/${request.book}/identities/${encodeURIComponent(String(request.reference))}/counts`,
+        StrongBibleCountsDto
+      )
+      return {
+        counts: response.counts.map(count => ({
+          Livre: count.book,
+          versesCountByBook: count.verseCount,
+        })),
+        ...(response.identity
+          ? { identity: response.identity as ResolvedStrongBibleIdentity }
+          : {}),
+      }
+    },
+    async loadFoundVersesByBook(versionId, request) {
+      const query = new URLSearchParams()
+      if (request.limit !== undefined) query.set('limit', String(request.limit))
+      if (request.offset !== undefined) query.set('offset', String(request.offset))
+      if (request.allBooks !== undefined) query.set('allBooks', String(request.allBooks))
+      if (request.lexemeId !== undefined) query.set('lexemeId', String(request.lexemeId))
+      const response = await get(
+        `/v1/strong-bibles/${encodeURIComponent(versionId)}/books/${request.book}/identities/${encodeURIComponent(String(request.reference))}/occurrences${query.size ? `?${query}` : ''}`,
+        StrongBibleOccurrencesDto
+      )
+      const verseKeys = response.verses.map(
+        verse => `${verse.book}-${verse.chapter}-${verse.verse}`
+      )
+      const texts = await loadVerseTextsFromChapterAdapter(
+        bibleChapterAdapter,
+        versionId,
+        verseKeys,
+        undefined,
+        response.resource.textRevision,
+        response.resource.textSha256
+      )
+      return {
+        verses: response.verses.flatMap(verse => {
+          const key = `${verse.book}-${verse.chapter}-${verse.verse}`
+          const text = texts[key]
+          return text == null
+            ? []
+            : [
+                {
+                  Livre: verse.book,
+                  Chapitre: verse.chapter,
+                  Verset: verse.verse,
+                  Texte: text,
+                  StrongSpans: verse.spans.map(toStrongBibleSpan),
+                },
+              ]
+        }),
+        ...(response.identity
+          ? { identity: response.identity as ResolvedStrongBibleIdentity }
+          : {}),
+        ...(response.nextOffset === undefined ? {} : { nextOffset: response.nextOffset }),
+      }
+    },
+    async loadLemmaStats(versionId, request) {
+      const response = await get(
+        `/v1/strong-bibles/${encodeURIComponent(versionId)}/books/${request.book}/identities/${encodeURIComponent(String(request.reference))}/lemmas`,
+        StrongBibleLemmaStatsDto
+      )
+      return {
+        lemmas: response.lemmas.map(lemma => ({ ...lemma })),
+        ...(response.identity
+          ? { identity: response.identity as ResolvedStrongBibleIdentity }
+          : {}),
+      }
+    },
+  }
+}
+
+export const createHybridStrongBibleResourceAdapter = ({
+  offline,
+  online,
+  remotelyReadableVersions,
+  isOnline,
+}: {
+  offline: StrongBibleResourceAdapter
+  online: StrongBibleResourceAdapter
+  remotelyReadableVersions: ReadonlySet<string>
+  isOnline: () => Promise<boolean>
+}): StrongBibleResourceAdapter => {
+  const isInvalidLocalAvailability = (availability: StrongBibleSidecarAvailability) =>
+    availability.status === 'corrupt' ||
+    availability.status === 'incompatible' ||
+    availability.status === 'base-incompatible'
+  const invalidOfflineCopy = () =>
+    new ResourceAccessError('INVALID_OFFLINE_COPY', [
+      'acquire-offline-copy',
+      'manage-offline-copies',
+    ])
+  const select = async <Result>(
+    versionId: StrongBibleVersionId,
+    localOperation: () => Promise<Result>,
+    remoteOperation: () => Promise<Result>
+  ): Promise<Result> => {
+    const local = await offline.getAvailability(versionId)
+    if (local.status === 'available') {
+      try {
+        return await localOperation()
+      } catch (error) {
+        const mapped = mapLocalResourceError(error)
+        if (!remotelyReadableVersions.has(versionId) || !(await isOnline())) throw mapped
+      }
+    }
+    if (local.status === 'incompatible' || local.status === 'base-incompatible') {
+      throw invalidOfflineCopy()
+    }
+    if (!remotelyReadableVersions.has(versionId)) {
+      if (isInvalidLocalAvailability(local)) throw invalidOfflineCopy()
+      throw new ResourceAccessError('OFFLINE_COPY_REQUIRED', ['acquire-offline-copy'])
+    }
+    if (!(await isOnline())) {
+      if (isInvalidLocalAvailability(local)) throw invalidOfflineCopy()
+      throw new ResourceAccessError('NETWORK_OFFLINE')
+    }
+    try {
+      return await remoteOperation()
+    } catch (error) {
+      if (isInvalidLocalAvailability(local)) throw invalidOfflineCopy()
+      throw error
+    }
+  }
+
+  return {
+    async getAvailability(versionId) {
+      const local = await offline.getAvailability(versionId)
+      if (local.status === 'available') return local
+      if (local.status === 'incompatible' || local.status === 'base-incompatible') return local
+      if (
+        !isStrongCapableBibleVersion(versionId) ||
+        !remotelyReadableVersions.has(versionId) ||
+        !(await isOnline())
+      ) {
+        return local
+      }
+      return online.getAvailability(versionId)
+    },
+    loadChapterSpans: (versionId, request) =>
+      select(
+        versionId,
+        () => offline.loadChapterSpans(versionId, request),
+        () => online.loadChapterSpans(versionId, request)
+      ),
+    loadVerse: (versionId, request) =>
+      select(
+        versionId,
+        () => offline.loadVerse(versionId, request),
+        () => online.loadVerse(versionId, request)
+      ),
+    loadCountsByBook: (versionId, request) =>
+      select(
+        versionId,
+        () => offline.loadCountsByBook(versionId, request),
+        () => online.loadCountsByBook(versionId, request)
+      ),
+    loadFoundVersesByBook: (versionId, request) =>
+      select(
+        versionId,
+        () => offline.loadFoundVersesByBook(versionId, request),
+        () => online.loadFoundVersesByBook(versionId, request)
+      ),
+    loadLemmaStats: (versionId, request) =>
+      select(
+        versionId,
+        () => offline.loadLemmaStats(versionId, request),
+        () => online.loadLemmaStats(versionId, request)
+      ),
+  }
+}
+
 export const createStrongBibleResourceAccess = (
   adapter: StrongBibleResourceAdapter = localStrongBibleResourceAdapter
 ): StrongBibleResourceAccess => {
@@ -268,13 +692,20 @@ export const createStrongBibleResourceAccess = (
       ]),
     ].filter((candidate): candidate is string => Boolean(candidate))
     const attempts: StrongBibleAttempt[] = []
+    let firstAvailabilityError: unknown
 
     for (const candidate of candidates) {
       if (!isStrongCapableBibleVersion(candidate)) {
         attempts.push({ versionId: candidate, status: 'unsupported' })
         continue
       }
-      const availability = await adapter.getAvailability(candidate)
+      let availability: StrongBibleSidecarAvailability
+      try {
+        availability = await adapter.getAvailability(candidate)
+      } catch (error) {
+        firstAvailabilityError ??= error
+        continue
+      }
       if (availability.status === 'available') {
         return {
           status: 'available',
@@ -288,6 +719,7 @@ export const createStrongBibleResourceAccess = (
       attempts.push({ versionId: candidate, status: availability.status })
     }
 
+    if (firstAvailabilityError !== undefined) throw firstAvailabilityError
     return { status: 'unavailable', attempts }
   }
 
@@ -305,11 +737,27 @@ export const createStrongBibleResourceAccess = (
         provenance: resolution.provenance,
         codes: [
           ...new Set(
-            Object.values(spansByVerse).flatMap(spans =>
+            Object.values(spansByVerse.spansByVerse).flatMap(spans =>
               spans.flatMap(span => span.identities.map(identity => identity.code))
             )
           ),
         ],
+      }
+    },
+
+    async loadChapterSpans(request) {
+      const resolution = await resolve(request)
+      if (resolution.status !== 'available') return resolution
+      const loaded = await adapter.loadChapterSpans(resolution.provenance.versionId, {
+        book: request.book,
+        chapter: request.chapter,
+      })
+      return {
+        status: 'available',
+        provenance: resolution.provenance,
+        spansByVerse: loaded.spansByVerse,
+        ...(loaded.textRevision ? { textRevision: loaded.textRevision } : {}),
+        ...(loaded.textSha256 ? { textSha256: loaded.textSha256 } : {}),
       }
     },
 

--- a/src/helpers/mobileResourceCatalog.ts
+++ b/src/helpers/mobileResourceCatalog.ts
@@ -216,6 +216,14 @@ export const getMobileBibleVersionIds = (
         .map(resourceId => resourceId.slice('bible:'.length))
         .sort()
 
+export const getMobileStrongBibleVersionIds = (
+  catalog: MobileResourceCatalog = MOBILE_RESOURCE_CATALOG
+): string[] =>
+  Object.keys(catalog.resources)
+    .filter(resourceId => resourceId.startsWith('bible-strong:'))
+    .map(resourceId => resourceId.slice('bible-strong:'.length))
+    .sort()
+
 let developmentResourceArtifactBaseUrl: string | undefined
 
 export const configureDevelopmentResourceArtifactBaseUrl = (value: string | undefined): void => {

--- a/src/helpers/strongBibleCatalog.ts
+++ b/src/helpers/strongBibleCatalog.ts
@@ -1,0 +1,72 @@
+export type StrongBibleVersionId =
+  | 'LSG'
+  | 'DBY'
+  | 'DBR'
+  | 'KJV'
+  | 'NASB2020'
+  | 'NASB1995'
+  | 'BSB'
+  | 'ASV'
+  | 'DARBY'
+  | 'RLT'
+  | 'RWEBSTER'
+  | 'RV1895'
+
+export type StrongBibleDatasetId =
+  | 'LSG'
+  | 'DBY'
+  | 'DBYR'
+  | 'KJV'
+  | 'NASB2020'
+  | 'NASB1995'
+  | 'BSB'
+  | 'ASV'
+  | 'DARBY_EN'
+  | 'RLT'
+  | 'RWEBSTER'
+  | 'RV1895'
+
+export const FRENCH_STRONG_BIBLE_PRIORITY = ['LSG', 'DBY', 'DBR'] as const
+export const ENGLISH_STRONG_BIBLE_PRIORITY = [
+  'KJV',
+  'NASB2020',
+  'NASB1995',
+  'BSB',
+  'ASV',
+  'DARBY',
+  'RLT',
+  'RWEBSTER',
+  'RV1895',
+] as const
+export const STRONG_BIBLE_FALLBACK_PRIORITY = [
+  ...FRENCH_STRONG_BIBLE_PRIORITY,
+  ...ENGLISH_STRONG_BIBLE_PRIORITY,
+] as const satisfies readonly StrongBibleVersionId[]
+
+const DATASET_BY_VERSION = {
+  LSG: 'LSG',
+  DBY: 'DBY',
+  DBR: 'DBYR',
+  KJV: 'KJV',
+  NASB2020: 'NASB2020',
+  NASB1995: 'NASB1995',
+  BSB: 'BSB',
+  ASV: 'ASV',
+  DARBY: 'DARBY_EN',
+  RLT: 'RLT',
+  RWEBSTER: 'RWEBSTER',
+  RV1895: 'RV1895',
+} as const satisfies Record<StrongBibleVersionId, StrongBibleDatasetId>
+
+export const isStrongBibleVersionId = (value: string): value is StrongBibleVersionId =>
+  value in DATASET_BY_VERSION
+
+export const getStrongBibleCatalogIdentity = (versionId: StrongBibleVersionId) => ({
+  versionId,
+  datasetId: DATASET_BY_VERSION[versionId],
+  language: FRENCH_STRONG_BIBLE_PRIORITY.includes(
+    versionId as (typeof FRENCH_STRONG_BIBLE_PRIORITY)[number]
+  )
+    ? ('fr' as const)
+    : ('en' as const),
+})

--- a/src/helpers/strongBiblePublications.ts
+++ b/src/helpers/strongBiblePublications.ts
@@ -3,51 +3,22 @@ import {
   REVERSE_INTERLINEAR_STEP_CONTRACT,
   STRONG_BIBLE_REVERSE_INTERLINEAR_CANDIDATES,
 } from './strongBibleReverseInterlinearCandidate'
+import {
+  ENGLISH_STRONG_BIBLE_PRIORITY,
+  FRENCH_STRONG_BIBLE_PRIORITY,
+  type StrongBibleDatasetId,
+  type StrongBibleVersionId,
+} from './strongBibleCatalog'
+
+export {
+  ENGLISH_STRONG_BIBLE_PRIORITY,
+  FRENCH_STRONG_BIBLE_PRIORITY,
+  STRONG_BIBLE_FALLBACK_PRIORITY,
+  type StrongBibleDatasetId,
+  type StrongBibleVersionId,
+} from './strongBibleCatalog'
 
 export type StrongMode = 'visible' | 'hidden' | 'reverse-interlinear'
-export type StrongBibleVersionId =
-  | 'LSG'
-  | 'DBY'
-  | 'DBR'
-  | 'KJV'
-  | 'NASB2020'
-  | 'NASB1995'
-  | 'BSB'
-  | 'ASV'
-  | 'DARBY'
-  | 'RLT'
-  | 'RWEBSTER'
-  | 'RV1895'
-export type StrongBibleDatasetId =
-  | 'LSG'
-  | 'DBY'
-  | 'DBYR'
-  | 'KJV'
-  | 'NASB2020'
-  | 'NASB1995'
-  | 'BSB'
-  | 'ASV'
-  | 'DARBY_EN'
-  | 'RLT'
-  | 'RWEBSTER'
-  | 'RV1895'
-
-export const FRENCH_STRONG_BIBLE_PRIORITY = ['LSG', 'DBY', 'DBR'] as const
-export const ENGLISH_STRONG_BIBLE_PRIORITY = [
-  'KJV',
-  'NASB2020',
-  'NASB1995',
-  'BSB',
-  'ASV',
-  'DARBY',
-  'RLT',
-  'RWEBSTER',
-  'RV1895',
-] as const
-export const STRONG_BIBLE_FALLBACK_PRIORITY = [
-  ...FRENCH_STRONG_BIBLE_PRIORITY,
-  ...ENGLISH_STRONG_BIBLE_PRIORITY,
-] as const satisfies readonly StrongBibleVersionId[]
 
 type PublicationArtifact = {
   url: string

--- a/src/helpers/strongBibleSidecar.ts
+++ b/src/helpers/strongBibleSidecar.ts
@@ -68,6 +68,7 @@ export type StrongBibleSidecarAvailability =
       versionId: StrongBibleVersionId
       datasetId: string
       textRevision: string
+      textSha256?: string
       strongRevision: string
     }
 
@@ -133,6 +134,7 @@ export const getStrongBibleSidecarAvailability = async (
         versionId,
         datasetId: metadata.datasetId,
         textRevision: metadata.textRevision,
+        textSha256: metadata.textSha256,
         strongRevision: metadata.strongRevision,
       }
     })


### PR DESCRIPTION
Closes #303

## Summary
- publish/import all 12 cataloged Strong Bible indexes through typed local PostgreSQL and Effect HTTP contracts
- add installed-copy-first mobile Strong access without file-presence/download gates
- validate content-derived Resource revisions, exact Bible dependencies, rights/capabilities, canonical/SQLite parity, bounded ZIPs and symlink-safe artifacts
- add complete 12-bundle integration gate with bounded memory/disk usage

## Bible Lexicon Maker handoff
Local branch `codex/issue-303-publish-and-serve-every-strong-bible-index-locally` commits:
- `7289049` producer/config/tests
- `927c216` publication boundary hardening
- `c2cf5de` verse-zero superscriptions

## Validation
- `yarn typecheck`
- `yarn format:check`
- `yarn resources:test` — 43/43
- `RESOURCE_STRONG_BIBLE_BUNDLES_ROOT=... yarn resources:test:strong` — 12/12 real bundles, PostgreSQL import/query green
- Bible Lexicon Maker publication tests — 14/14
- iOS runtime evidence: Strong activation without download alert; HTTP-only Strong reader renders H0430
- final independent Spec and Standards reviews: clean