### PR TITLE
feat(resources): publish and serve Nave French and English locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "resources:smoke:lexicon": "node scripts/smokeStrongLexiconResourceService.mjs",
     "resources:smoke:dictionary": "node scripts/smokeDictionaryResourceService.mjs",
     "resources:smoke:nave": "node scripts/smokeNaveResourceService.mjs",
+    "resources:smoke:nave:artifacts": "node scripts/smokeNaveResourceArtifacts.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "resources:test:lexicon": "RESOURCE_INTEGRATION=1 tsx --test --test-concurrency=1 resource-service/src/publication/__tests__/completeStrongLexiconPublications.integration.node-test.ts",
     "resources:smoke:lexicon": "node scripts/smokeStrongLexiconResourceService.mjs",
     "resources:smoke:dictionary": "node scripts/smokeDictionaryResourceService.mjs",
+    "resources:smoke:nave": "node scripts/smokeNaveResourceService.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/README.md
+++ b/resource-service/README.md
@@ -53,7 +53,7 @@ lexicon modules needed for lexical details. Validation compares every verse, tok
 offset, segment, localized gloss, morphology value, and ordered lexical identity between canonical
 JSON and the archived V5 SQLite sidecar.
 
-The NAVE_FR archive entry is `nave-fr.sqlite`. In addition to the existing `TOPICS` and `VERSES`
+Nave archive entries are `nave-fr.sqlite` (French) and `nave.sqlite` (English). In addition to the existing `TOPICS` and `VERSES`
 tables, publication copies contain one `RESOURCE_METADATA` row with `resource_id`, `revision`,
 `source_version`, and `source_sha256`. Validation opens the database and compares every topic,
 description, verse/chapter anchor, durable identity, and metadata value with canonical JSON before
@@ -65,6 +65,7 @@ paths, both files, archive entry, hashes, identity, source revision, counts, and
 ```bash
 yarn resources:bundle:validate --bundle resource-service/.local/publications/lsg
 yarn resources:bundle:validate --bundle resource-service/.local/publications/nave-fr
+yarn resources:bundle:validate --bundle resource-service/.local/publications/nave-en
 ```
 
 Import and activation are one Kysely transaction wrapped at the Effect repository boundary:
@@ -74,6 +75,7 @@ yarn resources:db:up
 yarn resources:migrate
 yarn resources:import --bundle resource-service/.local/publications/lsg
 yarn resources:import --bundle resource-service/.local/publications/nave-fr
+yarn resources:import --bundle resource-service/.local/publications/nave-en
 yarn resources:import-all --root /path/to/ordinary-bible-publications-current
 yarn resources:import-all --root /path/to/strong-bible-publications-current
 yarn resources:import-all --root /path/to/interlinear-publications-current
@@ -106,8 +108,7 @@ the Nave operations consumed by the app:
 - `GET /v1/naves/:language/verses/:verseKey/topics`
 - `GET /v1/naves/:language/random`
 
-Only `nave:fr` (`NAVE_FR`) is remotely readable in this tracer. English Nave remains available
-through its existing optional Offline copy. All 12 cataloged Strong Bible versions are remotely
+Both `nave:fr` (`NAVE_FR`) and `nave:en` (`NAVE_EN`) are remotely readable in this tracer. All 12 cataloged Strong Bible versions are remotely
 readable when their validated index publication and the exact declared Bible text revision and
 SHA-256 are active. An active index with a missing or mismatched Bible publication is deliberately
 unavailable. Both cataloged BHG interlinear languages are remotely readable under the same exact
@@ -177,5 +178,5 @@ unchanged; only the origin is replaced.
 
 Production builds ignore this override. The local server validates the explicit bundle before it
 starts and returns generation plus checksum headers used by the normal atomic installation flow.
-Bible and interlinear artifacts are served below `/bibles/`; NAVE_FR is served at the existing
-mobile catalog path `/databases/nave-fr.sqlite.zip`.
+Bible and interlinear artifacts are served below `/bibles/`; Nave is served at the existing mobile
+catalog paths `/databases/nave-fr.sqlite.zip` and `/databases/en/nave.sqlite.zip`.

--- a/resource-service/src/domain/nave.ts
+++ b/resource-service/src/domain/nave.ts
@@ -79,7 +79,9 @@ export class NaveRepository extends Context.Tag('NaveRepository')<
 >() {}
 
 const assertSupported = (language: NaveLanguage) =>
