### PR TITLE
feat(resources): publish and serve dictionaries locally (#306)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "resources:test:interlinear": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/publication/__tests__/completeInterlinearBiblePublications.integration.node-test.ts",
     "resources:test:lexicon": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/publication/__tests__/completeStrongLexiconPublications.integration.node-test.ts",
     "resources:smoke:lexicon": "node scripts/smokeStrongLexiconResourceService.mjs",
+    "resources:smoke:dictionary": "node scripts/smokeDictionaryResourceService.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/drizzle/0011_premium_jean_grey.sql
+++ b/resource-service/drizzle/0011_premium_jean_grey.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "dictionary_entries" (
+	"publication_id" integer NOT NULL,
+	"entry_id" integer NOT NULL,
+	"word" text NOT NULL,
+	"normalized_word" text NOT NULL,
+	"definition" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	CONSTRAINT "dictionary_entries_publication_entry_primary" PRIMARY KEY("publication_id","entry_id")
+);
+--> statement-breakpoint
+CREATE TABLE "dictionary_verse_links" (
+	"publication_id" integer NOT NULL,
+	"verse_key" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"word" text NOT NULL,
+	"normalized_word" text NOT NULL,
+	CONSTRAINT "dictionary_verse_links_publication_verse_ordinal_primary" PRIMARY KEY("publication_id","verse_key","ordinal")
+);
+--> statement-breakpoint
+ALTER TABLE "dictionary_entries" ADD CONSTRAINT "dictionary_entries_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dictionary_verse_links" ADD CONSTRAINT "dictionary_verse_links_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "dictionary_entries_browse" ON "dictionary_entries" USING btree ("publication_id","normalized_word","entry_id");--> statement-breakpoint
+CREATE INDEX "dictionary_entries_search" ON "dictionary_entries" USING btree ("publication_id","word");--> statement-breakpoint
+CREATE INDEX "dictionary_verse_links_lookup" ON "dictionary_verse_links" USING btree ("publication_id","verse_key","ordinal");

--- a/resource-service/drizzle/meta/0011_snapshot.json
+++ b/resource-service/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,3138 @@
+{
+  "id": "17a38860-4edf-49ba-9bf4-d6c222f38e38",
+  "prevId": "4084a139-7495-45e0-bf7f-b7dd53ee9014",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bible_verses": {
+      "name": "bible_verses",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presentation": {
+          "name": "presentation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"startTags\":[],\"layout\":[],\"notes\":[],\"headings\":[]}'::jsonb"
+        }
+      },
+      "indexes": {
+        "bible_verses_chapter_lookup": {
+          "name": "bible_verses_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bible_verses_publication_id_resource_publications_id_fk": {
+          "name": "bible_verses_publication_id_resource_publications_id_fk",
+          "tableFrom": "bible_verses",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bible_verses_publication_location_primary": {
+          "name": "bible_verses_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dictionary_entries": {
+      "name": "dictionary_entries",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_word": {
+          "name": "normalized_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dictionary_entries_browse": {
+          "name": "dictionary_entries_browse",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_word",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dictionary_entries_search": {
+          "name": "dictionary_entries_search",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "word",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_entries_publication_id_resource_publications_id_fk": {
+          "name": "dictionary_entries_publication_id_resource_publications_id_fk",
+          "tableFrom": "dictionary_entries",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dictionary_entries_publication_entry_primary": {
+          "name": "dictionary_entries_publication_entry_primary",
+          "columns": [
+            "publication_id",
+            "entry_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dictionary_verse_links": {
+      "name": "dictionary_verse_links",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_key": {
+          "name": "verse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_word": {
+          "name": "normalized_word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dictionary_verse_links_lookup": {
+          "name": "dictionary_verse_links_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_verse_links_publication_id_resource_publications_id_fk": {
+          "name": "dictionary_verse_links_publication_id_resource_publications_id_fk",
+          "tableFrom": "dictionary_verse_links",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dictionary_verse_links_publication_verse_ordinal_primary": {
+          "name": "dictionary_verse_links_publication_verse_ordinal_primary",
+          "columns": [
+            "publication_id",
+            "verse_key",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interlinear_bible_segment_identities": {
+      "name": "interlinear_bible_segment_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_order": {
+          "name": "identity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "interlinear_bible_segment_identities_code_lookup": {
+          "name": "interlinear_bible_segment_identities_code_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interlinear_bible_segment_identities_segment_fk": {
+          "name": "interlinear_bible_segment_identities_segment_fk",
+          "tableFrom": "interlinear_bible_segment_identities",
+          "tableTo": "interlinear_bible_segments",
+          "columnsFrom": [
+            "publication_id",
+            "segment_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "segment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "interlinear_bible_segment_identities_primary": {
+          "name": "interlinear_bible_segment_identities_primary",
+          "columns": [
+            "publication_id",
+            "segment_id",
+            "identity_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interlinear_bible_segments": {
+      "name": "interlinear_bible_segments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morphology": {
+          "name": "morphology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss": {
+          "name": "gloss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "interlinear_bible_segments_token_ordinal_unique": {
+          "name": "interlinear_bible_segments_token_ordinal_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interlinear_bible_segments_token_lookup": {
+          "name": "interlinear_bible_segments_token_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interlinear_bible_segments_token_fk": {
+          "name": "interlinear_bible_segments_token_fk",
+          "tableFrom": "interlinear_bible_segments",
+          "tableTo": "interlinear_bible_tokens",
+          "columnsFrom": [
+            "publication_id",
+            "token_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "token_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "interlinear_bible_segments_publication_id_primary": {
+          "name": "interlinear_bible_segments_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "segment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interlinear_bible_tokens": {
+      "name": "interlinear_bible_tokens",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_id": {
+          "name": "verse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "interlinear_bible_tokens_verse_ordinal_unique": {
+          "name": "interlinear_bible_tokens_verse_ordinal_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interlinear_bible_tokens_verse_lookup": {
+          "name": "interlinear_bible_tokens_verse_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interlinear_bible_tokens_verse_fk": {
+          "name": "interlinear_bible_tokens_verse_fk",
+          "tableFrom": "interlinear_bible_tokens",
+          "tableTo": "interlinear_bible_verses",
+          "columnsFrom": [
+            "publication_id",
+            "verse_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "verse_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "interlinear_bible_tokens_publication_id_primary": {
+          "name": "interlinear_bible_tokens_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interlinear_bible_verses": {
+      "name": "interlinear_bible_verses",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_id": {
+          "name": "verse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "interlinear_bible_verses_location_unique": {
+          "name": "interlinear_bible_verses_location_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interlinear_bible_verses_chapter_lookup": {
+          "name": "interlinear_bible_verses_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interlinear_bible_verses_publication_id_resource_publications_id_fk": {
+          "name": "interlinear_bible_verses_publication_id_resource_publications_id_fk",
+          "tableFrom": "interlinear_bible_verses",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "interlinear_bible_verses_publication_id_primary": {
+          "name": "interlinear_bible_verses_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "verse_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nave_topics": {
+      "name": "nave_topics",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial": {
+          "name": "initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nave_topics_browse": {
+          "name": "nave_topics_browse",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initial",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nave_topics_search": {
+          "name": "nave_topics_search",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nave_topics_publication_id_resource_publications_id_fk": {
+          "name": "nave_topics_publication_id_resource_publications_id_fk",
+          "tableFrom": "nave_topics",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "nave_topics_publication_name_primary": {
+          "name": "nave_topics_publication_name_primary",
+          "columns": [
+            "publication_id",
+            "normalized_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nave_verse_links": {
+      "name": "nave_verse_links",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_key": {
+          "name": "verse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nave_verse_links_verse_lookup": {
+          "name": "nave_verse_links_verse_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nave_verse_links_topic_lookup": {
+          "name": "nave_verse_links_topic_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nave_verse_links_publication_id_resource_publications_id_fk": {
+          "name": "nave_verse_links_publication_id_resource_publications_id_fk",
+          "tableFrom": "nave_verse_links",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nave_verse_links_topic_fk": {
+          "name": "nave_verse_links_topic_fk",
+          "tableFrom": "nave_verse_links",
+          "tableTo": "nave_topics",
+          "columnsFrom": [
+            "publication_id",
+            "normalized_name"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "normalized_name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "nave_verse_links_publication_verse_topic_primary": {
+          "name": "nave_verse_links_publication_verse_topic_primary",
+          "columns": [
+            "publication_id",
+            "verse_key",
+            "normalized_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_publications": {
+      "name": "resource_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "resource_publications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "resource_identity": {
+          "name": "resource_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_kind": {
+          "name": "resource_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "canonical_sha256": {
+          "name": "canonical_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offline_artifact_sha256": {
+          "name": "offline_artifact_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rights": {
+          "name": "rights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "resource_publications_identity_revision_unique": {
+          "name": "resource_publications_identity_revision_unique",
+          "columns": [
+            {
+              "expression": "resource_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_publications_one_active_identity": {
+          "name": "resource_publications_one_active_identity",
+          "columns": [
+            {
+              "expression": "resource_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resource_publications\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_identities": {
+      "name": "strong_bible_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_identities_code_unique": {
+          "name": "strong_bible_identities_code_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_identities_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_identities_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_identities",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_identities_publication_id_primary": {
+          "name": "strong_bible_identities_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "identity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_lexemes": {
+      "name": "strong_bible_lexemes",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lexeme_id": {
+          "name": "lexeme_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_lexemes_label_lookup": {
+          "name": "strong_bible_lexemes_label_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lemma",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "part_of_speech",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_lexemes_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_lexemes_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_lexemes",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_lexemes_publication_id_primary": {
+          "name": "strong_bible_lexemes_publication_id_primary",
+          "columns": [
+            "publication_id",
+            "lexeme_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_span_identities": {
+      "name": "strong_bible_span_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_order": {
+          "name": "identity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_span_identities_lookup": {
+          "name": "strong_bible_span_identities_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_span_identities_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_span_identities_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_span_identities",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_span_identities_span_fk": {
+          "name": "strong_bible_span_identities_span_fk",
+          "tableFrom": "strong_bible_span_identities",
+          "tableTo": "strong_bible_spans",
+          "columnsFrom": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_span_identities_identity_fk": {
+          "name": "strong_bible_span_identities_identity_fk",
+          "tableFrom": "strong_bible_span_identities",
+          "tableTo": "strong_bible_identities",
+          "columnsFrom": [
+            "publication_id",
+            "identity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "identity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_span_identities_publication_location_primary": {
+          "name": "strong_bible_span_identities_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal",
+            "identity_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_spans": {
+      "name": "strong_bible_spans",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_aligned": {
+          "name": "is_aligned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lexeme_id": {
+          "name": "lexeme_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_token_ids": {
+          "name": "step_token_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "strong_bible_spans_chapter_lookup": {
+          "name": "strong_bible_spans_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "strong_bible_spans_lexeme_lookup": {
+          "name": "strong_bible_spans_lexeme_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lexeme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_spans_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_spans_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_spans",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_spans_verse_fk": {
+          "name": "strong_bible_spans_verse_fk",
+          "tableFrom": "strong_bible_spans",
+          "tableTo": "strong_bible_verses",
+          "columnsFrom": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_bible_spans_lexeme_fk": {
+          "name": "strong_bible_spans_lexeme_fk",
+          "tableFrom": "strong_bible_spans",
+          "tableTo": "strong_bible_lexemes",
+          "columnsFrom": [
+            "publication_id",
+            "lexeme_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "lexeme_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_spans_publication_location_primary": {
+          "name": "strong_bible_spans_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_bible_verses": {
+      "name": "strong_bible_verses",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_bible_verses_chapter_lookup": {
+          "name": "strong_bible_verses_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_bible_verses_publication_id_resource_publications_id_fk": {
+          "name": "strong_bible_verses_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_bible_verses",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_bible_verses_publication_location_primary": {
+          "name": "strong_bible_verses_publication_location_primary",
+          "columns": [
+            "publication_id",
+            "book",
+            "chapter",
+            "verse"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entities": {
+      "name": "strong_lexicon_entities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_name": {
+          "name": "unique_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "u_strong": {
+          "name": "u_strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_lexicon_entities_unique_name": {
+          "name": "strong_lexicon_entities_unique_name",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unique_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "strong_lexicon_entities_ustrong_lookup": {
+          "name": "strong_lexicon_entities_ustrong_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "u_strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_lexicon_entities_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_entities_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_entities",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entities_primary": {
+          "name": "strong_lexicon_entities_primary",
+          "columns": [
+            "publication_id",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entity_places": {
+      "name": "strong_lexicon_entity_places",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_entity_places_entity_fk": {
+          "name": "strong_lexicon_entity_places_entity_fk",
+          "tableFrom": "strong_lexicon_entity_places",
+          "tableTo": "strong_lexicon_entities",
+          "columnsFrom": [
+            "publication_id",
+            "entity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entity_places_primary": {
+          "name": "strong_lexicon_entity_places_primary",
+          "columns": [
+            "publication_id",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entity_refs": {
+      "name": "strong_lexicon_entity_refs",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book": {
+          "name": "book",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_lexicon_entity_refs_chapter_lookup": {
+          "name": "strong_lexicon_entity_refs_chapter_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_lexicon_entity_refs_entity_fk": {
+          "name": "strong_lexicon_entity_refs_entity_fk",
+          "tableFrom": "strong_lexicon_entity_refs",
+          "tableTo": "strong_lexicon_entities",
+          "columnsFrom": [
+            "publication_id",
+            "entity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entity_refs_primary": {
+          "name": "strong_lexicon_entity_refs_primary",
+          "columns": [
+            "publication_id",
+            "entity_id",
+            "book",
+            "chapter",
+            "verse",
+            "suffix"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entity_relations": {
+      "name": "strong_lexicon_entity_relations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_entity_relations_from_fk": {
+          "name": "strong_lexicon_entity_relations_from_fk",
+          "tableFrom": "strong_lexicon_entity_relations",
+          "tableTo": "strong_lexicon_entities",
+          "columnsFrom": [
+            "publication_id",
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_lexicon_entity_relations_to_fk": {
+          "name": "strong_lexicon_entity_relations_to_fk",
+          "tableFrom": "strong_lexicon_entity_relations",
+          "tableTo": "strong_lexicon_entities",
+          "columnsFrom": [
+            "publication_id",
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entity_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entity_relations_primary": {
+          "name": "strong_lexicon_entity_relations_primary",
+          "columns": [
+            "publication_id",
+            "relation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entity_translations": {
+      "name": "strong_lexicon_entity_translations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_entity_translations_entity_fk": {
+          "name": "strong_lexicon_entity_translations_entity_fk",
+          "tableFrom": "strong_lexicon_entity_translations",
+          "tableTo": "strong_lexicon_entities",
+          "columnsFrom": [
+            "publication_id",
+            "entity_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entity_translations_primary": {
+          "name": "strong_lexicon_entity_translations_primary",
+          "columns": [
+            "publication_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entries": {
+      "name": "strong_lexicon_entries",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "e_strong": {
+          "name": "e_strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "d_strong": {
+          "name": "d_strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "u_strong": {
+          "name": "u_strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_lexicon_entries_code_lookup": {
+          "name": "strong_lexicon_entries_code_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "e_strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "d_strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "u_strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_lexicon_entries_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_entries_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_entries",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entries_primary": {
+          "name": "strong_lexicon_entries_primary",
+          "columns": [
+            "publication_id",
+            "entry_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_entry_identities": {
+      "name": "strong_lexicon_entry_identities",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_entry_id": {
+          "name": "step_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_code": {
+          "name": "step_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_lexicon_entry_identities_code_unique": {
+          "name": "strong_lexicon_entry_identities_code_unique",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_lexicon_entry_identities_entry_fk": {
+          "name": "strong_lexicon_entry_identities_entry_fk",
+          "tableFrom": "strong_lexicon_entry_identities",
+          "tableTo": "strong_lexicon_entries",
+          "columnsFrom": [
+            "publication_id",
+            "step_entry_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entry_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_entry_identities_primary": {
+          "name": "strong_lexicon_entry_identities_primary",
+          "columns": [
+            "publication_id",
+            "step_entry_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_morphology_code_translations": {
+      "name": "strong_lexicon_morphology_code_translations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morphology_code_id": {
+          "name": "morphology_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_morphology_code_translations_code_fk": {
+          "name": "strong_lexicon_morphology_code_translations_code_fk",
+          "tableFrom": "strong_lexicon_morphology_code_translations",
+          "tableTo": "strong_lexicon_morphology_codes",
+          "columnsFrom": [
+            "publication_id",
+            "morphology_code_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "morphology_code_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_morphology_code_translations_primary": {
+          "name": "strong_lexicon_morphology_code_translations_primary",
+          "columns": [
+            "publication_id",
+            "morphology_code_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_morphology_codes": {
+      "name": "strong_lexicon_morphology_codes",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morphology_code_id": {
+          "name": "morphology_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_code": {
+          "name": "normalized_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_morphology_codes_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_morphology_codes_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_morphology_codes",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_morphology_codes_primary": {
+          "name": "strong_lexicon_morphology_codes_primary",
+          "columns": [
+            "publication_id",
+            "morphology_code_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_records": {
+      "name": "strong_lexicon_records",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_name": {
+          "name": "unique_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "strong_lexicon_records_entry_lookup": {
+          "name": "strong_lexicon_records_entry_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "table_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "strong_lexicon_records_code_lookup": {
+          "name": "strong_lexicon_records_code_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "table_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "strong_lexicon_records_unique_name_lookup": {
+          "name": "strong_lexicon_records_unique_name_lookup",
+          "columns": [
+            {
+              "expression": "publication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "table_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unique_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strong_lexicon_records_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_records_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_records",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_records_primary": {
+          "name": "strong_lexicon_records_primary",
+          "columns": [
+            "publication_id",
+            "table_name",
+            "record_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_relation_kinds": {
+      "name": "strong_lexicon_relation_kinds",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_kind_id": {
+          "name": "relation_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_en": {
+          "name": "label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_fr": {
+          "name": "label_fr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_relation_kinds_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_relation_kinds_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_relation_kinds",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_relation_kinds_primary": {
+          "name": "strong_lexicon_relation_kinds_primary",
+          "columns": [
+            "publication_id",
+            "relation_kind_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_relations": {
+      "name": "strong_lexicon_relations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entry_id": {
+          "name": "from_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entry_id": {
+          "name": "to_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relation_kind_id": {
+          "name": "relation_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_relations_from_entry_fk": {
+          "name": "strong_lexicon_relations_from_entry_fk",
+          "tableFrom": "strong_lexicon_relations",
+          "tableTo": "strong_lexicon_entries",
+          "columnsFrom": [
+            "publication_id",
+            "from_entry_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entry_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strong_lexicon_relations_to_entry_fk": {
+          "name": "strong_lexicon_relations_to_entry_fk",
+          "tableFrom": "strong_lexicon_relations",
+          "tableTo": "strong_lexicon_entries",
+          "columnsFrom": [
+            "publication_id",
+            "to_entry_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entry_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "strong_lexicon_relations_kind_fk": {
+          "name": "strong_lexicon_relations_kind_fk",
+          "tableFrom": "strong_lexicon_relations",
+          "tableTo": "strong_lexicon_relation_kinds",
+          "columnsFrom": [
+            "publication_id",
+            "relation_kind_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "relation_kind_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_relations_primary": {
+          "name": "strong_lexicon_relations_primary",
+          "columns": [
+            "publication_id",
+            "relation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_resource_translations": {
+      "name": "strong_lexicon_resource_translations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_resource_translations_resource_fk": {
+          "name": "strong_lexicon_resource_translations_resource_fk",
+          "tableFrom": "strong_lexicon_resource_translations",
+          "tableTo": "strong_lexicon_resources",
+          "columnsFrom": [
+            "publication_id",
+            "resource_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "resource_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_resource_translations_primary": {
+          "name": "strong_lexicon_resource_translations_primary",
+          "columns": [
+            "publication_id",
+            "resource_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_resources": {
+      "name": "strong_lexicon_resources",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_entry_id": {
+          "name": "step_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_resources_publication_id_resource_publications_id_fk": {
+          "name": "strong_lexicon_resources_publication_id_resource_publications_id_fk",
+          "tableFrom": "strong_lexicon_resources",
+          "tableTo": "resource_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_resources_primary": {
+          "name": "strong_lexicon_resources_primary",
+          "columns": [
+            "publication_id",
+            "resource_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strong_lexicon_translations": {
+      "name": "strong_lexicon_translations",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_entry_id": {
+          "name": "step_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strong_lexicon_translations_entry_fk": {
+          "name": "strong_lexicon_translations_entry_fk",
+          "tableFrom": "strong_lexicon_translations",
+          "tableTo": "strong_lexicon_entries",
+          "columnsFrom": [
+            "publication_id",
+            "step_entry_id"
+          ],
+          "columnsTo": [
+            "publication_id",
+            "entry_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "strong_lexicon_translations_primary": {
+          "name": "strong_lexicon_translations_primary",
+          "columns": [
+            "publication_id",
+            "step_entry_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.resource_publication_status": {
+      "name": "resource_publication_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "active"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/resource-service/drizzle/meta/_journal.json
+++ b/resource-service/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786945688701,
       "tag": "0010_sudden_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1786948963837,
+      "tag": "0011_premium_jean_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -179,11 +179,7 @@ export const dictionaryVerseLinks = pgTable(
       name: 'dictionary_verse_links_publication_verse_ordinal_primary',
       columns: [table.publication_id, table.verse_key, table.ordinal],
     }),
-    index('dictionary_verse_links_lookup').on(
-      table.publication_id,
-      table.verse_key,
-      table.ordinal
-    ),
+    index('dictionary_verse_links_lookup').on(table.publication_id, table.verse_key, table.ordinal),
   ]
 )
 

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -137,6 +137,56 @@ export const naveVerseLinks = pgTable(
   ]
 )
 
+export const dictionaryEntries = pgTable(
+  'dictionary_entries',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    entry_id: integer('entry_id').notNull(),
+    word: text('word').notNull(),
+    normalized_word: text('normalized_word').notNull(),
+    definition: text('definition').notNull(),
+    payload: jsonb('payload').$type<Record<string, string | number | null>>().notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'dictionary_entries_publication_entry_primary',
+      columns: [table.publication_id, table.entry_id],
+    }),
+    index('dictionary_entries_browse').on(
+      table.publication_id,
+      table.normalized_word,
+      table.entry_id
+    ),
+    index('dictionary_entries_search').on(table.publication_id, table.word),
+  ]
+)
+
+export const dictionaryVerseLinks = pgTable(
+  'dictionary_verse_links',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    verse_key: text('verse_key').notNull(),
+    ordinal: integer('ordinal').notNull(),
+    word: text('word').notNull(),
+    normalized_word: text('normalized_word').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'dictionary_verse_links_publication_verse_ordinal_primary',
+      columns: [table.publication_id, table.verse_key, table.ordinal],
+    }),
+    index('dictionary_verse_links_lookup').on(
+      table.publication_id,
+      table.verse_key,
+      table.ordinal
+    ),
+  ]
+)
+
 export const strongBibleVerses = pgTable(
   'strong_bible_verses',
   {

--- a/resource-service/src/database/types.ts
+++ b/resource-service/src/database/types.ts
@@ -8,6 +8,8 @@ import type {
   interlinearBibleVerses,
   naveTopics,
   naveVerseLinks,
+  dictionaryEntries,
+  dictionaryVerseLinks,
   resourcePublications,
   strongBibleIdentities,
   strongBibleLexemes,
@@ -35,6 +37,8 @@ export type ResourcePublicationRow = Kyselify<typeof resourcePublications>
 export type BibleVerseRow = Kyselify<typeof bibleVerses>
 export type NaveTopicRow = Kyselify<typeof naveTopics>
 export type NaveVerseLinkRow = Kyselify<typeof naveVerseLinks>
+export type DictionaryEntryRow = Kyselify<typeof dictionaryEntries>
+export type DictionaryVerseLinkRow = Kyselify<typeof dictionaryVerseLinks>
 export type StrongBibleVerseRow = Kyselify<typeof strongBibleVerses>
 export type StrongBibleLexemeRow = Kyselify<typeof strongBibleLexemes>
 export type StrongBibleIdentityRow = Kyselify<typeof strongBibleIdentities>
@@ -67,6 +71,8 @@ export type ResourceDatabase = {
   bible_verses: BibleVerseRow
   nave_topics: NaveTopicRow
   nave_verse_links: NaveVerseLinkRow
+  dictionary_entries: DictionaryEntryRow
+  dictionary_verse_links: DictionaryVerseLinkRow
   strong_bible_verses: StrongBibleVerseRow
   strong_bible_lexemes: StrongBibleLexemeRow
   strong_bible_identities: StrongBibleIdentityRow

--- a/resource-service/src/domain/dictionary.ts
+++ b/resource-service/src/domain/dictionary.ts
@@ -1,0 +1,135 @@
+import { Context, Data, Effect } from 'effect'
+
+import {
+  DictionaryEntriesResponseDto,
+  DictionaryEntryDto,
+  DictionaryEntryResponseDto,
+  DictionaryRevisionDto,
+  DictionarySummaryDto,
+  DictionaryVerseWordsResponseDto,
+} from '../../../src/features/resources/dictionaryContract'
+
+export type DictionaryLanguage = 'fr' | 'en'
+
+export type DictionarySummary = {
+  id: number
+  word: string
+  normalizedWord: string
+}
+
+export type DictionaryEntry = {
+  id: number
+  word: string
+  definition: string
+}
+
+export type DictionaryListInput = {
+  language: DictionaryLanguage
+  initial?: string
+  search?: string
+  limit?: number
+  offset?: number
+}
+
+export type DictionaryEntryLookup = { language: DictionaryLanguage; word: string }
+export type DictionaryEntryIdLookup = { language: DictionaryLanguage; id: number }
+export type DictionaryVerseLookup = { language: DictionaryLanguage; verseKey: string }
+
+type ActiveDictionaryBase = { language: DictionaryLanguage; revision: string }
+export type ActiveDictionaryList = ActiveDictionaryBase & {
+  entries: readonly DictionarySummary[]
+  offset: number
+  limit: number
+  nextOffset?: number
+}
+export type ActiveDictionaryEntry = ActiveDictionaryBase & { entry: DictionaryEntry }
+export type ActiveDictionaryVerseWords = ActiveDictionaryBase & {
+  verseKey: string
+  words: readonly string[]
+}
+
+export class UnsupportedDictionaryLanguage extends Data.TaggedError(
+  'UnsupportedDictionaryLanguage'
+)<{ readonly language: DictionaryLanguage }> {}
+
+export class ActiveDictionaryPublicationUnavailable extends Data.TaggedError(
+  'ActiveDictionaryPublicationUnavailable'
+)<{ readonly language: DictionaryLanguage }> {}
+
+export class DictionaryEntryNotFound extends Data.TaggedError('DictionaryEntryNotFound')<{
+  readonly language: DictionaryLanguage
+  readonly word?: string
+  readonly id?: number
+}> {}
+
+export class DictionaryRepositoryFailure extends Data.TaggedError('DictionaryRepositoryFailure')<{
+  readonly cause: unknown
+}> {}
+
+export type DictionaryRepositoryError =
+  | ActiveDictionaryPublicationUnavailable
+  | DictionaryEntryNotFound
+  | DictionaryRepositoryFailure
+
+export type DictionaryRepositoryService = {
+  listEntries: (input: DictionaryListInput) => Effect.Effect<ActiveDictionaryList, DictionaryRepositoryError>
+  findEntry: (input: DictionaryEntryLookup) => Effect.Effect<ActiveDictionaryEntry, DictionaryRepositoryError>
+  findEntryById: (
+    input: DictionaryEntryIdLookup
+  ) => Effect.Effect<ActiveDictionaryEntry, DictionaryRepositoryError>
+  findVerseWords: (
+    input: DictionaryVerseLookup
+  ) => Effect.Effect<ActiveDictionaryVerseWords, DictionaryRepositoryError>
+}
+
+export class DictionaryRepository extends Context.Tag('DictionaryRepository')<
+  DictionaryRepository,
+  DictionaryRepositoryService
+>() {}
+
+const revisionDto = (language: DictionaryLanguage, revision: string) =>
+  new DictionaryRevisionDto({ kind: 'dictionary', language, revision })
+
+export const browseDictionaryEntries = (input: DictionaryListInput) =>
+  Effect.gen(function* () {
+    const repository = yield* DictionaryRepository
+    const active = yield* repository.listEntries(input)
+    return new DictionaryEntriesResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      entries: active.entries.map(entry => new DictionarySummaryDto(entry)),
+      offset: active.offset,
+      limit: active.limit,
+      ...(active.nextOffset === undefined ? {} : { nextOffset: active.nextOffset }),
+    })
+  })
+
+export const readDictionaryEntry = (input: DictionaryEntryLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* DictionaryRepository
+    const active = yield* repository.findEntry(input)
+    return new DictionaryEntryResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      entry: new DictionaryEntryDto(active.entry),
+    })
+  })
+
+export const readDictionaryEntryById = (input: DictionaryEntryIdLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* DictionaryRepository
+    const active = yield* repository.findEntryById(input)
+    return new DictionaryEntryResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      entry: new DictionaryEntryDto(active.entry),
+    })
+  })
+
+export const readDictionaryVerseWords = (input: DictionaryVerseLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* DictionaryRepository
+    const active = yield* repository.findVerseWords(input)
+    return new DictionaryVerseWordsResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      verseKey: active.verseKey,
+      words: [...active.words],
+    })
+  })

--- a/resource-service/src/domain/dictionary.ts
+++ b/resource-service/src/domain/dictionary.ts
@@ -72,8 +72,12 @@ export type DictionaryRepositoryError =
   | DictionaryRepositoryFailure
 
 export type DictionaryRepositoryService = {
-  listEntries: (input: DictionaryListInput) => Effect.Effect<ActiveDictionaryList, DictionaryRepositoryError>
-  findEntry: (input: DictionaryEntryLookup) => Effect.Effect<ActiveDictionaryEntry, DictionaryRepositoryError>
+  listEntries: (
+    input: DictionaryListInput
+  ) => Effect.Effect<ActiveDictionaryList, DictionaryRepositoryError>
+  findEntry: (
+    input: DictionaryEntryLookup
+  ) => Effect.Effect<ActiveDictionaryEntry, DictionaryRepositoryError>
   findEntryById: (
     input: DictionaryEntryIdLookup
   ) => Effect.Effect<ActiveDictionaryEntry, DictionaryRepositoryError>

--- a/resource-service/src/http/api.ts
+++ b/resource-service/src/http/api.ts
@@ -18,6 +18,16 @@ import {
   NaveVerseTopicsResponseDto,
 } from '../../../src/features/resources/naveContract'
 import {
+  DictionaryEntriesQuery,
+  DictionaryEntriesResponseDto,
+  DictionaryEntryIdPath,
+  DictionaryEntryPath,
+  DictionaryEntryResponseDto,
+  DictionaryLanguagePath,
+  DictionaryVersePath,
+  DictionaryVerseWordsResponseDto,
+} from '../../../src/features/resources/dictionaryContract'
+import {
   StrongBibleChapterDto,
   StrongBibleChapterPath,
   StrongBibleCountsDto,
@@ -129,6 +139,48 @@ const NaveApi = HttpApiGroup.make('naves')
     HttpApiEndpoint.get('getRandomNaveTopic', '/v1/naves/:language/random')
       .setPath(NaveLanguagePath)
       .addSuccess(NaveTopicResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+
+const DictionaryApi = HttpApiGroup.make('dictionaries')
+  .add(
+    HttpApiEndpoint.get('listDictionaryEntries', '/v1/dictionaries/:language/entries')
+      .setPath(DictionaryLanguagePath)
+      .setUrlParams(DictionaryEntriesQuery)
+      .addSuccess(DictionaryEntriesResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get('getDictionaryEntry', '/v1/dictionaries/:language/entries/:word')
+      .setPath(DictionaryEntryPath)
+      .addSuccess(DictionaryEntryResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get('getDictionaryEntryById', '/v1/dictionaries/:language/entries/by-id/:id')
+      .setPath(DictionaryEntryIdPath)
+      .addSuccess(DictionaryEntryResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getDictionaryVerseWords',
+      '/v1/dictionaries/:language/verses/:verseKey/words'
+    )
+      .setPath(DictionaryVersePath)
+      .addSuccess(DictionaryVerseWordsResponseDto)
       .addError(InvalidResourceRequestProblem, { status: 400 })
       .addError(ResourceNotFoundProblem, { status: 404 })
       .addError(ResourceUnavailableProblem, { status: 503 })
@@ -289,6 +341,7 @@ export class ResourceApi extends HttpApi.make('resource-api')
   .add(SystemApi)
   .add(BibleApi)
   .add(NaveApi)
+  .add(DictionaryApi)
   .add(StrongBibleApi)
   .add(InterlinearBibleApi)
   .add(StrongLexiconApi) {}

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -25,6 +25,17 @@ import {
   type NaveRepositoryService,
 } from '../domain/nave'
 import {
+  ActiveDictionaryPublicationUnavailable,
+  browseDictionaryEntries,
+  DictionaryEntryNotFound,
+  DictionaryRepository,
+  DictionaryRepositoryFailure,
+  readDictionaryEntry,
+  readDictionaryEntryById,
+  readDictionaryVerseWords,
+  type DictionaryRepositoryService,
+} from '../domain/dictionary'
+import {
   ActiveStrongBiblePublicationUnavailable,
   readStrongBibleChapter,
   readStrongBibleCounts,
@@ -94,6 +105,9 @@ const toHttpProblem = (
     | ActiveNavePublicationUnavailable
     | NaveTopicNotFound
     | NaveRepositoryFailure
+    | ActiveDictionaryPublicationUnavailable
+    | DictionaryEntryNotFound
+    | DictionaryRepositoryFailure
     | UnsupportedStrongBibleVersion
     | ActiveStrongBiblePublicationUnavailable
     | StrongBibleChapterNotFound
@@ -130,6 +144,7 @@ const toHttpProblem = (
       })
     case 'BibleChapterRepositoryFailure':
     case 'NaveRepositoryFailure':
+    case 'DictionaryRepositoryFailure':
     case 'StrongBibleRepositoryFailure':
     case 'InterlinearBibleRepositoryFailure':
     case 'StrongLexiconRepositoryFailure':
@@ -155,6 +170,19 @@ const toHttpProblem = (
         ...problemFields(requestId, 'The Nave publication is temporarily unavailable.'),
         status: 503,
         code: 'NAVE_PUBLICATION_INACTIVE',
+        retryAfterSeconds: 30,
+      })
+    case 'DictionaryEntryNotFound':
+      return new ResourceNotFoundProblem({
+        ...problemFields(requestId, 'This dictionary entry does not exist.'),
+        status: 404,
+        code: 'DICTIONARY_ENTRY_NOT_FOUND',
+      })
+    case 'ActiveDictionaryPublicationUnavailable':
+      return new ResourceUnavailableProblem({
+        ...problemFields(requestId, 'The dictionary publication is temporarily unavailable.'),
+        status: 503,
+        code: 'DICTIONARY_PUBLICATION_INACTIVE',
         retryAfterSeconds: 30,
       })
     case 'UnsupportedStrongBibleVersion':
@@ -213,6 +241,12 @@ const toHttpProblem = (
         status: 503,
         code: 'STRONG_LEXICON_PUBLICATION_INACTIVE',
         retryAfterSeconds: 30,
+      })
+    default:
+      return new ResourceInternalProblem({
+        ...problemFields(requestId, 'The Resource service could not complete the request.'),
+        status: 500,
+        code: 'RESOURCE_INTERNAL_FAILURE',
       })
   }
 }
@@ -351,6 +385,58 @@ const NaveApiLive = HttpApiBuilder.group(ResourceApi, 'naves', handlers =>
         ),
         requestId,
         request.headers['if-none-match']
+      )
+    })
+)
+
+const DictionaryApiLive = HttpApiBuilder.group(ResourceApi, 'dictionaries', handlers =>
+  handlers
+    .handle('listDictionaryEntries', ({ path, urlParams, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        browseDictionaryEntries({
+          language: path.language,
+          initial: urlParams.initial,
+          search: urlParams.search,
+          limit: urlParams.limit,
+          offset: urlParams.offset,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        urlParams.search
+          ? undefined
+          : ['dictionary', path.language, 'browse', urlParams.initial ?? '*', urlParams.offset ?? 0]
+      )
+    })
+    .handle('getDictionaryEntry', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readDictionaryEntry(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['dictionary', path.language, 'entry', path.word]
+      )
+    })
+    .handle('getDictionaryEntryById', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readDictionaryEntryById(path).pipe(
+          Effect.mapError(cause => toHttpProblem(cause, requestId))
+        ),
+        requestId,
+        request.headers['if-none-match'],
+        ['dictionary', path.language, 'entry-id', path.id]
+      )
+    })
+    .handle('getDictionaryVerseWords', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readDictionaryVerseWords(path).pipe(
+          Effect.mapError(cause => toHttpProblem(cause, requestId))
+        ),
+        requestId,
+        request.headers['if-none-match'],
+        ['dictionary', path.language, 'verse', path.verseKey]
       )
     })
 )
@@ -545,6 +631,7 @@ export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(SystemApiLive),
   Layer.provide(BibleApiLive),
   Layer.provide(NaveApiLive),
+  Layer.provide(DictionaryApiLive),
   Layer.provide(StrongBibleApiLive),
   Layer.provide(InterlinearBibleApiLive),
   Layer.provide(StrongLexiconApiLive)
@@ -567,6 +654,17 @@ const unavailableNaveRepository: NaveRepositoryService = {
   findVerseTopics: input =>
     Effect.fail(new ActiveNavePublicationUnavailable({ language: input.language })),
   findRandomTopic: language => Effect.fail(new ActiveNavePublicationUnavailable({ language })),
+}
+
+const unavailableDictionaryRepository: DictionaryRepositoryService = {
+  listEntries: input =>
+    Effect.fail(new ActiveDictionaryPublicationUnavailable({ language: input.language })),
+  findEntry: input =>
+    Effect.fail(new ActiveDictionaryPublicationUnavailable({ language: input.language })),
+  findEntryById: input =>
+    Effect.fail(new ActiveDictionaryPublicationUnavailable({ language: input.language })),
+  findVerseWords: input =>
+    Effect.fail(new ActiveDictionaryPublicationUnavailable({ language: input.language })),
 }
 
 const unavailableStrongBibleRepository: StrongBibleRepositoryService = {
@@ -611,6 +709,7 @@ const unavailableStrongLexiconRepository: StrongLexiconRepositoryService = {
 export const provideResourceRepositories = (
   repository: BibleChapterRepositoryService,
   naveRepository: NaveRepositoryService,
+  dictionaryRepository: DictionaryRepositoryService = unavailableDictionaryRepository,
   strongBibleRepository: StrongBibleRepositoryService = unavailableStrongBibleRepository,
   interlinearBibleRepository: InterlinearBibleRepositoryService = unavailableInterlinearBibleRepository,
   strongLexiconRepository: StrongLexiconRepositoryService = unavailableStrongLexiconRepository
@@ -620,6 +719,7 @@ export const provideResourceRepositories = (
       Layer.mergeAll(
         Layer.succeed(BibleChapterRepository, repository),
         Layer.succeed(NaveRepository, naveRepository),
+        Layer.succeed(DictionaryRepository, dictionaryRepository),
         Layer.succeed(StrongBibleRepository, strongBibleRepository),
         Layer.succeed(InterlinearBibleRepository, interlinearBibleRepository),
         Layer.succeed(StrongLexiconRepository, strongLexiconRepository)
@@ -637,6 +737,7 @@ export const makeResourceWebHandler = (
       provideResourceRepositories(
         repository,
         naveRepository,
+        overrides.dictionary ?? unavailableDictionaryRepository,
         overrides.strongBible ?? unavailableStrongBibleRepository,
         overrides.interlinearBible ?? unavailableInterlinearBibleRepository,
         overrides.strongLexicon ?? unavailableStrongLexiconRepository
@@ -674,6 +775,7 @@ export const makeResourceWebHandler = (
 }
 
 export type ResourceRepositoryOverrides = {
+  dictionary?: DictionaryRepositoryService
   strongBible?: StrongBibleRepositoryService
   interlinearBible?: InterlinearBibleRepositoryService
   strongLexicon?: StrongLexiconRepositoryService

--- a/resource-service/src/http/problems.ts
+++ b/resource-service/src/http/problems.ts
@@ -26,6 +26,8 @@ export class ResourceNotFoundProblem extends Schema.TaggedError<ResourceNotFound
       'BIBLE_CHAPTER_NOT_FOUND',
       'NAVE_UNSUPPORTED',
       'NAVE_TOPIC_NOT_FOUND',
+      'DICTIONARY_UNSUPPORTED',
+      'DICTIONARY_ENTRY_NOT_FOUND',
       'STRONG_BIBLE_UNSUPPORTED',
       'STRONG_BIBLE_CHAPTER_NOT_FOUND',
       'INTERLINEAR_UNSUPPORTED',
@@ -44,6 +46,7 @@ export class ResourceUnavailableProblem extends Schema.TaggedError<ResourceUnava
     code: Schema.Literal(
       'BIBLE_PUBLICATION_INACTIVE',
       'NAVE_PUBLICATION_INACTIVE',
+      'DICTIONARY_PUBLICATION_INACTIVE',
       'STRONG_BIBLE_PUBLICATION_INACTIVE',
       'INTERLINEAR_PUBLICATION_INACTIVE',
       'STRONG_LEXICON_PUBLICATION_INACTIVE'

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -141,6 +141,35 @@ const NavePublicationBundleManifestSchema = Schema.Struct({
   }),
 })
 
+const DictionaryPublicationBundleManifestSchema = Schema.Struct({
+  ...PublicationBundleCommonFields,
+  canonical: Schema.Struct({
+    ...PublicationBundleCommonFields.canonical.fields,
+    schemaVersion: Schema.Literal(1),
+  }),
+  offlineArtifact: Schema.Struct({
+    ...PublicationBundleCommonFields.offlineArtifact.fields,
+    entry: Schema.Literal('dictionnaire.sqlite'),
+  }),
+  identity: Schema.Struct({
+    kind: Schema.Literal('dictionary'),
+    resourceId: Schema.Literal('DICTIONNAIRE'),
+    language: Schema.Literal('fr', 'en'),
+  }),
+  alphabeticalBrowse: Schema.Struct({
+    initials: Schema.Array(Schema.NonEmptyString),
+    entryCountByInitial: Schema.Record({
+      key: Schema.String,
+      value: Schema.NonNegativeInt,
+    }),
+  }),
+  counts: Schema.Struct({
+    entries: Schema.NonNegativeInt,
+    verseAnchors: Schema.NonNegativeInt,
+    wordReferences: Schema.NonNegativeInt,
+  }),
+})
+
 const StrongBiblePublicationBundleManifestSchema = Schema.Struct({
   ...PublicationBundleCommonFields,
   identity: Schema.Struct({
@@ -241,6 +270,7 @@ const StrongLexiconPublicationBundleManifestSchema = Schema.Struct({
 const PublicationBundleManifestSchema = Schema.Union(
   BiblePublicationBundleManifestSchema,
   NavePublicationBundleManifestSchema,
+  DictionaryPublicationBundleManifestSchema,
   StrongBiblePublicationBundleManifestSchema,
   InterlinearBiblePublicationBundleManifestSchema,
   StrongLexiconPublicationBundleManifestSchema
@@ -248,6 +278,8 @@ const PublicationBundleManifestSchema = Schema.Union(
 
 export type BiblePublicationBundleManifest = typeof BiblePublicationBundleManifestSchema.Type
 export type NavePublicationBundleManifest = typeof NavePublicationBundleManifestSchema.Type
+export type DictionaryPublicationBundleManifest =
+  typeof DictionaryPublicationBundleManifestSchema.Type
 export type StrongBiblePublicationBundleManifest =
   typeof StrongBiblePublicationBundleManifestSchema.Type
 export type InterlinearBiblePublicationBundleManifest =
@@ -257,6 +289,7 @@ export type StrongLexiconPublicationBundleManifest =
 export type PublicationBundleManifest =
   | BiblePublicationBundleManifest
   | NavePublicationBundleManifest
+  | DictionaryPublicationBundleManifest
   | StrongBiblePublicationBundleManifest
   | InterlinearBiblePublicationBundleManifest
   | StrongLexiconPublicationBundleManifest
@@ -268,6 +301,10 @@ export const isBiblePublicationBundleManifest = (
 export const isNavePublicationBundleManifest = (
   manifest: PublicationBundleManifest
 ): manifest is NavePublicationBundleManifest => manifest.identity.kind === 'nave'
+
+export const isDictionaryPublicationBundleManifest = (
+  manifest: PublicationBundleManifest
+): manifest is DictionaryPublicationBundleManifest => manifest.identity.kind === 'dictionary'
 
 export const isStrongBiblePublicationBundleManifest = (
   manifest: PublicationBundleManifest
@@ -323,6 +360,30 @@ export type CanonicalNavePublication = {
   sourceSha256: string
   topics: CanonicalNaveTopic[]
   verseAnchors: CanonicalNaveVerseAnchor[]
+}
+
+export type CanonicalDictionaryEntry = {
+  id: number
+  word: string
+  normalizedWord: string
+  definition: string
+}
+
+export type CanonicalDictionaryVerseAnchor = {
+  verseKey: string
+  words: string[]
+}
+
+export type CanonicalDictionaryPublication = {
+  format: 'bible-strong-canonical-dictionary'
+  schemaVersion: 1
+  resourceId: 'DICTIONNAIRE'
+  language: 'fr' | 'en'
+  revision: string
+  sourceVersion: string
+  sourceSha256: string
+  entries: CanonicalDictionaryEntry[]
+  verseAnchors: CanonicalDictionaryVerseAnchor[]
 }
 
 export type CanonicalStrongBibleVerse = { book: number; chapter: number; verse: number }
@@ -408,6 +469,7 @@ export type CanonicalInterlinearBiblePublication = {
 export type CanonicalPublication =
   | CanonicalBiblePublication
   | CanonicalNavePublication
+  | CanonicalDictionaryPublication
   | CanonicalStrongBiblePublication
   | CanonicalInterlinearBiblePublication
   | CanonicalStrongLexiconModulePublication
@@ -439,6 +501,8 @@ export const derivePublicationRevision = (manifest: PublicationBundleManifest): 
   const resourceId =
     manifest.identity.kind === 'nave'
       ? manifest.identity.resourceId.toLowerCase()
+      : manifest.identity.kind === 'dictionary'
+        ? `dictionary-${manifest.identity.language}`
       : manifest.identity.kind === 'strong-lexicon-module'
         ? manifest.identity.resourceId
         : manifest.identity.versionId.toLowerCase()
@@ -502,6 +566,15 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
     isNavePublicationBundleManifest(manifest) &&
     (manifest.alphabeticalBrowse.initials.length === 0 ||
       Object.values(manifest.alphabeticalBrowse.topicCountByInitial).some(count => count === 0))
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_INVALID')
+  }
+  if (
+    isDictionaryPublicationBundleManifest(manifest) &&
+    (manifest.alphabeticalBrowse.initials.length === 0 ||
+      Object.values(manifest.alphabeticalBrowse.entryCountByInitial).some(count => count === 0) ||
+      manifest.counts.entries === 0 ||
+      manifest.counts.verseAnchors === 0)
   ) {
     throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_INVALID')
   }
@@ -662,6 +735,57 @@ export const decodeCanonicalNave = (value: unknown): CanonicalNavePublication =>
   }
 
   return candidate as CanonicalNavePublication
+}
+
+export const decodeCanonicalDictionary = (value: unknown): CanonicalDictionaryPublication => {
+  if (!value || typeof value !== 'object') throw new Error('CANONICAL_DICTIONARY_INVALID')
+  const candidate = value as Partial<CanonicalDictionaryPublication>
+  if (
+    candidate.format !== 'bible-strong-canonical-dictionary' ||
+    candidate.schemaVersion !== 1 ||
+    candidate.resourceId !== 'DICTIONNAIRE' ||
+    (candidate.language !== 'fr' && candidate.language !== 'en') ||
+    !isNonEmptyString(candidate.revision) ||
+    !isNonEmptyString(candidate.sourceVersion) ||
+    !/^[a-f0-9]{64}$/u.test(candidate.sourceSha256 ?? '') ||
+    !Array.isArray(candidate.entries) ||
+    !Array.isArray(candidate.verseAnchors) ||
+    candidate.entries.length === 0 ||
+    candidate.verseAnchors.length === 0
+  ) {
+    throw new Error('CANONICAL_DICTIONARY_INVALID')
+  }
+
+  const entryIds = new Set<number>()
+  for (const entry of candidate.entries) {
+    if (
+      !entry ||
+      !isPositiveInteger(entry.id) ||
+      !isNonEmptyString(entry.word) ||
+      !isNonEmptyString(entry.normalizedWord) ||
+      entry.normalizedWord !== entry.normalizedWord.trim().toLocaleLowerCase() ||
+      typeof entry.definition !== 'string' ||
+      entryIds.has(entry.id)
+    ) {
+      throw new Error('CANONICAL_DICTIONARY_ENTRY_INVALID')
+    }
+    entryIds.add(entry.id)
+  }
+
+  const verseKeys = new Set<string>()
+  for (const anchor of candidate.verseAnchors) {
+    if (
+      !anchor ||
+      !isDictionaryVerseKey(anchor.verseKey) ||
+      !Array.isArray(anchor.words) ||
+      anchor.words.some(word => !isNonEmptyString(word)) ||
+      verseKeys.has(anchor.verseKey)
+    ) {
+      throw new Error('CANONICAL_DICTIONARY_VERSE_INVALID')
+    }
+    verseKeys.add(anchor.verseKey)
+  }
+  return candidate as CanonicalDictionaryPublication
 }
 
 const isPositiveInteger = (value: unknown): value is number =>
@@ -969,6 +1093,55 @@ export const countCanonicalNaveContent = (publication: CanonicalNavePublication)
   ),
 })
 
+const isDictionaryVerseKey = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value.length <= 128 &&
+  value === value.trim() &&
+  value.split('-').length === 3 &&
+  value.split('-').every(segment => segment.length > 0) &&
+  !/[\\/\u0000-\u001f]/u.test(value)
+
+export const deriveDictionaryResourceRevision = (
+  publication: Pick<CanonicalDictionaryPublication, 'language' | 'entries' | 'verseAnchors'>
+): string => {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify({
+        language: publication.language,
+        entries: publication.entries,
+        verseAnchors: publication.verseAnchors,
+      })
+    )
+    .digest('hex')
+  return `dictionary-${publication.language}-${digest.slice(0, 20)}`
+}
+
+export const countCanonicalDictionaryContent = (publication: CanonicalDictionaryPublication) => ({
+  entries: publication.entries.length,
+  verseAnchors: publication.verseAnchors.length,
+  wordReferences: publication.verseAnchors.reduce((count, anchor) => count + anchor.words.length, 0),
+})
+
+export const getCanonicalDictionaryAlphabeticalBrowse = (
+  publication: CanonicalDictionaryPublication
+) => {
+  const entryCountByInitial: Record<string, number> = {}
+  for (const entry of publication.entries) {
+    const initial = [...entry.normalizedWord][0] ?? '#'
+    entryCountByInitial[initial] = (entryCountByInitial[initial] ?? 0) + 1
+  }
+  const initials = Object.keys(entryCountByInitial).sort((left, right) =>
+    left.localeCompare(right)
+  )
+  return {
+    initials,
+    entryCountByInitial: Object.fromEntries(
+      initials.map(initial => [initial, entryCountByInitial[initial] ?? 0])
+    ),
+  }
+}
+
 export const countCanonicalStrongBibleContent = (publication: CanonicalStrongBiblePublication) => ({
   verses: publication.verses.length,
   occurrences: publication.spans.length,
@@ -1112,6 +1285,79 @@ const validateNaveOfflineParity = async (
     if (
       JSON.stringify(topics) !== JSON.stringify(expectedTopics) ||
       JSON.stringify(verseAnchors) !== JSON.stringify(expectedVerseAnchors)
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.startsWith('OFFLINE_ARTIFACT_')) throw cause
+    throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+  } finally {
+    database?.close()
+  }
+}
+
+const validateDictionaryOfflineParity = async (
+  offlineContent: Uint8Array,
+  canonical: CanonicalDictionaryPublication
+) => {
+  const SQL = await initSqlJs()
+  let database: Database | undefined
+  try {
+    database = new SQL.Database(offlineContent)
+    const integrity = readSqliteRows(database, 'PRAGMA integrity_check')
+    if (integrity.length !== 1 || Object.values(integrity[0] ?? {}).some(value => value !== 'ok')) {
+      throw new Error('OFFLINE_ARTIFACT_INTEGRITY_INVALID')
+    }
+    const tables = readSqliteRows(
+      database,
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).map(row => requireSqliteString(row.name))
+    if (JSON.stringify(tables) !== JSON.stringify(['RESOURCE_METADATA', 'dictionnaire', 'verses'])) {
+      throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+    }
+    const metadataRows = readSqliteRows(
+      database,
+      'SELECT resource_id, language, revision, source_version, source_sha256 FROM RESOURCE_METADATA'
+    )
+    const metadata = metadataRows[0]
+    if (
+      metadataRows.length !== 1 ||
+      requireSqliteString(metadata?.resource_id) !== `dictionary:${canonical.language}` ||
+      requireSqliteString(metadata?.language) !== canonical.language ||
+      requireSqliteString(metadata?.revision) !== canonical.revision ||
+      requireSqliteString(metadata?.source_version) !== canonical.sourceVersion ||
+      requireSqliteString(metadata?.source_sha256) !== canonical.sourceSha256
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+    const entries = readSqliteRows(
+      database,
+      'SELECT id, sanitized_word, word, definition FROM dictionnaire ORDER BY id'
+    ).map(row => {
+      const id = requireSqliteInteger(row.id)
+      const normalizedWord = requireSqliteString(row.sanitized_word).trim().toLocaleLowerCase()
+      const word = requireSqliteString(row.word)
+      const definition = requireSqliteString(row.definition)
+      if (id <= 0 || !normalizedWord || !word) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+      return { id, word, normalizedWord, definition }
+    })
+    const verseAnchors = readSqliteRows(database, 'SELECT id, ref FROM verses ORDER BY id').map(row => {
+      const verseKey = requireSqliteString(row.id)
+      if (!isDictionaryVerseKey(verseKey)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+      let words: unknown
+      try {
+        words = JSON.parse(requireSqliteString(row.ref))
+      } catch (cause) {
+        throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+      }
+      if (!Array.isArray(words) || words.some(word => typeof word !== 'string' || !word.trim())) {
+        throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+      }
+      return { verseKey, words: [...new Set(words.map(word => word.trim().toLocaleLowerCase()))] }
+    })
+    if (
+      JSON.stringify(entries) !== JSON.stringify(canonical.entries) ||
+      JSON.stringify(verseAnchors) !== JSON.stringify(canonical.verseAnchors)
     ) {
       throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
     }
@@ -2165,6 +2411,7 @@ export const validatePublicationBundle = async (bundlePath: string) => {
   }
   if (
     (isNavePublicationBundleManifest(manifest) ||
+      isDictionaryPublicationBundleManifest(manifest) ||
       isStrongBiblePublicationBundleManifest(manifest) ||
       isInterlinearBiblePublicationBundleManifest(manifest) ||
       isStrongLexiconPublicationBundleManifest(manifest)) &&
@@ -2271,6 +2518,31 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_MISMATCH')
     }
     await validateNaveOfflineParity(offlineContent, canonical)
+  } else if (isDictionaryPublicationBundleManifest(manifest)) {
+    canonical = decodeCanonicalDictionary(canonicalValue)
+    if (
+      canonical.resourceId !== manifest.identity.resourceId ||
+      canonical.language !== manifest.identity.language ||
+      canonical.revision !== manifest.revision ||
+      deriveDictionaryResourceRevision(canonical) !== manifest.revision ||
+      canonical.sourceVersion !== manifest.provenance.sourceVersion ||
+      canonical.sourceSha256 !== manifest.provenance.sourceSha256
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
+    }
+    if (
+      JSON.stringify(countCanonicalDictionaryContent(canonical)) !==
+      JSON.stringify(manifest.counts)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_COUNT_MISMATCH')
+    }
+    if (
+      JSON.stringify(getCanonicalDictionaryAlphabeticalBrowse(canonical)) !==
+      JSON.stringify(manifest.alphabeticalBrowse)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_MISMATCH')
+    }
+    await validateDictionaryOfflineParity(offlineContent, canonical)
   } else if (isStrongBiblePublicationBundleManifest(manifest)) {
     canonical = decodeCanonicalStrongBible(canonicalValue)
     if (

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -503,9 +503,9 @@ export const derivePublicationRevision = (manifest: PublicationBundleManifest): 
       ? manifest.identity.resourceId.toLowerCase()
       : manifest.identity.kind === 'dictionary'
         ? `dictionary-${manifest.identity.language}`
-      : manifest.identity.kind === 'strong-lexicon-module'
-        ? manifest.identity.resourceId
-        : manifest.identity.versionId.toLowerCase()
+        : manifest.identity.kind === 'strong-lexicon-module'
+          ? manifest.identity.resourceId
+          : manifest.identity.versionId.toLowerCase()
   const digest = createHash('sha256')
     .update(JSON.stringify(normalizeJson(envelope)))
     .digest('hex')
@@ -1120,7 +1120,10 @@ export const deriveDictionaryResourceRevision = (
 export const countCanonicalDictionaryContent = (publication: CanonicalDictionaryPublication) => ({
   entries: publication.entries.length,
   verseAnchors: publication.verseAnchors.length,
-  wordReferences: publication.verseAnchors.reduce((count, anchor) => count + anchor.words.length, 0),
+  wordReferences: publication.verseAnchors.reduce(
+    (count, anchor) => count + anchor.words.length,
+    0
+  ),
 })
 
 export const getCanonicalDictionaryAlphabeticalBrowse = (
@@ -1131,9 +1134,7 @@ export const getCanonicalDictionaryAlphabeticalBrowse = (
     const initial = [...entry.normalizedWord][0] ?? '#'
     entryCountByInitial[initial] = (entryCountByInitial[initial] ?? 0) + 1
   }
-  const initials = Object.keys(entryCountByInitial).sort((left, right) =>
-    left.localeCompare(right)
-  )
+  const initials = Object.keys(entryCountByInitial).sort((left, right) => left.localeCompare(right))
   return {
     initials,
     entryCountByInitial: Object.fromEntries(
@@ -1312,7 +1313,9 @@ const validateDictionaryOfflineParity = async (
       database,
       "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
     ).map(row => requireSqliteString(row.name))
-    if (JSON.stringify(tables) !== JSON.stringify(['RESOURCE_METADATA', 'dictionnaire', 'verses'])) {
+    if (
+      JSON.stringify(tables) !== JSON.stringify(['RESOURCE_METADATA', 'dictionnaire', 'verses'])
+    ) {
       throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
     }
     const metadataRows = readSqliteRows(
@@ -1341,20 +1344,22 @@ const validateDictionaryOfflineParity = async (
       if (id <= 0 || !normalizedWord || !word) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
       return { id, word, normalizedWord, definition }
     })
-    const verseAnchors = readSqliteRows(database, 'SELECT id, ref FROM verses ORDER BY id').map(row => {
-      const verseKey = requireSqliteString(row.id)
-      if (!isDictionaryVerseKey(verseKey)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
-      let words: unknown
-      try {
-        words = JSON.parse(requireSqliteString(row.ref))
-      } catch (cause) {
-        throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+    const verseAnchors = readSqliteRows(database, 'SELECT id, ref FROM verses ORDER BY id').map(
+      row => {
+        const verseKey = requireSqliteString(row.id)
+        if (!isDictionaryVerseKey(verseKey)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+        let words: unknown
+        try {
+          words = JSON.parse(requireSqliteString(row.ref))
+        } catch (cause) {
+          throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+        }
+        if (!Array.isArray(words) || words.some(word => typeof word !== 'string' || !word.trim())) {
+          throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+        }
+        return { verseKey, words: [...new Set(words.map(word => word.trim().toLocaleLowerCase()))] }
       }
-      if (!Array.isArray(words) || words.some(word => typeof word !== 'string' || !word.trim())) {
-        throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
-      }
-      return { verseKey, words: [...new Set(words.map(word => word.trim().toLocaleLowerCase()))] }
-    })
+    )
     if (
       JSON.stringify(entries) !== JSON.stringify(canonical.entries) ||
       JSON.stringify(verseAnchors) !== JSON.stringify(canonical.verseAnchors)
@@ -2531,8 +2536,7 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
     }
     if (
-      JSON.stringify(countCanonicalDictionaryContent(canonical)) !==
-      JSON.stringify(manifest.counts)
+      JSON.stringify(countCanonicalDictionaryContent(canonical)) !== JSON.stringify(manifest.counts)
     ) {
       throw new Error('PUBLICATION_BUNDLE_COUNT_MISMATCH')
     }

--- a/resource-service/src/repositories/dictionaryRepository.ts
+++ b/resource-service/src/repositories/dictionaryRepository.ts
@@ -1,0 +1,135 @@
+import { Effect } from 'effect'
+import type { Kysely } from 'kysely'
+
+import { tryDatabasePromise } from '../database/databaseEffect'
+import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
+import {
+  ActiveDictionaryPublicationUnavailable,
+  DictionaryEntryNotFound,
+  DictionaryRepositoryFailure,
+  type DictionaryEntry,
+  type DictionaryLanguage,
+  type DictionaryRepositoryService,
+} from '../domain/dictionary'
+import type { ResourceDatabase } from '../database/types'
+
+const mapEntry = (row: { entry_id: number; word: string; definition: string }): DictionaryEntry => ({
+  id: row.entry_id,
+  word: row.word,
+  definition: row.definition,
+})
+
+export const makeKyselyDictionaryRepository = (
+  database: Kysely<ResourceDatabase>
+): DictionaryRepositoryService => {
+  const findActivePublication = (language: DictionaryLanguage) =>
+    tryDatabasePromise('dictionary.publication.read-active', () =>
+      database
+        .selectFrom('resource_publications')
+        .select(['id', 'revision'])
+        .where('resource_identity', '=', `dictionary:${language}`)
+        .where('status', '=', 'active')
+        .executeTakeFirst()
+    ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
+
+  const requirePublication = (language: DictionaryLanguage) =>
+    Effect.gen(function* () {
+      const publication = yield* findActivePublication(language)
+      if (!publication) {
+        return yield* new ActiveDictionaryPublicationUnavailable({ language })
+      }
+      return publication
+    })
+
+  return {
+    listEntries: input =>
+      Effect.gen(function* () {
+        const publication = yield* requirePublication(input.language)
+        const limit = input.limit ?? 500
+        const offset = input.offset ?? 0
+        let query = database
+          .selectFrom('dictionary_entries')
+          .select(['entry_id', 'word', 'normalized_word'])
+          .where('publication_id', '=', publication.id)
+        if (input.initial?.trim()) {
+          query = query.where('normalized_word', 'ilike', `${input.initial.trim().toLocaleLowerCase()}%`)
+        }
+        if (input.search?.trim()) {
+          const search = `%${input.search.trim()}%`
+          query = query.where(eb =>
+            eb.or([eb('word', 'ilike', search), eb('normalized_word', 'ilike', search)])
+          )
+        }
+        const rows = yield* tryDatabasePromise('dictionary.entries.browse', () =>
+          query.orderBy('normalized_word').orderBy('entry_id').limit(limit + 1).offset(offset).execute()
+        ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
+        const hasNext = rows.length > limit
+        return {
+          language: input.language,
+          revision: publication.revision,
+          entries: rows.slice(0, limit).map(row => ({
+            id: row.entry_id,
+            word: row.word,
+            normalizedWord: row.normalized_word,
+          })),
+          offset,
+          limit,
+          ...(hasNext ? { nextOffset: offset + limit } : {}),
+        }
+      }),
+    findEntry: input =>
+      Effect.gen(function* () {
+        const publication = yield* requirePublication(input.language)
+        const normalized = input.word.trim().toLocaleLowerCase()
+        const row = yield* tryDatabasePromise('dictionary.entry.read', () =>
+          database
+            .selectFrom('dictionary_entries')
+            .select(['entry_id', 'word', 'definition'])
+            .where('publication_id', '=', publication.id)
+            .where(eb => eb.or([eb('normalized_word', '=', normalized), eb('word', '=', input.word)]))
+            .orderBy('entry_id')
+            .executeTakeFirst()
+        ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
+        if (!row) return yield* new DictionaryEntryNotFound(input)
+        return { language: input.language, revision: publication.revision, entry: mapEntry(row) }
+      }),
+    findEntryById: input =>
+      Effect.gen(function* () {
+        const publication = yield* requirePublication(input.language)
+        const row = yield* tryDatabasePromise('dictionary.entry.read-by-id', () =>
+          database
+            .selectFrom('dictionary_entries')
+            .select(['entry_id', 'word', 'definition'])
+            .where('publication_id', '=', publication.id)
+            .where('entry_id', '=', input.id)
+            .executeTakeFirst()
+        ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
+        if (!row) return yield* new DictionaryEntryNotFound(input)
+        return { language: input.language, revision: publication.revision, entry: mapEntry(row) }
+      }),
+    findVerseWords: input =>
+      Effect.gen(function* () {
+        const publication = yield* requirePublication(input.language)
+        const rows = yield* tryDatabasePromise('dictionary.verse.read-words', () =>
+          database
+            .selectFrom('dictionary_verse_links')
+            .select(['word'])
+            .where('publication_id', '=', publication.id)
+            .where('verse_key', '=', input.verseKey)
+            .orderBy('ordinal')
+            .execute()
+        ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
+        return {
+          language: input.language,
+          revision: publication.revision,
+          verseKey: input.verseKey,
+          words: rows.map(row => row.word),
+        }
+      }),
+  }
+}
+
+export const makeNeonDictionaryRepository = (config: NeonDatabaseConfig) => {
+  const database = makeNeonDatabase(config)
+  return { repository: makeKyselyDictionaryRepository(database), dispose: () => database.destroy() }
+}

--- a/resource-service/src/repositories/dictionaryRepository.ts
+++ b/resource-service/src/repositories/dictionaryRepository.ts
@@ -13,7 +13,11 @@ import {
 } from '../domain/dictionary'
 import type { ResourceDatabase } from '../database/types'
 
-const mapEntry = (row: { entry_id: number; word: string; definition: string }): DictionaryEntry => ({
+const mapEntry = (row: {
+  entry_id: number
+  word: string
+  definition: string
+}): DictionaryEntry => ({
   id: row.entry_id,
   word: row.word,
   definition: row.definition,
@@ -52,7 +56,11 @@ export const makeKyselyDictionaryRepository = (
           .select(['entry_id', 'word', 'normalized_word'])
           .where('publication_id', '=', publication.id)
         if (input.initial?.trim()) {
-          query = query.where('normalized_word', 'ilike', `${input.initial.trim().toLocaleLowerCase()}%`)
+          query = query.where(
+            'normalized_word',
+            'ilike',
+            `${input.initial.trim().toLocaleLowerCase()}%`
+          )
         }
         if (input.search?.trim()) {
           const search = `%${input.search.trim()}%`
@@ -61,7 +69,12 @@ export const makeKyselyDictionaryRepository = (
           )
         }
         const rows = yield* tryDatabasePromise('dictionary.entries.browse', () =>
-          query.orderBy('normalized_word').orderBy('entry_id').limit(limit + 1).offset(offset).execute()
+          query
+            .orderBy('normalized_word')
+            .orderBy('entry_id')
+            .limit(limit + 1)
+            .offset(offset)
+            .execute()
         ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))
         const hasNext = rows.length > limit
         return {
@@ -86,7 +99,9 @@ export const makeKyselyDictionaryRepository = (
             .selectFrom('dictionary_entries')
             .select(['entry_id', 'word', 'definition'])
             .where('publication_id', '=', publication.id)
-            .where(eb => eb.or([eb('normalized_word', '=', normalized), eb('word', '=', input.word)]))
+            .where(eb =>
+              eb.or([eb('normalized_word', '=', normalized), eb('word', '=', input.word)])
+            )
             .orderBy('entry_id')
             .executeTakeFirst()
         ).pipe(Effect.mapError(cause => new DictionaryRepositoryFailure({ cause })))

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -7,11 +7,13 @@ import { tryDatabasePromise, type DatabaseFailure } from '../database/databaseEf
 import type { ResourceDatabase } from '../database/types'
 import {
   isBiblePublicationBundleManifest,
+  isDictionaryPublicationBundleManifest,
   isInterlinearBiblePublicationBundleManifest,
   isNavePublicationBundleManifest,
   isStrongLexiconPublicationBundleManifest,
   validatePublicationBundle,
   type CanonicalStrongLexiconModulePublication,
+  type CanonicalDictionaryPublication,
 } from '../publication/publicationBundle'
 
 export class PublicationImportFailure extends Data.TaggedError('PublicationImportFailure')<{
@@ -321,6 +323,8 @@ export const importPublicationBundle = (
         ? `bible-text:${manifest.identity.versionId}`
         : isNavePublicationBundleManifest(manifest)
           ? `nave:${manifest.identity.language}`
+          : isDictionaryPublicationBundleManifest(manifest)
+            ? `dictionary:${manifest.identity.language}`
           : isInterlinearBiblePublicationBundleManifest(manifest)
             ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
             : isStrongLexiconPublicationBundleManifest(manifest)
@@ -370,6 +374,17 @@ export const importPublicationBundle = (
               canonical_schema_version: manifest.canonical.schemaVersion,
               offline_entry: manifest.offlineArtifact.entry,
             }
+          : isDictionaryPublicationBundleManifest(manifest)
+            ? {
+                resource_id: manifest.identity.resourceId,
+                language: manifest.identity.language,
+                alphabetical_browse: manifest.alphabeticalBrowse,
+                delivery_capabilities: manifest.deliveryCapabilities,
+                counts: manifest.counts,
+                canonical_schema_version: manifest.canonical.schemaVersion,
+                resource_revision: manifest.revision,
+                offline_entry: manifest.offlineArtifact.entry,
+              }
           : isInterlinearBiblePublicationBundleManifest(manifest)
             ? {
                 version_id: manifest.identity.versionId,
@@ -426,6 +441,13 @@ export const importPublicationBundle = (
                 revision: manifest.revision,
                 itemCount: manifest.counts.topics,
               }
+            : isDictionaryPublicationBundleManifest(manifest)
+              ? {
+                  status,
+                  resourceIdentity,
+                  revision: manifest.revision,
+                  itemCount: manifest.counts.entries,
+                }
             : isInterlinearBiblePublicationBundleManifest(manifest)
               ? {
                   status,
@@ -616,6 +638,35 @@ export const importPublicationBundle = (
                   .values(links.slice(offset, offset + 1_000))
                   .execute()
               }
+            } else if (canonical.format === 'bible-strong-canonical-dictionary') {
+              const dictionaryCanonical = canonical as CanonicalDictionaryPublication
+              await insertChunks(
+                transaction,
+                'dictionary_entries',
+                dictionaryCanonical.entries.map(entry => ({
+                  publication_id: publication.id,
+                  entry_id: entry.id,
+                  word: entry.word,
+                  normalized_word: entry.normalizedWord,
+                  definition: entry.definition,
+                  payload: {
+                    id: entry.id,
+                    word: entry.word,
+                    sanitized_word: entry.normalizedWord,
+                    definition: entry.definition,
+                  },
+                }))
+              )
+              const links = dictionaryCanonical.verseAnchors.flatMap(anchor =>
+                anchor.words.map((word, ordinal) => ({
+                  publication_id: publication.id,
+                  verse_key: anchor.verseKey,
+                  ordinal,
+                  word,
+                  normalized_word: word.trim().toLocaleLowerCase(),
+                }))
+              )
+              await insertChunks(transaction, 'dictionary_verse_links', links)
             } else if (canonical.format === 'bible-strong-canonical-strong-index') {
               for (let offset = 0; offset < canonical.verses.length; offset += 1_000) {
                 assertNotInterrupted(signal)

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -325,11 +325,11 @@ export const importPublicationBundle = (
           ? `nave:${manifest.identity.language}`
           : isDictionaryPublicationBundleManifest(manifest)
             ? `dictionary:${manifest.identity.language}`
-          : isInterlinearBiblePublicationBundleManifest(manifest)
-            ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
-            : isStrongLexiconPublicationBundleManifest(manifest)
-              ? manifest.identity.resourceId
-              : `strong-bible-index:${manifest.identity.versionId}`
+            : isInterlinearBiblePublicationBundleManifest(manifest)
+              ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
+              : isStrongLexiconPublicationBundleManifest(manifest)
+                ? manifest.identity.resourceId
+                : `strong-bible-index:${manifest.identity.versionId}`
       const publicationStatus =
         manifest.deliveryCapabilities.onlineAccess ||
         (options.activateForLocalDevelopment &&
@@ -385,33 +385,11 @@ export const importPublicationBundle = (
                 resource_revision: manifest.revision,
                 offline_entry: manifest.offlineArtifact.entry,
               }
-          : isInterlinearBiblePublicationBundleManifest(manifest)
-            ? {
-                version_id: manifest.identity.versionId,
-                dataset_id: manifest.identity.datasetId,
-                language: manifest.identity.language,
-                delivery_capabilities: manifest.deliveryCapabilities,
-                dependencies: manifest.dependencies,
-                counts: manifest.counts,
-                canonical_schema_version: manifest.canonical.schemaVersion,
-                resource_revision: manifest.revision,
-                text_revision: manifest.dependencies.bible.revision,
-                text_sha256: manifest.dependencies.bible.textSha256,
-                offline_entry: manifest.offlineArtifact.entry,
-              }
-            : isStrongLexiconPublicationBundleManifest(manifest)
+            : isInterlinearBiblePublicationBundleManifest(manifest)
               ? {
-                  module_id: manifest.identity.moduleId,
-                  delivery_capabilities: manifest.deliveryCapabilities,
-                  dependencies: manifest.dependencies,
-                  counts: manifest.counts,
-                  canonical_schema_version: manifest.canonical.schemaVersion,
-                  resource_revision: manifest.revision,
-                  offline_entry: manifest.offlineArtifact.entry,
-                }
-              : {
                   version_id: manifest.identity.versionId,
                   dataset_id: manifest.identity.datasetId,
+                  language: manifest.identity.language,
                   delivery_capabilities: manifest.deliveryCapabilities,
                   dependencies: manifest.dependencies,
                   counts: manifest.counts,
@@ -419,12 +397,34 @@ export const importPublicationBundle = (
                   resource_revision: manifest.revision,
                   text_revision: manifest.dependencies.bible.revision,
                   text_sha256: manifest.dependencies.bible.textSha256,
-                  strong_revision:
-                    canonical.format === 'bible-strong-canonical-strong-index'
-                      ? canonical.strongRevision
-                      : undefined,
                   offline_entry: manifest.offlineArtifact.entry,
                 }
+              : isStrongLexiconPublicationBundleManifest(manifest)
+                ? {
+                    module_id: manifest.identity.moduleId,
+                    delivery_capabilities: manifest.deliveryCapabilities,
+                    dependencies: manifest.dependencies,
+                    counts: manifest.counts,
+                    canonical_schema_version: manifest.canonical.schemaVersion,
+                    resource_revision: manifest.revision,
+                    offline_entry: manifest.offlineArtifact.entry,
+                  }
+                : {
+                    version_id: manifest.identity.versionId,
+                    dataset_id: manifest.identity.datasetId,
+                    delivery_capabilities: manifest.deliveryCapabilities,
+                    dependencies: manifest.dependencies,
+                    counts: manifest.counts,
+                    canonical_schema_version: manifest.canonical.schemaVersion,
+                    resource_revision: manifest.revision,
+                    text_revision: manifest.dependencies.bible.revision,
+                    text_sha256: manifest.dependencies.bible.textSha256,
+                    strong_revision:
+                      canonical.format === 'bible-strong-canonical-strong-index'
+                        ? canonical.strongRevision
+                        : undefined,
+                    offline_entry: manifest.offlineArtifact.entry,
+                  }
       const publicationMetadata = { ...metadata, manifest_sha256: manifestSha256 }
       const makeResult = (status: PublicationImportResult['status']): PublicationImportResult =>
         isBiblePublicationBundleManifest(manifest)
@@ -448,29 +448,29 @@ export const importPublicationBundle = (
                   revision: manifest.revision,
                   itemCount: manifest.counts.entries,
                 }
-            : isInterlinearBiblePublicationBundleManifest(manifest)
-              ? {
-                  status,
-                  resourceIdentity,
-                  revision: manifest.revision,
-                  itemCount: manifest.counts.segments,
-                }
-              : isStrongLexiconPublicationBundleManifest(manifest)
+              : isInterlinearBiblePublicationBundleManifest(manifest)
                 ? {
                     status,
                     resourceIdentity,
                     revision: manifest.revision,
-                    itemCount: Object.values(manifest.counts).reduce(
-                      (total, count) => total + count,
-                      0
-                    ),
+                    itemCount: manifest.counts.segments,
                   }
-                : {
-                    status,
-                    resourceIdentity,
-                    revision: manifest.revision,
-                    itemCount: manifest.counts.occurrences,
-                  }
+                : isStrongLexiconPublicationBundleManifest(manifest)
+                  ? {
+                      status,
+                      resourceIdentity,
+                      revision: manifest.revision,
+                      itemCount: Object.values(manifest.counts).reduce(
+                        (total, count) => total + count,
+                        0
+                      ),
+                    }
+                  : {
+                      status,
+                      resourceIdentity,
+                      revision: manifest.revision,
+                      itemCount: manifest.counts.occurrences,
+                    }
 
       return tryDatabasePromise(
         'publication.import',

--- a/resource-service/src/runtime/node.ts
+++ b/resource-service/src/runtime/node.ts
@@ -7,12 +7,14 @@ import { createServer } from 'node:http'
 import { makeLocalDatabase } from '../database/localDatabase'
 import { BibleChapterRepository } from '../domain/bibleChapter'
 import { NaveRepository } from '../domain/nave'
+import { DictionaryRepository } from '../domain/dictionary'
 import { StrongBibleRepository } from '../domain/strongBible'
 import { InterlinearBibleRepository } from '../domain/interlinearBible'
 import { StrongLexiconRepository } from '../domain/strongLexicon'
 import { ResourceApiLive } from '../http/app'
 import { makeKyselyBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeKyselyNaveRepository } from '../repositories/naveRepository'
+import { makeKyselyDictionaryRepository } from '../repositories/dictionaryRepository'
 import { makeKyselyStrongBibleRepository } from '../repositories/strongBibleRepository'
 import { makeKyselyInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeKyselyStrongLexiconRepository } from '../repositories/strongLexiconRepository'
@@ -32,6 +34,7 @@ const RepositoryLive = Layer.mergeAll(
     )
   ),
   Layer.succeed(NaveRepository, makeKyselyNaveRepository(database)),
+  Layer.succeed(DictionaryRepository, makeKyselyDictionaryRepository(database)),
   Layer.succeed(StrongBibleRepository, makeKyselyStrongBibleRepository(database)),
   Layer.succeed(InterlinearBibleRepository, makeKyselyInterlinearBibleRepository(database)),
   Layer.succeed(StrongLexiconRepository, makeKyselyStrongLexiconRepository(database))

--- a/resource-service/src/runtime/worker.ts
+++ b/resource-service/src/runtime/worker.ts
@@ -1,11 +1,13 @@
 import { makeResourceWebHandler } from '../http/app'
 import type { BibleChapterRepositoryService } from '../domain/bibleChapter'
 import type { NaveRepositoryService } from '../domain/nave'
+import type { DictionaryRepositoryService } from '../domain/dictionary'
 import type { StrongBibleRepositoryService } from '../domain/strongBible'
 import type { InterlinearBibleRepositoryService } from '../domain/interlinearBible'
 import type { StrongLexiconRepositoryService } from '../domain/strongLexicon'
 import { makeNeonBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeNeonNaveRepository } from '../repositories/naveRepository'
+import { makeNeonDictionaryRepository } from '../repositories/dictionaryRepository'
 import { makeNeonStrongBibleRepository } from '../repositories/strongBibleRepository'
 import { makeNeonInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeNeonStrongLexiconRepository } from '../repositories/strongLexiconRepository'
@@ -17,11 +19,13 @@ export type ResourceWorkerBindings = {
 export const makeResourceWorkerHandler = (
   repository: BibleChapterRepositoryService,
   naveRepository?: NaveRepositoryService,
+  dictionaryRepository?: DictionaryRepositoryService,
   strongBibleRepository?: StrongBibleRepositoryService,
   interlinearBibleRepository?: InterlinearBibleRepositoryService,
   strongLexiconRepository?: StrongLexiconRepositoryService
 ) =>
   makeResourceWebHandler(repository, naveRepository, {
+    dictionary: dictionaryRepository,
     strongBible: strongBibleRepository,
     interlinearBible: interlinearBibleRepository,
     strongLexicon: strongLexiconRepository,
@@ -38,6 +42,7 @@ const getWorkerHandler = (connectionString: string) => {
   if (cached?.connectionString === connectionString) return cached.web
   const { repository } = makeNeonBibleChapterRepository({ connectionString })
   const { repository: naveRepository } = makeNeonNaveRepository({ connectionString })
+  const { repository: dictionaryRepository } = makeNeonDictionaryRepository({ connectionString })
   const { repository: strongBibleRepository } = makeNeonStrongBibleRepository({ connectionString })
   const { repository: interlinearBibleRepository } = makeNeonInterlinearBibleRepository({
     connectionString,
@@ -48,6 +53,7 @@ const getWorkerHandler = (connectionString: string) => {
   const web = makeResourceWorkerHandler(
     repository,
     naveRepository,
+    dictionaryRepository,
     strongBibleRepository,
     interlinearBibleRepository,
     strongLexiconRepository

--- a/scripts/smokeDictionaryResourceService.mjs
+++ b/scripts/smokeDictionaryResourceService.mjs
@@ -51,10 +51,16 @@ const main = async () => {
   assert(Array.isArray(verse.body?.words) && verse.body.words.length > 0, 'verse-empty')
 
   const missing = await request('/v1/dictionaries/fr/entries/__smoke_missing__')
-  assert(missing.response.status === 404 && missing.body?.code === 'DICTIONARY_ENTRY_NOT_FOUND', 'missing-not-404')
+  assert(
+    missing.response.status === 404 && missing.body?.code === 'DICTIONARY_ENTRY_NOT_FOUND',
+    'missing-not-404'
+  )
 
   const invalidLanguage = await request('/v1/dictionaries/de/entries')
-  assert(invalidLanguage.response.status === 400, `invalid-language-status:${invalidLanguage.response.status}`)
+  assert(
+    invalidLanguage.response.status === 400,
+    `invalid-language-status:${invalidLanguage.response.status}`
+  )
 
   console.log(
     JSON.stringify(
@@ -67,12 +73,14 @@ const main = async () => {
         verseWordsChecked: verse.body.words.length,
       },
       null,
-      2,
-    ),
+      2
+    )
   )
 }
 
-main().catch((error) => {
-  console.error(`dictionary-resource-smoke-failed: ${error instanceof Error ? error.message : String(error)}`)
+main().catch(error => {
+  console.error(
+    `dictionary-resource-smoke-failed: ${error instanceof Error ? error.message : String(error)}`
+  )
   process.exitCode = 1
 })

--- a/scripts/smokeDictionaryResourceService.mjs
+++ b/scripts/smokeDictionaryResourceService.mjs
@@ -1,0 +1,78 @@
+const baseUrl = (process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787').replace(/\/$/u, '')
+
+const request = async (path, options = {}) => {
+  const response = await fetch(`${baseUrl}${path}`, options)
+  const text = await response.text()
+  let body
+  try {
+    body = text ? JSON.parse(text) : undefined
+  } catch {
+    throw new Error(`invalid-json:${path}:${text.slice(0, 120)}`)
+  }
+  return { response, body }
+}
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const main = async () => {
+  const health = await request('/health')
+  assert(health.response.status === 200 && health.body?.status === 'ok', 'health-failed')
+
+  const frList = await request('/v1/dictionaries/fr/entries?initial=a&limit=3')
+  assert(frList.response.status === 200, `fr-list-status:${frList.response.status}`)
+  assert(frList.body?.resource?.language === 'fr', 'fr-list-resource-invalid')
+  assert(Array.isArray(frList.body?.entries) && frList.body.entries.length > 0, 'fr-list-empty')
+  const first = frList.body.entries[0]
+  assert(Number.isSafeInteger(first.id) && typeof first.word === 'string', 'fr-list-entry-invalid')
+
+  const wordPath = `/v1/dictionaries/fr/entries/${encodeURIComponent(first.word)}`
+  const byWord = await request(wordPath)
+  assert(byWord.response.status === 200, `fr-detail-status:${byWord.response.status}`)
+  assert(byWord.body?.entry?.id === first.id, 'fr-detail-id-mismatch')
+  assert(typeof byWord.body?.entry?.definition === 'string', 'fr-detail-definition-missing')
+
+  const byId = await request(`/v1/dictionaries/fr/entries/by-id/${first.id}`)
+  assert(byId.response.status === 200 && byId.body?.entry?.id === first.id, 'fr-id-detail-invalid')
+
+  const cached = await request(wordPath, {
+    headers: { 'if-none-match': byWord.response.headers.get('etag') ?? '' },
+  })
+  assert(cached.response.status === 304, `etag-status:${cached.response.status}`)
+
+  const enList = await request('/v1/dictionaries/en/entries?initial=a&limit=3')
+  assert(enList.response.status === 200, `en-list-status:${enList.response.status}`)
+  assert(enList.body?.resource?.language === 'en', 'en-list-resource-invalid')
+  assert(Array.isArray(enList.body?.entries) && enList.body.entries.length > 0, 'en-list-empty')
+
+  const verse = await request('/v1/dictionaries/fr/verses/1-1-1/words')
+  assert(verse.response.status === 200, `verse-status:${verse.response.status}`)
+  assert(Array.isArray(verse.body?.words) && verse.body.words.length > 0, 'verse-empty')
+
+  const missing = await request('/v1/dictionaries/fr/entries/__smoke_missing__')
+  assert(missing.response.status === 404 && missing.body?.code === 'DICTIONARY_ENTRY_NOT_FOUND', 'missing-not-404')
+
+  const invalidLanguage = await request('/v1/dictionaries/de/entries')
+  assert(invalidLanguage.response.status === 400, `invalid-language-status:${invalidLanguage.response.status}`)
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        frRevision: frList.body.resource.revision,
+        enRevision: enList.body.resource.revision,
+        frEntriesChecked: frList.body.entries.length,
+        verseWordsChecked: verse.body.words.length,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((error) => {
+  console.error(`dictionary-resource-smoke-failed: ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+})

--- a/src/assets/mobile-resource-catalog.json
+++ b/src/assets/mobile-resource-catalog.json
@@ -1457,16 +1457,16 @@
       "entries": {
         "canonical": {
           "entry": "dictionnaire.sqlite",
-          "sha256": "33120ac7e89aa5390836f55ac6a36366cd60824488408cdd9472ee30ba9f9f38",
+          "sha256": "20bba5cccf99d4fc2dffccce861cac596e814bd9178d93ecbf4ef488078e50d6",
           "bytes": 22532096
         }
       },
-      "archiveSha256": "bb041f16f4cc8d0f8c35e28752683f41dc52d747fcabd79cd1e4534760a09b9c",
-      "archiveBytes": 6819016,
-      "contentSha256": "33120ac7e89aa5390836f55ac6a36366cd60824488408cdd9472ee30ba9f9f38",
+      "archiveSha256": "7da622e2b6d11d0d41766a1f5aba9b091f157eed8161aa45be2ebc3981cb0621",
+      "archiveBytes": 6819899,
+      "contentSha256": "20bba5cccf99d4fc2dffccce861cac596e814bd9178d93ecbf4ef488078e50d6",
       "contentBytes": 22532096,
       "installedBytes": 22532096,
-      "peakInstallationBytes": 33753779,
+      "peakInstallationBytes": 33754795,
       "strategy": "archive-extract"
     },
     "database:DICTIONNAIRE:fr": {
@@ -1477,16 +1477,16 @@
       "entries": {
         "canonical": {
           "entry": "dictionnaire.sqlite",
-          "sha256": "167b6b2f8764de0093879f0f440b25baf8c50c513400d8c035ecb011835a1a08",
-          "bytes": 24455168
+          "sha256": "de510c259915c889c7dc154f25418c9753355e774d1938afaa876ce661e9697c",
+          "bytes": 24456192
         }
       },
-      "archiveSha256": "47216086d400f0e9c8739bd9baa0b868cf26969548305f519e00a17fc4a71a51",
-      "archiveBytes": 6602308,
-      "contentSha256": "167b6b2f8764de0093879f0f440b25baf8c50c513400d8c035ecb011835a1a08",
-      "contentBytes": 24455168,
-      "installedBytes": 24455168,
-      "peakInstallationBytes": 35716098,
+      "archiveSha256": "b124243c601ba224b9907f7bd8c8cca104ae56acad1f2140164080e0e46ba09b",
+      "archiveBytes": 6602491,
+      "contentSha256": "de510c259915c889c7dc154f25418c9753355e774d1938afaa876ce661e9697c",
+      "contentBytes": 24456192,
+      "installedBytes": 24456192,
+      "peakInstallationBytes": 35717486,
       "strategy": "archive-extract"
     },
     "database:MHY:fr": {

--- a/src/features/dictionnary/DictionaryDetailTabScreen.tsx
+++ b/src/features/dictionnary/DictionaryDetailTabScreen.tsx
@@ -80,7 +80,8 @@ const DictionnaryDetailScreen = ({
   })
   const dictionaryQuery = useQuery({
     queryKey: ['dictionary-detail', dictionaryResourceLanguage, word],
-    queryFn: async () => (word ? ((await resources.dictionary.loadItem(word)) ?? null) : null),
+    queryFn: async () =>
+      word ? ((await resources.dictionary.loadItem(word, dictionaryResourceLanguage)) ?? null) : null,
     enabled: !!word,
     staleTime: Infinity,
     ...localQueryOptions,

--- a/src/features/dictionnary/DictionaryDetailTabScreen.tsx
+++ b/src/features/dictionnary/DictionaryDetailTabScreen.tsx
@@ -81,7 +81,9 @@ const DictionnaryDetailScreen = ({
   const dictionaryQuery = useQuery({
     queryKey: ['dictionary-detail', dictionaryResourceLanguage, word],
     queryFn: async () =>
-      word ? ((await resources.dictionary.loadItem(word, dictionaryResourceLanguage)) ?? null) : null,
+      word
+        ? ((await resources.dictionary.loadItem(word, dictionaryResourceLanguage)) ?? null)
+        : null,
     enabled: !!word,
     staleTime: Infinity,
     ...localQueryOptions,

--- a/src/features/dictionnary/DictionnaireVerseDetailCard.tsx
+++ b/src/features/dictionnary/DictionnaireVerseDetailCard.tsx
@@ -20,6 +20,7 @@ import { useResourceAccess } from '~features/resources/resourceAccess'
 import captureError from '~helpers/captureError'
 import { getDefaultBibleVersion } from '~helpers/languageUtils'
 import type { DictionaryEntry } from '~features/resources/dictionaryAccess'
+import type { ResourceLanguage } from '~helpers/databaseTypes'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLayoutSize } from '~helpers/useLayoutSize'
 import { wp } from '~helpers/utils'
@@ -119,7 +120,7 @@ const useFormattedText = ({
 }: {
   verse: Verse
   wordsInVerse?: string[]
-  resourceLang: string
+  resourceLang: ResourceLanguage
 }) => {
   const resources = useResourceAccess()
   const [selectedWord, setSelectedWord] = useState<string>()
@@ -142,7 +143,7 @@ const useFormattedText = ({
     queryFn: () =>
       Promise.all(
         (wordsInVerse ?? []).map(async w => {
-          const word = await resources.dictionary.loadItem(w)
+          const word = await resources.dictionary.loadItem(w, resourceLang)
           return word
         })
       ),
@@ -215,7 +216,8 @@ const DictionnaireVerseDetailScreen = ({
 
   const { error: dictionaryWordsError, data: wordsInVerse } = useQuery<string[]>({
     queryKey: ['dictionaryWords', `${Livre}-${Chapitre}-${Verset}`, resourceLang],
-    queryFn: () => resources.dictionary.loadWordsForVerse(`${Livre}-${Chapitre}-${Verset}`),
+    queryFn: () =>
+      resources.dictionary.loadWordsForVerse(`${Livre}-${Chapitre}-${Verset}`, resourceLang),
     ...localQueryOptions,
   })
 

--- a/src/features/home/WordOfTheDay.tsx
+++ b/src/features/home/WordOfTheDay.tsx
@@ -40,7 +40,8 @@ const DictionnaireOfTheDay = ({ color1 = 'rgba(86,204,242,1)', color2 = 'rgba(47
     queryKey: ['home-dictionary-random', lang, randomSeed],
     queryFn: async () =>
       (await resources.dictionary.loadItemByRowId(
-        lang === 'fr' ? randomIntFromInterval(5437, 10872) : randomIntFromInterval(1, 8620)
+        lang === 'fr' ? randomIntFromInterval(5437, 10872) : randomIntFromInterval(1, 8620),
+        lang
       )) ?? null,
     ...localQueryOptions,
   })

--- a/src/features/lexique/useUtilities.tsx
+++ b/src/features/lexique/useUtilities.tsx
@@ -12,7 +12,7 @@ interface UseSearchValueOptions {
   onDebouncedValue?: () => void
 }
 
-type QueryFunction<T> = (value: string) => Promise<T[]>
+type QueryFunction<T> = (value: string, resourceLanguage?: ResourceLanguage) => Promise<T[]>
 
 interface QueryConfig<T> {
   queryKey?: QueryKey
@@ -50,7 +50,7 @@ export const useResultsByLetterOrSearch = <T,>(
       mode,
       active.value ?? '',
     ],
-    queryFn: () => active.query!(active.value!),
+    queryFn: () => active.query!(active.value!, active.resourceLanguage),
     enabled,
     staleTime: Infinity,
     ...localQueryOptions,

--- a/src/features/resources/dictionaryAccess.ts
+++ b/src/features/resources/dictionaryAccess.ts
@@ -7,6 +7,13 @@ import { mapLocalResourceError, unwrapLocalResourceResult } from './resourceAcce
 import { getLocalResourceAvailability } from './resourceAvailability'
 import type { ResourceLanguage } from '~helpers/databaseTypes'
 import type { ResourceAvailability } from './resourceModel'
+import { Schema } from 'effect'
+import {
+  DictionaryEntriesResponseDto,
+  DictionaryEntryResponseDto,
+  DictionaryVerseWordsResponseDto,
+} from './dictionaryContract'
+import { ResourceAccessError } from './resourceAccessError'
 
 export type DictionarySummary = {
   id: number
@@ -15,6 +22,7 @@ export type DictionarySummary = {
 }
 
 export type DictionaryEntry = {
+  id?: number
   word: string
   definition: string
 }
@@ -23,11 +31,14 @@ export type DictionaryWordReference = { word: string }
 
 export type DictionaryAccess = {
   getAvailability?: (language: ResourceLanguage) => Promise<ResourceAvailability>
-  listByLetter: (letter: string) => Promise<DictionarySummary[]>
-  search: (searchValue: string) => Promise<DictionarySummary[]>
-  loadItem: (word: string) => Promise<DictionaryEntry | undefined>
-  loadItemByRowId: (id: number | string) => Promise<DictionaryWordReference | undefined>
-  loadWordsForVerse: (verseId: string) => Promise<string[]>
+  listByLetter: (letter: string, language?: ResourceLanguage) => Promise<DictionarySummary[]>
+  search: (searchValue: string, language?: ResourceLanguage) => Promise<DictionarySummary[]>
+  loadItem: (word: string, language?: ResourceLanguage) => Promise<DictionaryEntry | undefined>
+  loadItemByRowId: (
+    id: number | string,
+    language?: ResourceLanguage
+  ) => Promise<DictionaryWordReference | undefined>
+  loadWordsForVerse: (verseId: string, language?: ResourceLanguage) => Promise<string[]>
 }
 
 export const localDictionaryAccess: DictionaryAccess = {
@@ -78,4 +89,258 @@ export const localDictionaryAccess: DictionaryAccess = {
       throw mapLocalResourceError(error)
     }
   },
+}
+
+type HttpDictionaryAccessOptions = {
+  baseUrl: string
+  fetcher?: typeof fetch
+  isOnline: () => Promise<boolean>
+  timeoutMs?: number
+}
+
+const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '')
+
+const resourceErrorFromResponse = (status: number, code: unknown) => {
+  if (status === 404 && code === 'DICTIONARY_ENTRY_NOT_FOUND') {
+    return new ResourceAccessError('NOT_FOUND')
+  }
+  if (status === 404 && code === 'DICTIONARY_UNSUPPORTED') {
+    return new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  }
+  if (status === 503 && code === 'DICTIONARY_PUBLICATION_INACTIVE') {
+    return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+  }
+  return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+}
+
+export const createHttpDictionaryAccess = ({
+  baseUrl,
+  fetcher = fetch,
+  isOnline,
+  timeoutMs = 10_000,
+}: HttpDictionaryAccessOptions): DictionaryAccess => {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const request = async (path: string): Promise<unknown> => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(`${normalizedBaseUrl}${path}`, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      })
+      const payload: unknown = await response.json().catch(() => undefined)
+      if (!response.ok) {
+        const code =
+          payload && typeof payload === 'object' && 'code' in payload ? payload.code : undefined
+        throw resourceErrorFromResponse(response.status, code)
+      }
+      return payload
+    } catch (error) {
+      if (error instanceof ResourceAccessError) throw error
+      throw new ResourceAccessError((await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE')
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+  const decode = <A>(schema: Schema.Schema<A>, payload: unknown): A => {
+    try {
+      return Schema.decodeUnknownSync(schema)(payload)
+    } catch {
+      throw new ResourceAccessError('INTEGRITY_FAILURE')
+    }
+  }
+  const assertLanguage = (actual: ResourceLanguage, expected: ResourceLanguage) => {
+    if (actual !== expected) throw new ResourceAccessError('INTEGRITY_FAILURE')
+  }
+  const languageOrFrench = (language: ResourceLanguage | undefined) => language ?? 'fr'
+
+  return {
+    getAvailability: async language =>
+      language === 'fr' || language === 'en'
+        ? { status: 'available' }
+        : {
+            status: 'unavailable',
+            reason: 'offline-copy-required',
+            recoveries: ['acquire-offline-copy'],
+          },
+    listByLetter: async (letter, language) => {
+      const lang = languageOrFrench(language)
+      const payload = await request(
+        `/v1/dictionaries/${encodeURIComponent(lang)}/entries?initial=${encodeURIComponent(letter)}`
+      )
+      const decoded = decode(DictionaryEntriesResponseDto, payload)
+      assertLanguage(decoded.resource.language, lang)
+      return [...decoded.entries]
+    },
+    search: async (searchValue, language) => {
+      const lang = languageOrFrench(language)
+      const payload = await request(
+        `/v1/dictionaries/${encodeURIComponent(lang)}/entries?search=${encodeURIComponent(searchValue)}`
+      )
+      const decoded = decode(DictionaryEntriesResponseDto, payload)
+      assertLanguage(decoded.resource.language, lang)
+      return [...decoded.entries]
+    },
+    loadItem: async (word, language) => {
+      const lang = languageOrFrench(language)
+      try {
+        const payload = await request(
+          `/v1/dictionaries/${encodeURIComponent(lang)}/entries/${encodeURIComponent(word)}`
+        )
+        const decoded = decode(DictionaryEntryResponseDto, payload)
+        assertLanguage(decoded.resource.language, lang)
+        if (decoded.entry.word.length === 0) throw new ResourceAccessError('INTEGRITY_FAILURE')
+        return decoded.entry
+      } catch (error) {
+        if (error instanceof ResourceAccessError && error.code === 'NOT_FOUND') return undefined
+        throw error
+      }
+    },
+    loadItemByRowId: async (id, language) => {
+      const lang = languageOrFrench(language)
+      try {
+        const payload = await request(
+          `/v1/dictionaries/${encodeURIComponent(lang)}/entries/by-id/${encodeURIComponent(String(id))}`
+        )
+        const decoded = decode(DictionaryEntryResponseDto, payload)
+        assertLanguage(decoded.resource.language, lang)
+        return { word: decoded.entry.word }
+      } catch (error) {
+        if (error instanceof ResourceAccessError && error.code === 'NOT_FOUND') return undefined
+        throw error
+      }
+    },
+    loadWordsForVerse: async (verseId, language) => {
+      const lang = languageOrFrench(language)
+      const payload = await request(
+        `/v1/dictionaries/${encodeURIComponent(lang)}/verses/${encodeURIComponent(verseId)}/words`
+      )
+      const decoded = decode(DictionaryVerseWordsResponseDto, payload)
+      assertLanguage(decoded.resource.language, lang)
+      if (decoded.verseKey !== verseId) throw new ResourceAccessError('INTEGRITY_FAILURE')
+      return [...decoded.words]
+    },
+  }
+}
+
+export const unavailableHttpDictionaryAccess: DictionaryAccess = {
+  getAvailability: async () => ({
+    status: 'unavailable',
+    reason: 'offline-copy-required',
+    recoveries: ['acquire-offline-copy'],
+  }),
+  listByLetter: async () => {
+    throw new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  },
+  search: async () => {
+    throw new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  },
+  loadItem: async () => {
+    throw new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  },
+  loadItemByRowId: async () => {
+    throw new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  },
+  loadWordsForVerse: async () => {
+    throw new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  },
+}
+
+export const createHybridDictionaryAccess = ({
+  offline,
+  online,
+  remotelyReadableLanguages,
+  isOnline,
+}: {
+  offline: DictionaryAccess
+  online: DictionaryAccess
+  remotelyReadableLanguages: ReadonlySet<ResourceLanguage>
+  isOnline: () => Promise<boolean>
+}): DictionaryAccess => {
+  const availability = async (language: ResourceLanguage) => ({
+    local:
+      (await offline.getAvailability?.(language)) ??
+      ({
+        status: 'unavailable',
+        reason: 'offline-copy-required',
+        recoveries: ['acquire-offline-copy'],
+      } as const),
+    remotelyReadable: remotelyReadableLanguages.has(language),
+  })
+  const localFailure = (state: Awaited<ReturnType<typeof availability>>) => {
+    if (state.local.status !== 'available' && state.local.reason === 'invalid-offline-copy') {
+      return new ResourceAccessError('INVALID_OFFLINE_COPY', [
+        'acquire-offline-copy',
+        'manage-offline-copies',
+      ])
+    }
+    return new ResourceAccessError('OFFLINE_COPY_REQUIRED', ['acquire-offline-copy'])
+  }
+  const runSearch = async <T>(
+    language: ResourceLanguage,
+    localOperation: () => Promise<T>,
+    remoteOperation: () => Promise<T>
+  ) => {
+    const state = await availability(language)
+    if (state.remotelyReadable && (await isOnline())) {
+      try {
+        return await remoteOperation()
+      } catch (error) {
+        if (
+          state.local.status === 'available' &&
+          error instanceof ResourceAccessError &&
+          (error.code === 'NETWORK_OFFLINE' || error.code === 'TEMPORARY_UNAVAILABLE')
+        ) {
+          return localOperation()
+        }
+        throw error
+      }
+    }
+    if (state.local.status === 'available') return localOperation()
+    if (!state.remotelyReadable) throw localFailure(state)
+    throw new ResourceAccessError('NETWORK_OFFLINE')
+  }
+  const runRead = async <T>(
+    language: ResourceLanguage,
+    localOperation: () => Promise<T>,
+    remoteOperation: () => Promise<T>
+  ) => {
+    const state = await availability(language)
+    if (state.local.status === 'available') {
+      try {
+        const local = await localOperation()
+        if (local !== undefined) return local
+      } catch (error) {
+        if (!(error instanceof ResourceAccessError) || error.code !== 'NOT_FOUND') throw error
+      }
+    }
+    if (!state.remotelyReadable) throw localFailure(state)
+    return remoteOperation()
+  }
+  return {
+    getAvailability: async language => {
+      const state = await availability(language)
+      return state.local.status === 'available' || state.remotelyReadable
+        ? { status: 'available' }
+        : state.local
+    },
+    listByLetter: (letter, language = 'fr') =>
+      runSearch(language, () => offline.listByLetter(letter, language), () => online.listByLetter(letter, language)),
+    search: (value, language = 'fr') =>
+      runSearch(language, () => offline.search(value, language), () => online.search(value, language)),
+    loadItem: (word, language = 'fr') =>
+      runRead(language, () => offline.loadItem(word, language), () => online.loadItem(word, language)),
+    loadItemByRowId: (id, language = 'fr') =>
+      runRead(
+        language,
+        () => offline.loadItemByRowId(id, language),
+        () => online.loadItemByRowId(id, language)
+      ),
+    loadWordsForVerse: (verse, language = 'fr') =>
+      runRead(
+        language,
+        () => offline.loadWordsForVerse(verse, language),
+        () => online.loadWordsForVerse(verse, language)
+      ),
+  }
 }

--- a/src/features/resources/dictionaryAccess.ts
+++ b/src/features/resources/dictionaryAccess.ts
@@ -137,7 +137,9 @@ export const createHttpDictionaryAccess = ({
       return payload
     } catch (error) {
       if (error instanceof ResourceAccessError) throw error
-      throw new ResourceAccessError((await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE')
+      throw new ResourceAccessError(
+        (await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE'
+      )
     } finally {
       clearTimeout(timeout)
     }
@@ -325,11 +327,23 @@ export const createHybridDictionaryAccess = ({
         : state.local
     },
     listByLetter: (letter, language = 'fr') =>
-      runSearch(language, () => offline.listByLetter(letter, language), () => online.listByLetter(letter, language)),
+      runSearch(
+        language,
+        () => offline.listByLetter(letter, language),
+        () => online.listByLetter(letter, language)
+      ),
     search: (value, language = 'fr') =>
-      runSearch(language, () => offline.search(value, language), () => online.search(value, language)),
+      runSearch(
+        language,
+        () => offline.search(value, language),
+        () => online.search(value, language)
+      ),
     loadItem: (word, language = 'fr') =>
-      runRead(language, () => offline.loadItem(word, language), () => online.loadItem(word, language)),
+      runRead(
+        language,
+        () => offline.loadItem(word, language),
+        () => online.loadItem(word, language)
+      ),
     loadItemByRowId: (id, language = 'fr') =>
       runRead(
         language,

--- a/src/features/resources/dictionaryContract.ts
+++ b/src/features/resources/dictionaryContract.ts
@@ -1,0 +1,82 @@
+import { Schema } from 'effect'
+
+const DictionaryVerseKey = Schema.String.pipe(
+  Schema.pattern(/^[^\\/\u0000-\u001f\s]+-[^\\/\u0000-\u001f\s]+-[^\\/\u0000-\u001f\s]+$/u)
+)
+
+export class DictionaryLanguagePath extends Schema.Class<DictionaryLanguagePath>(
+  'DictionaryLanguagePath'
+)({
+  language: Schema.Literal('fr', 'en'),
+}) {}
+
+export class DictionaryEntryPath extends Schema.Class<DictionaryEntryPath>('DictionaryEntryPath')({
+  ...DictionaryLanguagePath.fields,
+  word: Schema.NonEmptyString,
+}) {}
+
+export class DictionaryEntryIdPath extends Schema.Class<DictionaryEntryIdPath>(
+  'DictionaryEntryIdPath'
+)({
+  ...DictionaryLanguagePath.fields,
+  id: Schema.NumberFromString.pipe(Schema.int(), Schema.positive()),
+}) {}
+
+export class DictionaryVersePath extends Schema.Class<DictionaryVersePath>('DictionaryVersePath')({
+  ...DictionaryLanguagePath.fields,
+  verseKey: DictionaryVerseKey,
+}) {}
+
+export class DictionaryEntriesQuery extends Schema.Class<DictionaryEntriesQuery>(
+  'DictionaryEntriesQuery'
+)({
+  initial: Schema.optional(Schema.NonEmptyString),
+  search: Schema.optional(Schema.NonEmptyString),
+  limit: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 500))),
+  offset: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative())),
+}) {}
+
+export class DictionaryRevisionDto extends Schema.Class<DictionaryRevisionDto>(
+  'DictionaryRevisionDto'
+)({
+  kind: Schema.Literal('dictionary'),
+  language: Schema.Literal('fr', 'en'),
+  revision: Schema.NonEmptyString,
+}) {}
+
+export class DictionarySummaryDto extends Schema.Class<DictionarySummaryDto>('DictionarySummaryDto')({
+  id: Schema.Int.pipe(Schema.positive()),
+  word: Schema.NonEmptyString,
+  normalizedWord: Schema.NonEmptyString,
+}) {}
+
+export class DictionaryEntryDto extends Schema.Class<DictionaryEntryDto>('DictionaryEntryDto')({
+  id: Schema.Int.pipe(Schema.positive()),
+  word: Schema.NonEmptyString,
+  definition: Schema.String,
+}) {}
+
+export class DictionaryEntriesResponseDto extends Schema.Class<DictionaryEntriesResponseDto>(
+  'DictionaryEntriesResponseDto'
+)({
+  resource: DictionaryRevisionDto,
+  entries: Schema.Array(DictionarySummaryDto),
+  offset: Schema.NonNegativeInt,
+  limit: Schema.Int.pipe(Schema.positive()),
+  nextOffset: Schema.optional(Schema.NonNegativeInt),
+}) {}
+
+export class DictionaryEntryResponseDto extends Schema.Class<DictionaryEntryResponseDto>(
+  'DictionaryEntryResponseDto'
+)({
+  resource: DictionaryRevisionDto,
+  entry: DictionaryEntryDto,
+}) {}
+
+export class DictionaryVerseWordsResponseDto extends Schema.Class<DictionaryVerseWordsResponseDto>(
+  'DictionaryVerseWordsResponseDto'
+)({
+  resource: DictionaryRevisionDto,
+  verseKey: DictionaryVerseKey,
+  words: Schema.Array(Schema.NonEmptyString),
+}) {}

--- a/src/features/resources/dictionaryContract.ts
+++ b/src/features/resources/dictionaryContract.ts
@@ -44,7 +44,9 @@ export class DictionaryRevisionDto extends Schema.Class<DictionaryRevisionDto>(
   revision: Schema.NonEmptyString,
 }) {}
 
-export class DictionarySummaryDto extends Schema.Class<DictionarySummaryDto>('DictionarySummaryDto')({
+export class DictionarySummaryDto extends Schema.Class<DictionarySummaryDto>(
+  'DictionarySummaryDto'
+)({
   id: Schema.Int.pipe(Schema.positive()),
   word: Schema.NonEmptyString,
   normalizedWord: Schema.NonEmptyString,

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -24,7 +24,13 @@ import {
   localBibleSearchAccess,
   type BibleSearchAccess,
 } from '~features/resources/bibleSearchAccess'
-import { localDictionaryAccess, type DictionaryAccess } from '~features/resources/dictionaryAccess'
+import {
+  createHttpDictionaryAccess,
+  createHybridDictionaryAccess,
+  localDictionaryAccess,
+  unavailableHttpDictionaryAccess,
+  type DictionaryAccess,
+} from '~features/resources/dictionaryAccess'
 import {
   createHttpNaveAccess,
   createHybridNaveAccess,
@@ -133,6 +139,15 @@ const onlineNaveAccess = resourceApiBaseUrl
       isOnline: async () => onlineManager.isOnline(),
     })
   : unavailableHttpNaveAccess
+const remotelyReadableDictionaryLanguages = new Set<ResourceLanguage>(
+  resourceApiBaseUrl ? ['fr', 'en'] : []
+)
+const onlineDictionaryAccess = resourceApiBaseUrl
+  ? createHttpDictionaryAccess({
+      baseUrl: resourceApiBaseUrl,
+      isOnline: async () => onlineManager.isOnline(),
+    })
+  : unavailableHttpDictionaryAccess
 const remotelyReadableStrongBibleVersions = new Set(
   resourceApiBaseUrl ? STRONG_BIBLE_FALLBACK_PRIORITY : []
 )
@@ -214,7 +229,12 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
     isOnline: async () => onlineManager.isOnline(),
   }),
   bibleSearch: localBibleSearchAccess,
-  dictionary: localDictionaryAccess,
+  dictionary: createHybridDictionaryAccess({
+    offline: localDictionaryAccess,
+    online: onlineDictionaryAccess,
+    remotelyReadableLanguages: remotelyReadableDictionaryLanguages,
+    isOnline: async () => onlineManager.isOnline(),
+  }),
   lexiconBible: lexiconBibleAccess,
   nave: createHybridNaveAccess({
     offline: localNaveAccess,
@@ -236,7 +256,8 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
         resourceApiBaseUrl ? new Set(['fr']) : new Set(),
         remotelyReadableStrongBibleVersions,
         remotelyReadableInterlinearLocales,
-        remotelyReadableStrongLexiconModules
+        remotelyReadableStrongLexiconModules,
+        remotelyReadableDictionaryLanguages
       ),
   },
 }

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -87,8 +87,7 @@ export const getResourceOnlineAccess = (
     remotelyReadableInterlinearLanguages.has(identity.language)) ||
   (identity.kind === 'strong-lexicon' &&
     remotelyReadableStrongLexiconModules.has(identity.moduleId)) ||
-  (identity.kind === 'dictionary' &&
-    remotelyReadableDictionaryLanguages.has(identity.language)) ||
+  (identity.kind === 'dictionary' && remotelyReadableDictionaryLanguages.has(identity.language)) ||
   (identity.kind === 'nave' && remotelyReadableNaveLanguages.has(identity.language)) ||
   (identity.kind === 'commentary' && identity.collection === 'FIRESTORE')
     ? { status: 'remotely-readable' }

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -77,7 +77,8 @@ export const getResourceOnlineAccess = (
   remotelyReadableNaveLanguages: ReadonlySet<ResourceLanguage> = new Set(),
   remotelyReadableStrongBibleVersions: ReadonlySet<string> = new Set(),
   remotelyReadableInterlinearLanguages: ReadonlySet<ResourceLanguage> = new Set(),
-  remotelyReadableStrongLexiconModules: ReadonlySet<string> = new Set()
+  remotelyReadableStrongLexiconModules: ReadonlySet<string> = new Set(),
+  remotelyReadableDictionaryLanguages: ReadonlySet<ResourceLanguage> = new Set()
 ): OnlineAccessState =>
   (identity.kind === 'bible-text' && remotelyReadableBibleVersions.has(identity.versionId)) ||
   (identity.kind === 'strong-bible-index' &&
@@ -86,6 +87,8 @@ export const getResourceOnlineAccess = (
     remotelyReadableInterlinearLanguages.has(identity.language)) ||
   (identity.kind === 'strong-lexicon' &&
     remotelyReadableStrongLexiconModules.has(identity.moduleId)) ||
+  (identity.kind === 'dictionary' &&
+    remotelyReadableDictionaryLanguages.has(identity.language)) ||
   (identity.kind === 'nave' && remotelyReadableNaveLanguages.has(identity.language)) ||
   (identity.kind === 'commentary' && identity.collection === 'FIRESTORE')
     ? { status: 'remotely-readable' }

--- a/src/features/search/SQLiteSearchScreen.tsx
+++ b/src/features/search/SQLiteSearchScreen.tsx
@@ -473,7 +473,10 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       try {
         const result =
           browseItemType === 'dictionary' && !trimmedSearchValue
-            ? await resources.dictionary.listByLetter(dictionaryLetter, resourcesLanguage.DICTIONNAIRE)
+            ? await resources.dictionary.listByLetter(
+                dictionaryLetter,
+                resourcesLanguage.DICTIONNAIRE
+              )
             : await resources.dictionary.search(trimmedSearchValue, resourcesLanguage.DICTIONNAIRE)
         return result
       } catch (error) {

--- a/src/features/search/SQLiteSearchScreen.tsx
+++ b/src/features/search/SQLiteSearchScreen.tsx
@@ -473,8 +473,8 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       try {
         const result =
           browseItemType === 'dictionary' && !trimmedSearchValue
-            ? await resources.dictionary.listByLetter(dictionaryLetter)
-            : await resources.dictionary.search(trimmedSearchValue)
+            ? await resources.dictionary.listByLetter(dictionaryLetter, resourcesLanguage.DICTIONNAIRE)
+            : await resources.dictionary.search(trimmedSearchValue, resourcesLanguage.DICTIONNAIRE)
         return result
       } catch (error) {
         appLogger.error('database', 'search.dictionary.failed', { error })

--- a/src/features/studyRelations/CreateEntityRelationModal.tsx
+++ b/src/features/studyRelations/CreateEntityRelationModal.tsx
@@ -444,8 +444,8 @@ const CreateEntityRelationModal = ({
         )
       }
       return deferredResourceSearchValue.trim()
-        ? resources.dictionary.search(deferredResourceSearchValue)
-        : resources.dictionary.listByLetter(dictionaryLetter)
+        ? resources.dictionary.search(deferredResourceSearchValue, resourcesLanguage.DICTIONNAIRE)
+        : resources.dictionary.listByLetter(dictionaryLetter, resourcesLanguage.DICTIONNAIRE)
     },
     enabled: shouldLoadDictionaryTargets,
   })


### PR DESCRIPTION
## Summary
- add Bible Lexicon Maker dictionary FR/EN publication producer (canonical JSON + SQLite.zip + manifest)
- add typed local PostgreSQL dictionary tables, migration, importer, and Effect/Kysely API
- connect dictionary UI access to installed-first/local API behavior with typed HTTP contracts
- add local producer and API smoke scripts (no E2E/Argent)

## Local evidence
- BLM real FR/EN bundles validated from `/tmp/dictionary-306/build5`
- BLM smoke: validates both bundles and rejects mutated count/checksum manifests
- local PostgreSQL migration applied and FR/EN bundles imported
- re-import result: `unchanged` for both languages
- `yarn resources:smoke:dictionary` passes against `http://127.0.0.1:8787`
- `yarn typecheck` passes
- `yarn resources:architecture:check` passes

The companion Bible Lexicon Maker commit is `41cf244` in the local BLM worktree (that checkout currently has no configured remote).