-  language === 'fr' ? Effect.void : Effect.fail(new UnsupportedNaveLanguage({ language }))
+  language === 'fr' || language === 'en'
+    ? Effect.void
+    : Effect.fail(new UnsupportedNaveLanguage({ language }))
 
 const revisionDto = (language: NaveLanguage, revision: string) =>
   new NaveRevisionDto({ kind: 'nave', language, revision })

--- a/resource-service/src/http/__tests__/naveApi.node-test.ts
+++ b/resource-service/src/http/__tests__/naveApi.node-test.ts
@@ -110,7 +110,7 @@ describe('v1 Nave API', () => {
     try {
       const cases = [
         ['/v1/naves/fr/topics/absent', 404, 'NAVE_TOPIC_NOT_FOUND'],
-        ['/v1/naves/en/random', 404, 'NAVE_UNSUPPORTED'],
+        ['/v1/naves/en/random', 503, 'NAVE_PUBLICATION_INACTIVE'],
         ['/v1/naves/fr/random', 503, 'NAVE_PUBLICATION_INACTIVE'],
         ['/v1/naves/french/random', 400, 'INVALID_RESOURCE_REQUEST'],
         ['/v1/naves/fr/verses/0-0-0/topics', 400, 'INVALID_RESOURCE_REQUEST'],

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -120,12 +120,12 @@ const NavePublicationBundleManifestSchema = Schema.Struct({
   ...PublicationBundleCommonFields,
   offlineArtifact: Schema.Struct({
     ...PublicationBundleCommonFields.offlineArtifact.fields,
-    entry: Schema.Literal('nave-fr.sqlite'),
+    entry: Schema.Literal('nave-fr.sqlite', 'nave.sqlite'),
   }),
   identity: Schema.Struct({
     kind: Schema.Literal('nave'),
-    resourceId: Schema.Literal('NAVE_FR'),
-    language: Schema.Literal('fr'),
+    resourceId: Schema.Literal('NAVE_FR', 'NAVE_EN'),
+    language: Schema.Literal('fr', 'en'),
   }),
   alphabeticalBrowse: Schema.Struct({
     initials: Schema.Array(Schema.NonEmptyString),
@@ -354,7 +354,7 @@ export type CanonicalNaveVerseAnchor = {
 export type CanonicalNavePublication = {
   format: 'bible-strong-canonical-nave'
   schemaVersion: 1
-  resourceId: 'NAVE_FR'
+  resourceId: 'NAVE_FR' | 'NAVE_EN'
   revision: string
   sourceVersion: string
   sourceSha256: string
@@ -556,6 +556,15 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
     throw new Error('PUBLICATION_BUNDLE_RIGHTS_MISMATCH')
   }
   if (
+    isNavePublicationBundleManifest(manifest) &&
+    (manifest.identity.resourceId !==
+      (manifest.identity.language === 'fr' ? 'NAVE_FR' : 'NAVE_EN') ||
+      manifest.offlineArtifact.entry !==
+        (manifest.identity.language === 'fr' ? 'nave-fr.sqlite' : 'nave.sqlite'))
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_MANIFEST_INVALID')
+  }
+  if (
     isBiblePublicationBundleManifest(manifest) &&
     (manifest.canon.orderedBooks.length === 0 ||
       Object.values(manifest.coverage.chaptersByBook).some(chapters => chapters.length === 0))
@@ -687,7 +696,7 @@ export const decodeCanonicalNave = (value: unknown): CanonicalNavePublication =>
   if (
     candidate.format !== 'bible-strong-canonical-nave' ||
     candidate.schemaVersion !== 1 ||
-    candidate.resourceId !== 'NAVE_FR' ||
+    (candidate.resourceId !== 'NAVE_FR' && candidate.resourceId !== 'NAVE_EN') ||
     !isNonEmptyString(candidate.revision) ||
     !isNonEmptyString(candidate.sourceVersion) ||
     !isNonEmptyString(candidate.sourceSha256) ||

--- a/resource-service/src/runtime/developmentArtifacts.ts
+++ b/resource-service/src/runtime/developmentArtifacts.ts
@@ -14,8 +14,12 @@ export const createDevelopmentArtifact = (
   bytes: Buffer
 ): DevelopmentArtifact => {
   const filename = path.basename(manifest.offlineArtifact.path)
+  const databasePrefix =
+    manifest.identity.kind === 'nave' && manifest.identity.language === 'en'
+      ? '/databases/en'
+      : '/databases'
   return {
-    route: `/${manifest.identity.kind === 'nave' || manifest.identity.kind === 'strong-lexicon-module' ? 'databases' : 'bibles'}/${filename}`,
+    route: `${manifest.identity.kind === 'nave' || manifest.identity.kind === 'strong-lexicon-module' ? databasePrefix : '/bibles'}/${filename}`,
     bytes,
     headers: {
       'content-type': manifest.offlineArtifact.mediaType,

--- a/scripts/smokeNaveResourceArtifacts.mjs
+++ b/scripts/smokeNaveResourceArtifacts.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const baseUrl = process.env.RESOURCE_ARTIFACT_BASE_URL ?? 'http://127.0.0.1:8788'
+const readArchiveBytes = async (bundle, fallback) => {
+  if (!bundle) return fallback
+  const manifest = JSON.parse(await readFile(`${bundle}/manifest.json`, 'utf8'))
+  return manifest.offlineArtifact.bytes
+}
+
+const artifacts = [
+  {
+    path: '/databases/nave-fr.sqlite.zip',
+    bytes: await readArchiveBytes(process.env.NAVE_FR_BUNDLE, 2068972),
+  },
+  {
+    path: '/databases/en/nave.sqlite.zip',
+    bytes: await readArchiveBytes(process.env.NAVE_EN_BUNDLE, 2010815),
+  },
+]
+
+for (const artifact of artifacts) {
+  const response = await fetch(`${baseUrl}${artifact.path}`, { method: 'HEAD' })
+  assert.equal(response.status, 200, artifact.path)
+  assert.equal(Number(response.headers.get('content-length')), artifact.bytes)
+  assert.ok(response.headers.get('etag'))
+}
+
+console.log('nave-resource-artifacts-smoke:ok')

--- a/scripts/smokeNaveResourceService.mjs
+++ b/scripts/smokeNaveResourceService.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+
+const baseUrl = process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787'
+
+const request = async path => {
+  const response = await fetch(`${baseUrl}${path}`)
+  const body = await response.json().catch(() => undefined)
+  return { response, body }
+}
+
+const health = await request('/health')
+assert.equal(health.response.status, 200)
+
+const frenchTopic = await request('/v1/naves/fr/topics/love')
+assert.equal(frenchTopic.response.status, 200)
+assert.equal(frenchTopic.body.resource.language, 'fr')
+assert.equal(frenchTopic.body.topic.normalizedName, 'love')
+
+const frenchCached = await fetch(`${baseUrl}/v1/naves/fr/topics/love`, {
+  headers: { 'if-none-match': frenchTopic.response.headers.get('etag') },
+})
+assert.equal(frenchCached.status, 304)
+
+const englishTopic = await request('/v1/naves/en/topics/hamutal')
+assert.equal(englishTopic.response.status, 200)
+assert.equal(englishTopic.body.resource.language, 'en')
+
+const frenchVerse = await request('/v1/naves/fr/verses/43-3-16/topics')
+assert.equal(frenchVerse.response.status, 200)
+assert.equal(frenchVerse.body.verseKey, '43-3-16')
+assert.ok(frenchVerse.body.verseTopics.length > 0)
+
+const englishRandom = await request('/v1/naves/en/random')
+assert.equal(englishRandom.response.status, 200)
+assert.equal(englishRandom.body.resource.language, 'en')
+
+const missing = await request('/v1/naves/en/topics/not-a-real-topic')
+assert.equal(missing.response.status, 404)
+
+const unsupported = await request('/v1/naves/de/topics')
+assert.equal(unsupported.response.status, 400)
+
+console.log('nave-resource-service-smoke:ok')

--- a/src/assets/mobile-resource-catalog.json
+++ b/src/assets/mobile-resource-catalog.json
@@ -1517,15 +1517,15 @@
       "entries": {
         "canonical": {
           "entry": "nave.sqlite",
-          "sha256": "e66721dc7e2db41d71e0a5a3e2a7afb6c0676367bcc339b64ac821ea77cb5726",
-          "bytes": 7401472
+          "sha256": "85ebea651a48023c8c31b2a805c3805d9189f479b3848e9053c270845ee687a0",
+          "bytes": 7402496
         }
       },
-      "archiveSha256": "dbc579c0bd262d2a06a2a8913d9245bfee12de359eb18f234f5e99c2ff0f8f57",
-      "archiveBytes": 2010635,
-      "contentSha256": "e66721dc7e2db41d71e0a5a3e2a7afb6c0676367bcc339b64ac821ea77cb5726",
-      "contentBytes": 7401472,
-      "installedBytes": 7401472,
+      "archiveSha256": "0e94c41d69e852c0cfb1ca72431110e3f7e22a1ff31a78304258894296230ee1",
+      "archiveBytes": 2010815,
+      "contentSha256": "85ebea651a48023c8c31b2a805c3805d9189f479b3848e9053c270845ee687a0",
+      "contentBytes": 7402496,
+      "installedBytes": 7402496,
       "peakInstallationBytes": 10823924,
       "strategy": "archive-extract"
     },
@@ -1537,15 +1537,15 @@
       "entries": {
         "canonical": {
           "entry": "nave-fr.sqlite",
-          "sha256": "42e6c1e43fd8a082cef5591f8d11bfa962c57f1bc541031c67426890829fdf85",
-          "bytes": 7790592
+          "sha256": "8a5769b3b526cb8fdf119936758864773ff74908af949a4354d7d38b58a9ef6b",
+          "bytes": 7791616
         }
       },
-      "archiveSha256": "78ad5378c02ae8ae5243f2294057eee445188dd417f4ddd811d08dba7c9f108d",
-      "archiveBytes": 2068625,
-      "contentSha256": "42e6c1e43fd8a082cef5591f8d11bfa962c57f1bc541031c67426890829fdf85",
-      "contentBytes": 7790592,
-      "installedBytes": 7790592,
+      "archiveSha256": "75df3e31501ef968b7d9343244e45fcbe8563f893e0c8fce82064ca2436c9dd3",
+      "archiveBytes": 2068972,
+      "contentSha256": "8a5769b3b526cb8fdf119936758864773ff74908af949a4354d7d38b58a9ef6b",
+      "contentBytes": 7791616,
+      "installedBytes": 7791616,
       "peakInstallationBytes": 11338100,
       "strategy": "archive-extract"
     },

--- a/src/features/resources/naveAccess.ts
+++ b/src/features/resources/naveAccess.ts
@@ -158,7 +158,7 @@ export const createHttpNaveAccess = ({
 
   return {
     getAvailability: async language =>
-      language === 'fr'
+      language === 'fr' || language === 'en'
         ? { status: 'available' }
         : {
             status: 'unavailable',

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -142,6 +142,9 @@ const onlineNaveAccess = resourceApiBaseUrl
 const remotelyReadableDictionaryLanguages = new Set<ResourceLanguage>(
   resourceApiBaseUrl ? ['fr', 'en'] : []
 )
+const remotelyReadableNaveLanguages = new Set<ResourceLanguage>(
+  resourceApiBaseUrl ? ['fr', 'en'] : []
+)
 const onlineDictionaryAccess = resourceApiBaseUrl
   ? createHttpDictionaryAccess({
       baseUrl: resourceApiBaseUrl,
@@ -239,7 +242,7 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
   nave: createHybridNaveAccess({
     offline: localNaveAccess,
     online: onlineNaveAccess,
-    remotelyReadableLanguages: resourceApiBaseUrl ? new Set(['fr']) : new Set(),
+    remotelyReadableLanguages: remotelyReadableNaveLanguages,
     isOnline: async () => onlineManager.isOnline(),
   }),
   strongLexicon: strongLexiconAccess,
@@ -253,7 +256,7 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
       getResourceOnlineAccess(
         identity,
         remotelyReadableBibleVersions,
-        resourceApiBaseUrl ? new Set(['fr']) : new Set(),
+        remotelyReadableNaveLanguages,
         remotelyReadableStrongBibleVersions,
         remotelyReadableInterlinearLocales,
         remotelyReadableStrongLexiconModules,


### PR DESCRIPTION
Closes #307

- generalize the local Nave publication producer to French and English
- generate canonical JSON + SQLite.zip + manifest for each language
- activate both Nave publications in local PostgreSQL and serve them through the existing Effect API
- prefer installed copies, otherwise use the local HTTP resource API for both languages
- update mobile catalog hashes and add concise BLM/API smoke scripts

Validation:
- BLM publication smoke: FR + EN bundles validate
- yarn typecheck
- yarn resources:architecture:check
- yarn resources:smoke:nave