### PR TITLE
feat(resources): publish and serve commentary and cross-references locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "resources:smoke:dictionary": "node scripts/smokeDictionaryResourceService.mjs",
     "resources:smoke:nave": "node scripts/smokeNaveResourceService.mjs",
     "resources:smoke:nave:artifacts": "node scripts/smokeNaveResourceArtifacts.mjs",
+    "resources:smoke:supplementary": "node scripts/smokeSupplementaryResourceService.mjs",
+    "resources:smoke:supplementary:artifacts": "node scripts/smokeSupplementaryResourceArtifacts.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/drizzle/0012_supplementary_resources.sql
+++ b/resource-service/drizzle/0012_supplementary_resources.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "commentary_verses" (
+	"publication_id" integer NOT NULL,
+	"verse_key" text NOT NULL,
+	"content" text NOT NULL,
+	CONSTRAINT "commentary_verses_publication_verse_primary" PRIMARY KEY("publication_id","verse_key")
+);
+--> statement-breakpoint
+CREATE TABLE "cross_reference_links" (
+	"publication_id" integer NOT NULL,
+	"verse_key" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"reference" text NOT NULL,
+	CONSTRAINT "cross_reference_links_publication_verse_ordinal_primary" PRIMARY KEY("publication_id","verse_key","ordinal")
+);
+--> statement-breakpoint
+ALTER TABLE "commentary_verses" ADD CONSTRAINT "commentary_verses_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "cross_reference_links" ADD CONSTRAINT "cross_reference_links_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "commentary_verses_lookup" ON "commentary_verses" USING btree ("publication_id","verse_key");
+--> statement-breakpoint
+CREATE INDEX "cross_reference_links_lookup" ON "cross_reference_links" USING btree ("publication_id","verse_key","ordinal");

--- a/resource-service/drizzle/meta/_journal.json
+++ b/resource-service/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786948963837,
       "tag": "0011_premium_jean_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786953000000,
+      "tag": "0012_supplementary_resources",
+      "breakpoints": true
     }
   ]
 }

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -170,11 +170,7 @@ export const crossReferenceLinks = pgTable(
       name: 'cross_reference_links_publication_verse_ordinal_primary',
       columns: [table.publication_id, table.verse_key, table.ordinal],
     }),
-    index('cross_reference_links_lookup').on(
-      table.publication_id,
-      table.verse_key,
-      table.ordinal
-    ),
+    index('cross_reference_links_lookup').on(table.publication_id, table.verse_key, table.ordinal),
   ]
 )
 

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -137,6 +137,47 @@ export const naveVerseLinks = pgTable(
   ]
 )
 
+export const commentaryVerses = pgTable(
+  'commentary_verses',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    verse_key: text('verse_key').notNull(),
+    content: text('content').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'commentary_verses_publication_verse_primary',
+      columns: [table.publication_id, table.verse_key],
+    }),
+    index('commentary_verses_lookup').on(table.publication_id, table.verse_key),
+  ]
+)
+
+export const crossReferenceLinks = pgTable(
+  'cross_reference_links',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    verse_key: text('verse_key').notNull(),
+    ordinal: integer('ordinal').notNull(),
+    reference: text('reference').notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'cross_reference_links_publication_verse_ordinal_primary',
+      columns: [table.publication_id, table.verse_key, table.ordinal],
+    }),
+    index('cross_reference_links_lookup').on(
+      table.publication_id,
+      table.verse_key,
+      table.ordinal
+    ),
+  ]
+)
+
 export const dictionaryEntries = pgTable(
   'dictionary_entries',
   {

--- a/resource-service/src/database/types.ts
+++ b/resource-service/src/database/types.ts
@@ -2,6 +2,8 @@ import type { Kyselify } from 'drizzle-orm/kysely'
 
 import type {
   bibleVerses,
+  commentaryVerses,
+  crossReferenceLinks,
   interlinearBibleSegmentIdentities,
   interlinearBibleSegments,
   interlinearBibleTokens,
@@ -35,6 +37,8 @@ import type {
 
 export type ResourcePublicationRow = Kyselify<typeof resourcePublications>
 export type BibleVerseRow = Kyselify<typeof bibleVerses>
+export type CommentaryVerseRow = Kyselify<typeof commentaryVerses>
+export type CrossReferenceLinkRow = Kyselify<typeof crossReferenceLinks>
 export type NaveTopicRow = Kyselify<typeof naveTopics>
 export type NaveVerseLinkRow = Kyselify<typeof naveVerseLinks>
 export type DictionaryEntryRow = Kyselify<typeof dictionaryEntries>
@@ -69,6 +73,8 @@ export type StrongLexiconEntityRelationRow = Kyselify<typeof strongLexiconEntity
 export type ResourceDatabase = {
   resource_publications: ResourcePublicationRow
   bible_verses: BibleVerseRow
+  commentary_verses: CommentaryVerseRow
+  cross_reference_links: CrossReferenceLinkRow
   nave_topics: NaveTopicRow
   nave_verse_links: NaveVerseLinkRow
   dictionary_entries: DictionaryEntryRow

--- a/resource-service/src/domain/supplementary.ts
+++ b/resource-service/src/domain/supplementary.ts
@@ -33,7 +33,9 @@ export class SupplementaryContentNotFound extends Data.TaggedError('Supplementar
   readonly verseKey?: string
 }> {}
 
-export class SupplementaryRepositoryFailure extends Data.TaggedError('SupplementaryRepositoryFailure')<{
+export class SupplementaryRepositoryFailure extends Data.TaggedError(
+  'SupplementaryRepositoryFailure'
+)<{
   readonly cause: unknown
 }> {}
 

--- a/resource-service/src/domain/supplementary.ts
+++ b/resource-service/src/domain/supplementary.ts
@@ -1,0 +1,100 @@
+import { Context, Data, Effect } from 'effect'
+
+import {
+  CommentaryChapterResponseDto,
+  CommentaryVerseResponseDto,
+  CrossReferenceResponseDto,
+  SupplementaryRevisionDto,
+} from '../../../src/features/resources/supplementaryContract'
+
+export type SupplementaryLanguage = 'fr'
+export type CommentaryVerseLookup = { collection: 'MHY'; language: 'fr'; verseKey: string }
+export type CommentaryChapterLookup = {
+  collection: 'MHY'
+  language: 'fr'
+  book: number
+  chapter: number
+}
+export type CrossReferenceLookup = { language: 'fr'; verseKey: string }
+
+type ActiveCommentaryVerse = CommentaryVerseLookup & { revision: string; content: string }
+type ActiveCommentaryChapter = CommentaryChapterLookup & {
+  revision: string
+  comments: Record<string, string>
+}
+type ActiveCrossReferences = CrossReferenceLookup & { revision: string; references: string[] }
+
+export class ActiveSupplementaryPublicationUnavailable extends Data.TaggedError(
+  'ActiveSupplementaryPublicationUnavailable'
+)<{ readonly resourceIdentity: string }> {}
+
+export class SupplementaryContentNotFound extends Data.TaggedError('SupplementaryContentNotFound')<{
+  readonly resourceIdentity: string
+  readonly verseKey?: string
+}> {}
+
+export class SupplementaryRepositoryFailure extends Data.TaggedError('SupplementaryRepositoryFailure')<{
+  readonly cause: unknown
+}> {}
+
+export type SupplementaryRepositoryError =
+  | ActiveSupplementaryPublicationUnavailable
+  | SupplementaryContentNotFound
+  | SupplementaryRepositoryFailure
+
+export type SupplementaryRepositoryService = {
+  findCommentaryVerse: (
+    input: CommentaryVerseLookup
+  ) => Effect.Effect<ActiveCommentaryVerse, SupplementaryRepositoryError>
+  findCommentaryChapter: (
+    input: CommentaryChapterLookup
+  ) => Effect.Effect<ActiveCommentaryChapter, SupplementaryRepositoryError>
+  findCrossReferences: (
+    input: CrossReferenceLookup
+  ) => Effect.Effect<ActiveCrossReferences, SupplementaryRepositoryError>
+}
+
+export class SupplementaryRepository extends Context.Tag('SupplementaryRepository')<
+  SupplementaryRepository,
+  SupplementaryRepositoryService
+>() {}
+
+const revisionDto = (
+  kind: 'commentary' | 'cross-references',
+  resourceId: 'MHY' | 'TRESOR',
+  revision: string
+) => new SupplementaryRevisionDto({ kind, resourceId, language: 'fr', revision })
+
+export const readCommentaryVerse = (input: CommentaryVerseLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* SupplementaryRepository
+    const active = yield* repository.findCommentaryVerse(input)
+    return new CommentaryVerseResponseDto({
+      resource: revisionDto('commentary', 'MHY', active.revision),
+      verseKey: active.verseKey,
+      content: active.content,
+    })
+  })
+
+export const readCommentaryChapter = (input: CommentaryChapterLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* SupplementaryRepository
+    const active = yield* repository.findCommentaryChapter(input)
+    return new CommentaryChapterResponseDto({
+      resource: revisionDto('commentary', 'MHY', active.revision),
+      book: active.book,
+      chapter: active.chapter,
+      serializedComments: JSON.stringify(active.comments),
+    })
+  })
+
+export const readCrossReferences = (input: CrossReferenceLookup) =>
+  Effect.gen(function* () {
+    const repository = yield* SupplementaryRepository
+    const active = yield* repository.findCrossReferences(input)
+    return new CrossReferenceResponseDto({
+      resource: revisionDto('cross-references', 'TRESOR', active.revision),
+      verseKey: active.verseKey,
+      references: active.references,
+    })
+  })

--- a/resource-service/src/http/api.ts
+++ b/resource-service/src/http/api.ts
@@ -63,6 +63,14 @@ import {
   StrongLexiconSearchResponseDto,
 } from '../../../src/features/resources/strongLexiconContract'
 import {
+  CommentaryChapterPath,
+  CommentaryChapterResponseDto,
+  CommentaryPath,
+  CommentaryVerseResponseDto,
+  CrossReferencePath,
+  CrossReferenceResponseDto,
+} from '../../../src/features/resources/supplementaryContract'
+import {
   InvalidResourceRequestProblem,
   ResourceInternalProblem,
   ResourceNotFoundProblem,
@@ -337,6 +345,40 @@ const StrongLexiconApi = HttpApiGroup.make('strongLexicon')
       .addError(ResourceInternalProblem, { status: 500 })
   )
 
+const SupplementaryApi = HttpApiGroup.make('supplementary')
+  .add(
+    HttpApiEndpoint.get(
+      'getCommentaryVerse',
+      '/v1/commentaries/:collection/:language/verses/:verseKey'
+    )
+      .setPath(CommentaryPath)
+      .addSuccess(CommentaryVerseResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get(
+      'getCommentaryChapter',
+      '/v1/commentaries/:collection/:language/chapters/:book/:chapter'
+    )
+      .setPath(CommentaryChapterPath)
+      .addSuccess(CommentaryChapterResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get('getCrossReferences', '/v1/cross-references/:language/verses/:verseKey')
+      .setPath(CrossReferencePath)
+      .addSuccess(CrossReferenceResponseDto)
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+
 export class ResourceApi extends HttpApi.make('resource-api')
   .add(SystemApi)
   .add(BibleApi)
@@ -344,4 +386,5 @@ export class ResourceApi extends HttpApi.make('resource-api')
   .add(DictionaryApi)
   .add(StrongBibleApi)
   .add(InterlinearBibleApi)
-  .add(StrongLexiconApi) {}
+  .add(StrongLexiconApi)
+  .add(SupplementaryApi) {}

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -73,6 +73,16 @@ import {
   StrongLexiconRepositoryFailure,
   type StrongLexiconRepositoryService,
 } from '../domain/strongLexicon'
+import {
+  ActiveSupplementaryPublicationUnavailable,
+  readCommentaryChapter,
+  readCommentaryVerse,
+  readCrossReferences,
+  SupplementaryContentNotFound,
+  SupplementaryRepository,
+  SupplementaryRepositoryFailure,
+  type SupplementaryRepositoryService,
+} from '../domain/supplementary'
 import { HealthResponse, ResourceApi } from './api'
 import {
   InvalidResourceRequestProblem,
@@ -119,7 +129,10 @@ const toHttpProblem = (
     | ActiveStrongLexiconPublicationUnavailable
     | StrongLexiconEntryNotFound
     | StrongLexiconEntityNotFound
-    | StrongLexiconRepositoryFailure,
+    | StrongLexiconRepositoryFailure
+    | ActiveSupplementaryPublicationUnavailable
+    | SupplementaryContentNotFound
+    | SupplementaryRepositoryFailure,
   requestId: string
 ) => {
   switch (cause._tag) {
@@ -148,10 +161,24 @@ const toHttpProblem = (
     case 'StrongBibleRepositoryFailure':
     case 'InterlinearBibleRepositoryFailure':
     case 'StrongLexiconRepositoryFailure':
+    case 'SupplementaryRepositoryFailure':
       return new ResourceInternalProblem({
         ...problemFields(requestId, 'The Resource service could not complete the request.'),
         status: 500,
         code: 'RESOURCE_INTERNAL_FAILURE',
+      })
+    case 'SupplementaryContentNotFound':
+      return new ResourceNotFoundProblem({
+        ...problemFields(requestId, 'This supplementary resource content does not exist.'),
+        status: 404,
+        code: 'SUPPLEMENTARY_CONTENT_NOT_FOUND',
+      })
+    case 'ActiveSupplementaryPublicationUnavailable':
+      return new ResourceUnavailableProblem({
+        ...problemFields(requestId, 'The supplementary publication is temporarily unavailable.'),
+        status: 503,
+        code: 'SUPPLEMENTARY_PUBLICATION_INACTIVE',
+        retryAfterSeconds: 30,
       })
     case 'UnsupportedNaveLanguage':
       return new ResourceNotFoundProblem({
@@ -627,6 +654,39 @@ const StrongLexiconApiLive = HttpApiBuilder.group(ResourceApi, 'strongLexicon', 
     })
 )
 
+const SupplementaryApiLive = HttpApiBuilder.group(ResourceApi, 'supplementary', handlers =>
+  handlers
+    .handle('getCommentaryVerse', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readCommentaryVerse(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['commentary', path.collection, path.language, path.verseKey]
+      )
+    })
+    .handle('getCommentaryChapter', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readCommentaryChapter(path).pipe(
+          Effect.mapError(cause => toHttpProblem(cause, requestId))
+        ),
+        requestId,
+        request.headers['if-none-match'],
+        ['commentary', path.collection, path.language, path.book, path.chapter]
+      )
+    })
+    .handle('getCrossReferences', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readCrossReferences(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['cross-references', path.language, path.verseKey]
+      )
+    })
+)
+
 export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(SystemApiLive),
   Layer.provide(BibleApiLive),
@@ -634,7 +694,8 @@ export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(DictionaryApiLive),
   Layer.provide(StrongBibleApiLive),
   Layer.provide(InterlinearBibleApiLive),
-  Layer.provide(StrongLexiconApiLive)
+  Layer.provide(StrongLexiconApiLive),
+  Layer.provide(SupplementaryApiLive)
 )
 
 const unavailableRepository: BibleChapterRepositoryService = {
@@ -706,13 +767,29 @@ const unavailableStrongLexiconRepository: StrongLexiconRepositoryService = {
     Effect.fail(new ActiveStrongLexiconPublicationUnavailable({ moduleId: 'entities' })),
 }
 
+const unavailableSupplementaryRepository: SupplementaryRepositoryService = {
+  findCommentaryVerse: () =>
+    Effect.fail(
+      new ActiveSupplementaryPublicationUnavailable({ resourceIdentity: 'commentary:MHY:fr' })
+    ),
+  findCommentaryChapter: () =>
+    Effect.fail(
+      new ActiveSupplementaryPublicationUnavailable({ resourceIdentity: 'commentary:MHY:fr' })
+    ),
+  findCrossReferences: () =>
+    Effect.fail(
+      new ActiveSupplementaryPublicationUnavailable({ resourceIdentity: 'cross-references:fr' })
+    ),
+}
+
 export const provideResourceRepositories = (
   repository: BibleChapterRepositoryService,
   naveRepository: NaveRepositoryService,
   dictionaryRepository: DictionaryRepositoryService = unavailableDictionaryRepository,
   strongBibleRepository: StrongBibleRepositoryService = unavailableStrongBibleRepository,
   interlinearBibleRepository: InterlinearBibleRepositoryService = unavailableInterlinearBibleRepository,
-  strongLexiconRepository: StrongLexiconRepositoryService = unavailableStrongLexiconRepository
+  strongLexiconRepository: StrongLexiconRepositoryService = unavailableStrongLexiconRepository,
+  supplementaryRepository: SupplementaryRepositoryService = unavailableSupplementaryRepository
 ) =>
   ResourceApiLive.pipe(
     Layer.provide(
@@ -722,7 +799,8 @@ export const provideResourceRepositories = (
         Layer.succeed(DictionaryRepository, dictionaryRepository),
         Layer.succeed(StrongBibleRepository, strongBibleRepository),
         Layer.succeed(InterlinearBibleRepository, interlinearBibleRepository),
-        Layer.succeed(StrongLexiconRepository, strongLexiconRepository)
+        Layer.succeed(StrongLexiconRepository, strongLexiconRepository),
+        Layer.succeed(SupplementaryRepository, supplementaryRepository)
       )
     )
   )
@@ -740,7 +818,8 @@ export const makeResourceWebHandler = (
         overrides.dictionary ?? unavailableDictionaryRepository,
         overrides.strongBible ?? unavailableStrongBibleRepository,
         overrides.interlinearBible ?? unavailableInterlinearBibleRepository,
-        overrides.strongLexicon ?? unavailableStrongLexiconRepository
+        overrides.strongLexicon ?? unavailableStrongLexiconRepository,
+        overrides.supplementary ?? unavailableSupplementaryRepository
       ),
       HttpServer.layerContext
     )
@@ -779,4 +858,5 @@ export type ResourceRepositoryOverrides = {
   strongBible?: StrongBibleRepositoryService
   interlinearBible?: InterlinearBibleRepositoryService
   strongLexicon?: StrongLexiconRepositoryService
+  supplementary?: SupplementaryRepositoryService
 }

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -668,9 +668,7 @@ const SupplementaryApiLive = HttpApiBuilder.group(ResourceApi, 'supplementary', 
     .handle('getCommentaryChapter', ({ path, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
       return serveRevisionedResponse(
-        readCommentaryChapter(path).pipe(
-          Effect.mapError(cause => toHttpProblem(cause, requestId))
-        ),
+        readCommentaryChapter(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
         requestId,
         request.headers['if-none-match'],
         ['commentary', path.collection, path.language, path.book, path.chapter]

--- a/resource-service/src/http/problems.ts
+++ b/resource-service/src/http/problems.ts
@@ -33,7 +33,8 @@ export class ResourceNotFoundProblem extends Schema.TaggedError<ResourceNotFound
       'INTERLINEAR_UNSUPPORTED',
       'INTERLINEAR_CHAPTER_NOT_FOUND',
       'STRONG_LEXICON_ENTRY_NOT_FOUND',
-      'STRONG_LEXICON_ENTITY_NOT_FOUND'
+      'STRONG_LEXICON_ENTITY_NOT_FOUND',
+      'SUPPLEMENTARY_CONTENT_NOT_FOUND'
     ),
   }
 ) {}
@@ -49,7 +50,8 @@ export class ResourceUnavailableProblem extends Schema.TaggedError<ResourceUnava
       'DICTIONARY_PUBLICATION_INACTIVE',
       'STRONG_BIBLE_PUBLICATION_INACTIVE',
       'INTERLINEAR_PUBLICATION_INACTIVE',
-      'STRONG_LEXICON_PUBLICATION_INACTIVE'
+      'STRONG_LEXICON_PUBLICATION_INACTIVE',
+      'SUPPLEMENTARY_PUBLICATION_INACTIVE'
     ),
     retryAfterSeconds: Schema.Int.pipe(Schema.positive()),
   }

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -170,6 +170,49 @@ const DictionaryPublicationBundleManifestSchema = Schema.Struct({
   }),
 })
 
+const CommentaryPublicationBundleManifestSchema = Schema.Struct({
+  ...PublicationBundleCommonFields,
+  canonical: Schema.Struct({
+    ...PublicationBundleCommonFields.canonical.fields,
+    schemaVersion: Schema.Literal(1),
+  }),
+  offlineArtifact: Schema.Struct({
+    ...PublicationBundleCommonFields.offlineArtifact.fields,
+    entry: Schema.Literal('commentaires-mhy.sqlite'),
+  }),
+  identity: Schema.Struct({
+    kind: Schema.Literal('commentary'),
+    resourceId: Schema.Literal('MHY'),
+    language: Schema.Literal('fr'),
+  }),
+  counts: Schema.Struct({
+    chapters: Schema.NonNegativeInt,
+    verses: Schema.NonNegativeInt,
+    characters: Schema.NonNegativeInt,
+  }),
+})
+
+const CrossReferencePublicationBundleManifestSchema = Schema.Struct({
+  ...PublicationBundleCommonFields,
+  canonical: Schema.Struct({
+    ...PublicationBundleCommonFields.canonical.fields,
+    schemaVersion: Schema.Literal(1),
+  }),
+  offlineArtifact: Schema.Struct({
+    ...PublicationBundleCommonFields.offlineArtifact.fields,
+    entry: Schema.Literal('commentaires-tresor.sqlite'),
+  }),
+  identity: Schema.Struct({
+    kind: Schema.Literal('cross-references'),
+    resourceId: Schema.Literal('TRESOR'),
+    language: Schema.Literal('fr'),
+  }),
+  counts: Schema.Struct({
+    verseAnchors: Schema.NonNegativeInt,
+    references: Schema.NonNegativeInt,
+  }),
+})
+
 const StrongBiblePublicationBundleManifestSchema = Schema.Struct({
   ...PublicationBundleCommonFields,
   identity: Schema.Struct({
@@ -271,6 +314,8 @@ const PublicationBundleManifestSchema = Schema.Union(
   BiblePublicationBundleManifestSchema,
   NavePublicationBundleManifestSchema,
   DictionaryPublicationBundleManifestSchema,
+  CommentaryPublicationBundleManifestSchema,
+  CrossReferencePublicationBundleManifestSchema,
   StrongBiblePublicationBundleManifestSchema,
   InterlinearBiblePublicationBundleManifestSchema,
   StrongLexiconPublicationBundleManifestSchema
@@ -280,6 +325,10 @@ export type BiblePublicationBundleManifest = typeof BiblePublicationBundleManife
 export type NavePublicationBundleManifest = typeof NavePublicationBundleManifestSchema.Type
 export type DictionaryPublicationBundleManifest =
   typeof DictionaryPublicationBundleManifestSchema.Type
+export type CommentaryPublicationBundleManifest =
+  typeof CommentaryPublicationBundleManifestSchema.Type
+export type CrossReferencePublicationBundleManifest =
+  typeof CrossReferencePublicationBundleManifestSchema.Type
 export type StrongBiblePublicationBundleManifest =
   typeof StrongBiblePublicationBundleManifestSchema.Type
 export type InterlinearBiblePublicationBundleManifest =
@@ -290,6 +339,8 @@ export type PublicationBundleManifest =
   | BiblePublicationBundleManifest
   | NavePublicationBundleManifest
   | DictionaryPublicationBundleManifest
+  | CommentaryPublicationBundleManifest
+  | CrossReferencePublicationBundleManifest
   | StrongBiblePublicationBundleManifest
   | InterlinearBiblePublicationBundleManifest
   | StrongLexiconPublicationBundleManifest
@@ -305,6 +356,15 @@ export const isNavePublicationBundleManifest = (
 export const isDictionaryPublicationBundleManifest = (
   manifest: PublicationBundleManifest
 ): manifest is DictionaryPublicationBundleManifest => manifest.identity.kind === 'dictionary'
+
+export const isCommentaryPublicationBundleManifest = (
+  manifest: PublicationBundleManifest
+): manifest is CommentaryPublicationBundleManifest => manifest.identity.kind === 'commentary'
+
+export const isCrossReferencePublicationBundleManifest = (
+  manifest: PublicationBundleManifest
+): manifest is CrossReferencePublicationBundleManifest =>
+  manifest.identity.kind === 'cross-references'
 
 export const isStrongBiblePublicationBundleManifest = (
   manifest: PublicationBundleManifest
@@ -384,6 +444,28 @@ export type CanonicalDictionaryPublication = {
   sourceSha256: string
   entries: CanonicalDictionaryEntry[]
   verseAnchors: CanonicalDictionaryVerseAnchor[]
+}
+
+export type CanonicalCommentaryPublication = {
+  format: 'bible-strong-canonical-commentary'
+  schemaVersion: 1
+  resourceId: 'MHY'
+  language: 'fr'
+  revision: string
+  sourceVersion: string
+  sourceSha256: string
+  verses: Array<{ verseKey: string; content: string }>
+}
+
+export type CanonicalCrossReferencePublication = {
+  format: 'bible-strong-canonical-cross-references'
+  schemaVersion: 1
+  resourceId: 'TRESOR'
+  language: 'fr'
+  revision: string
+  sourceVersion: string
+  sourceSha256: string
+  verseAnchors: Array<{ verseKey: string; references: string[] }>
 }
 
 export type CanonicalStrongBibleVerse = { book: number; chapter: number; verse: number }
@@ -470,6 +552,8 @@ export type CanonicalPublication =
   | CanonicalBiblePublication
   | CanonicalNavePublication
   | CanonicalDictionaryPublication
+  | CanonicalCommentaryPublication
+  | CanonicalCrossReferencePublication
   | CanonicalStrongBiblePublication
   | CanonicalInterlinearBiblePublication
   | CanonicalStrongLexiconModulePublication
@@ -503,6 +587,10 @@ export const derivePublicationRevision = (manifest: PublicationBundleManifest): 
       ? manifest.identity.resourceId.toLowerCase()
       : manifest.identity.kind === 'dictionary'
         ? `dictionary-${manifest.identity.language}`
+        : manifest.identity.kind === 'commentary'
+          ? `commentary-${manifest.identity.resourceId.toLowerCase()}-${manifest.identity.language}`
+          : manifest.identity.kind === 'cross-references'
+            ? `cross-references-${manifest.identity.language}`
         : manifest.identity.kind === 'strong-lexicon-module'
           ? manifest.identity.resourceId
           : manifest.identity.versionId.toLowerCase()
@@ -577,6 +665,22 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
       Object.values(manifest.alphabeticalBrowse.topicCountByInitial).some(count => count === 0))
   ) {
     throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_INVALID')
+  }
+  if (
+    isCommentaryPublicationBundleManifest(manifest) &&
+    (manifest.identity.resourceId !== 'MHY' ||
+      manifest.offlineArtifact.entry !== 'commentaires-mhy.sqlite' ||
+      manifest.counts.verses === 0)
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_MANIFEST_INVALID')
+  }
+  if (
+    isCrossReferencePublicationBundleManifest(manifest) &&
+    (manifest.identity.resourceId !== 'TRESOR' ||
+      manifest.offlineArtifact.entry !== 'commentaires-tresor.sqlite' ||
+      manifest.counts.verseAnchors === 0)
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_MANIFEST_INVALID')
   }
   if (
     isDictionaryPublicationBundleManifest(manifest) &&
@@ -795,6 +899,76 @@ export const decodeCanonicalDictionary = (value: unknown): CanonicalDictionaryPu
     verseKeys.add(anchor.verseKey)
   }
   return candidate as CanonicalDictionaryPublication
+}
+
+const isSupplementaryVerseKey = (value: unknown): value is string =>
+  typeof value === 'string' && /^[1-9]\d*-[1-9]\d*-(?:0|[1-9]\d*)$/u.test(value)
+
+export const decodeCanonicalCommentary = (value: unknown): CanonicalCommentaryPublication => {
+  if (!value || typeof value !== 'object') throw new Error('CANONICAL_COMMENTARY_INVALID')
+  const candidate = value as Partial<CanonicalCommentaryPublication>
+  if (
+    candidate.format !== 'bible-strong-canonical-commentary' ||
+    candidate.schemaVersion !== 1 ||
+    candidate.resourceId !== 'MHY' ||
+    candidate.language !== 'fr' ||
+    !isNonEmptyString(candidate.revision) ||
+    !isNonEmptyString(candidate.sourceVersion) ||
+    !/^[a-f0-9]{64}$/u.test(candidate.sourceSha256 ?? '') ||
+    !Array.isArray(candidate.verses) ||
+    candidate.verses.length === 0
+  ) {
+    throw new Error('CANONICAL_COMMENTARY_INVALID')
+  }
+  const keys = new Set<string>()
+  for (const verse of candidate.verses) {
+    if (
+      !verse ||
+      !isSupplementaryVerseKey(verse.verseKey) ||
+      typeof verse.content !== 'string' ||
+      !verse.content.trim() ||
+      keys.has(verse.verseKey)
+    ) {
+      throw new Error('CANONICAL_COMMENTARY_VERSE_INVALID')
+    }
+    keys.add(verse.verseKey)
+  }
+  return candidate as CanonicalCommentaryPublication
+}
+
+export const decodeCanonicalCrossReferences = (
+  value: unknown
+): CanonicalCrossReferencePublication => {
+  if (!value || typeof value !== 'object') throw new Error('CANONICAL_CROSS_REFERENCES_INVALID')
+  const candidate = value as Partial<CanonicalCrossReferencePublication>
+  if (
+    candidate.format !== 'bible-strong-canonical-cross-references' ||
+    candidate.schemaVersion !== 1 ||
+    candidate.resourceId !== 'TRESOR' ||
+    candidate.language !== 'fr' ||
+    !isNonEmptyString(candidate.revision) ||
+    !isNonEmptyString(candidate.sourceVersion) ||
+    !/^[a-f0-9]{64}$/u.test(candidate.sourceSha256 ?? '') ||
+    !Array.isArray(candidate.verseAnchors) ||
+    candidate.verseAnchors.length === 0
+  ) {
+    throw new Error('CANONICAL_CROSS_REFERENCES_INVALID')
+  }
+  const keys = new Set<string>()
+  for (const anchor of candidate.verseAnchors) {
+    if (
+      !anchor ||
+      !isSupplementaryVerseKey(anchor.verseKey) ||
+      !Array.isArray(anchor.references) ||
+      anchor.references.length === 0 ||
+      anchor.references.some(reference => typeof reference !== 'string' || !reference.trim()) ||
+      keys.has(anchor.verseKey)
+    ) {
+      throw new Error('CANONICAL_CROSS_REFERENCES_ANCHOR_INVALID')
+    }
+    keys.add(anchor.verseKey)
+  }
+  return candidate as CanonicalCrossReferencePublication
 }
 
 const isPositiveInteger = (value: unknown): value is number =>
@@ -1372,6 +1546,121 @@ const validateDictionaryOfflineParity = async (
     if (
       JSON.stringify(entries) !== JSON.stringify(canonical.entries) ||
       JSON.stringify(verseAnchors) !== JSON.stringify(canonical.verseAnchors)
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.startsWith('OFFLINE_ARTIFACT_')) throw cause
+    throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+  } finally {
+    database?.close()
+  }
+}
+
+const validateCommentaryOfflineParity = async (
+  offlineContent: Uint8Array,
+  canonical: CanonicalCommentaryPublication
+) => {
+  const SQL = await initSqlJs()
+  let database: Database | undefined
+  try {
+    database = new SQL.Database(offlineContent)
+    const integrity = readSqliteRows(database, 'PRAGMA integrity_check')
+    if (integrity.length !== 1 || Object.values(integrity[0] ?? {}).some(value => value !== 'ok')) {
+      throw new Error('OFFLINE_ARTIFACT_INTEGRITY_INVALID')
+    }
+    const metadataRows = readSqliteRows(
+      database,
+      'SELECT resource_id, language, revision, source_version, source_sha256 FROM RESOURCE_METADATA'
+    )
+    const metadata = metadataRows[0]
+    if (
+      metadataRows.length !== 1 ||
+      requireSqliteString(metadata?.resource_id) !== canonical.resourceId ||
+      requireSqliteString(metadata?.language) !== canonical.language ||
+      requireSqliteString(metadata?.revision) !== canonical.revision ||
+      requireSqliteString(metadata?.source_version) !== canonical.sourceVersion ||
+      requireSqliteString(metadata?.source_sha256) !== canonical.sourceSha256
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+    const verses = readSqliteRows(database, 'SELECT id, commentaires FROM COMMENTAIRES')
+      .flatMap(row => {
+        const chapterKey = requireSqliteString(row.id)
+        let content: unknown
+        try {
+          content = JSON.parse(requireSqliteString(row.commentaires))
+        } catch (cause) {
+          throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+        }
+        if (!content || typeof content !== 'object' || Array.isArray(content)) {
+          throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+        }
+        return Object.entries(content).flatMap(([verse, value]) =>
+          typeof value === 'string' && value.trim()
+            ? [{ verseKey: `${chapterKey}-${verse}`, content: value }]
+            : []
+        )
+      })
+      .sort(compareVerseKey)
+    if (JSON.stringify(verses) !== JSON.stringify([...canonical.verses].sort(compareVerseKey))) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.startsWith('OFFLINE_ARTIFACT_')) throw cause
+    throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+  } finally {
+    database?.close()
+  }
+}
+
+const validateCrossReferenceOfflineParity = async (
+  offlineContent: Uint8Array,
+  canonical: CanonicalCrossReferencePublication
+) => {
+  const SQL = await initSqlJs()
+  let database: Database | undefined
+  try {
+    database = new SQL.Database(offlineContent)
+    const integrity = readSqliteRows(database, 'PRAGMA integrity_check')
+    if (integrity.length !== 1 || Object.values(integrity[0] ?? {}).some(value => value !== 'ok')) {
+      throw new Error('OFFLINE_ARTIFACT_INTEGRITY_INVALID')
+    }
+    const metadataRows = readSqliteRows(
+      database,
+      'SELECT resource_id, language, revision, source_version, source_sha256 FROM RESOURCE_METADATA'
+    )
+    const metadata = metadataRows[0]
+    if (
+      metadataRows.length !== 1 ||
+      requireSqliteString(metadata?.resource_id) !== canonical.resourceId ||
+      requireSqliteString(metadata?.language) !== canonical.language ||
+      requireSqliteString(metadata?.revision) !== canonical.revision ||
+      requireSqliteString(metadata?.source_version) !== canonical.sourceVersion ||
+      requireSqliteString(metadata?.source_sha256) !== canonical.sourceSha256
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
+    const anchors = readSqliteRows(database, 'SELECT id, commentaires FROM COMMENTAIRES')
+      .flatMap(row => {
+        const verseKey = requireSqliteString(row.id)
+        let references: unknown
+        try {
+          references = JSON.parse(requireSqliteString(row.commentaires))
+        } catch (cause) {
+          throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID', { cause })
+        }
+        if (!Array.isArray(references)) throw new Error('OFFLINE_ARTIFACT_SCHEMA_INVALID')
+        const values = references
+          .filter((reference): reference is string => typeof reference === 'string')
+          .map(reference => reference.trim())
+          .filter(Boolean)
+        return values.length > 0 ? [{ verseKey, references: values }] : []
+      })
+      .sort(compareVerseKey)
+    if (
+      JSON.stringify(anchors) !==
+      JSON.stringify([...canonical.verseAnchors].sort(compareVerseKey))
     ) {
       throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
     }
@@ -2426,6 +2715,8 @@ export const validatePublicationBundle = async (bundlePath: string) => {
   if (
     (isNavePublicationBundleManifest(manifest) ||
       isDictionaryPublicationBundleManifest(manifest) ||
+      isCommentaryPublicationBundleManifest(manifest) ||
+      isCrossReferencePublicationBundleManifest(manifest) ||
       isStrongBiblePublicationBundleManifest(manifest) ||
       isInterlinearBiblePublicationBundleManifest(manifest) ||
       isStrongLexiconPublicationBundleManifest(manifest)) &&
@@ -2556,6 +2847,34 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       throw new Error('PUBLICATION_BUNDLE_ALPHABETICAL_BROWSE_MISMATCH')
     }
     await validateDictionaryOfflineParity(offlineContent, canonical)
+  } else if (isCommentaryPublicationBundleManifest(manifest)) {
+    canonical = decodeCanonicalCommentary(canonicalValue)
+    if (
+      canonical.resourceId !== manifest.identity.resourceId ||
+      canonical.language !== manifest.identity.language ||
+      canonical.revision !== manifest.revision ||
+      canonical.sourceVersion !== manifest.provenance.sourceVersion ||
+      canonical.sourceSha256 !== manifest.provenance.sourceSha256 ||
+      manifest.counts.verses !== canonical.verses.length ||
+      manifest.counts.characters !== canonical.verses.reduce((total, verse) => total + verse.content.length, 0)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
+    }
+    await validateCommentaryOfflineParity(offlineContent, canonical)
+  } else if (isCrossReferencePublicationBundleManifest(manifest)) {
+    canonical = decodeCanonicalCrossReferences(canonicalValue)
+    if (
+      canonical.resourceId !== manifest.identity.resourceId ||
+      canonical.language !== manifest.identity.language ||
+      canonical.revision !== manifest.revision ||
+      canonical.sourceVersion !== manifest.provenance.sourceVersion ||
+      canonical.sourceSha256 !== manifest.provenance.sourceSha256 ||
+      manifest.counts.verseAnchors !== canonical.verseAnchors.length ||
+      manifest.counts.references !== canonical.verseAnchors.reduce((total, anchor) => total + anchor.references.length, 0)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
+    }
+    await validateCrossReferenceOfflineParity(offlineContent, canonical)
   } else if (isStrongBiblePublicationBundleManifest(manifest)) {
     canonical = decodeCanonicalStrongBible(canonicalValue)
     if (

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -591,9 +591,9 @@ export const derivePublicationRevision = (manifest: PublicationBundleManifest): 
           ? `commentary-${manifest.identity.resourceId.toLowerCase()}-${manifest.identity.language}`
           : manifest.identity.kind === 'cross-references'
             ? `cross-references-${manifest.identity.language}`
-        : manifest.identity.kind === 'strong-lexicon-module'
-          ? manifest.identity.resourceId
-          : manifest.identity.versionId.toLowerCase()
+            : manifest.identity.kind === 'strong-lexicon-module'
+              ? manifest.identity.resourceId
+              : manifest.identity.versionId.toLowerCase()
   const digest = createHash('sha256')
     .update(JSON.stringify(normalizeJson(envelope)))
     .digest('hex')
@@ -1659,8 +1659,7 @@ const validateCrossReferenceOfflineParity = async (
       })
       .sort(compareVerseKey)
     if (
-      JSON.stringify(anchors) !==
-      JSON.stringify([...canonical.verseAnchors].sort(compareVerseKey))
+      JSON.stringify(anchors) !== JSON.stringify([...canonical.verseAnchors].sort(compareVerseKey))
     ) {
       throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
     }
@@ -2856,7 +2855,8 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       canonical.sourceVersion !== manifest.provenance.sourceVersion ||
       canonical.sourceSha256 !== manifest.provenance.sourceSha256 ||
       manifest.counts.verses !== canonical.verses.length ||
-      manifest.counts.characters !== canonical.verses.reduce((total, verse) => total + verse.content.length, 0)
+      manifest.counts.characters !==
+        canonical.verses.reduce((total, verse) => total + verse.content.length, 0)
     ) {
       throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
     }
@@ -2870,7 +2870,8 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       canonical.sourceVersion !== manifest.provenance.sourceVersion ||
       canonical.sourceSha256 !== manifest.provenance.sourceSha256 ||
       manifest.counts.verseAnchors !== canonical.verseAnchors.length ||
-      manifest.counts.references !== canonical.verseAnchors.reduce((total, anchor) => total + anchor.references.length, 0)
+      manifest.counts.references !==
+        canonical.verseAnchors.reduce((total, anchor) => total + anchor.references.length, 0)
     ) {
       throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
     }

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -8,12 +8,16 @@ import type { ResourceDatabase } from '../database/types'
 import {
   isBiblePublicationBundleManifest,
   isDictionaryPublicationBundleManifest,
+  isCommentaryPublicationBundleManifest,
+  isCrossReferencePublicationBundleManifest,
   isInterlinearBiblePublicationBundleManifest,
   isNavePublicationBundleManifest,
   isStrongLexiconPublicationBundleManifest,
   validatePublicationBundle,
   type CanonicalStrongLexiconModulePublication,
   type CanonicalDictionaryPublication,
+  type CanonicalCommentaryPublication,
+  type CanonicalCrossReferencePublication,
 } from '../publication/publicationBundle'
 
 export class PublicationImportFailure extends Data.TaggedError('PublicationImportFailure')<{
@@ -325,6 +329,10 @@ export const importPublicationBundle = (
           ? `nave:${manifest.identity.language}`
           : isDictionaryPublicationBundleManifest(manifest)
             ? `dictionary:${manifest.identity.language}`
+            : isCommentaryPublicationBundleManifest(manifest)
+              ? `commentary:${manifest.identity.resourceId}:${manifest.identity.language}`
+              : isCrossReferencePublicationBundleManifest(manifest)
+                ? `cross-references:${manifest.identity.language}`
             : isInterlinearBiblePublicationBundleManifest(manifest)
               ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
               : isStrongLexiconPublicationBundleManifest(manifest)
@@ -385,6 +393,26 @@ export const importPublicationBundle = (
                 resource_revision: manifest.revision,
                 offline_entry: manifest.offlineArtifact.entry,
               }
+            : isCommentaryPublicationBundleManifest(manifest)
+              ? {
+                  resource_id: manifest.identity.resourceId,
+                  language: manifest.identity.language,
+                  delivery_capabilities: manifest.deliveryCapabilities,
+                  counts: manifest.counts,
+                  canonical_schema_version: manifest.canonical.schemaVersion,
+                  resource_revision: manifest.revision,
+                  offline_entry: manifest.offlineArtifact.entry,
+                }
+              : isCrossReferencePublicationBundleManifest(manifest)
+                ? {
+                    resource_id: manifest.identity.resourceId,
+                    language: manifest.identity.language,
+                    delivery_capabilities: manifest.deliveryCapabilities,
+                    counts: manifest.counts,
+                    canonical_schema_version: manifest.canonical.schemaVersion,
+                    resource_revision: manifest.revision,
+                    offline_entry: manifest.offlineArtifact.entry,
+                  }
             : isInterlinearBiblePublicationBundleManifest(manifest)
               ? {
                   version_id: manifest.identity.versionId,
@@ -448,7 +476,21 @@ export const importPublicationBundle = (
                   revision: manifest.revision,
                   itemCount: manifest.counts.entries,
                 }
-              : isInterlinearBiblePublicationBundleManifest(manifest)
+            : isCommentaryPublicationBundleManifest(manifest)
+              ? {
+                  status,
+                  resourceIdentity,
+                  revision: manifest.revision,
+                  itemCount: manifest.counts.verses,
+                }
+              : isCrossReferencePublicationBundleManifest(manifest)
+                ? {
+                    status,
+                    resourceIdentity,
+                    revision: manifest.revision,
+                    itemCount: manifest.counts.references,
+                  }
+            : isInterlinearBiblePublicationBundleManifest(manifest)
                 ? {
                     status,
                     resourceIdentity,
@@ -667,6 +709,31 @@ export const importPublicationBundle = (
                 }))
               )
               await insertChunks(transaction, 'dictionary_verse_links', links)
+            } else if (canonical.format === 'bible-strong-canonical-commentary') {
+              const commentaryCanonical = canonical as CanonicalCommentaryPublication
+              await insertChunks(
+                transaction,
+                'commentary_verses',
+                commentaryCanonical.verses.map(verse => ({
+                  publication_id: publication.id,
+                  verse_key: verse.verseKey,
+                  content: verse.content,
+                }))
+              )
+            } else if (canonical.format === 'bible-strong-canonical-cross-references') {
+              const crossReferenceCanonical = canonical as CanonicalCrossReferencePublication
+              await insertChunks(
+                transaction,
+                'cross_reference_links',
+                crossReferenceCanonical.verseAnchors.flatMap(anchor =>
+                  anchor.references.map((reference, ordinal) => ({
+                    publication_id: publication.id,
+                    verse_key: anchor.verseKey,
+                    ordinal,
+                    reference,
+                  }))
+                )
+              )
             } else if (canonical.format === 'bible-strong-canonical-strong-index') {
               for (let offset = 0; offset < canonical.verses.length; offset += 1_000) {
                 assertNotInterrupted(signal)

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -333,11 +333,11 @@ export const importPublicationBundle = (
               ? `commentary:${manifest.identity.resourceId}:${manifest.identity.language}`
               : isCrossReferencePublicationBundleManifest(manifest)
                 ? `cross-references:${manifest.identity.language}`
-            : isInterlinearBiblePublicationBundleManifest(manifest)
-              ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
-              : isStrongLexiconPublicationBundleManifest(manifest)
-                ? manifest.identity.resourceId
-                : `strong-bible-index:${manifest.identity.versionId}`
+                : isInterlinearBiblePublicationBundleManifest(manifest)
+                  ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
+                  : isStrongLexiconPublicationBundleManifest(manifest)
+                    ? manifest.identity.resourceId
+                    : `strong-bible-index:${manifest.identity.versionId}`
       const publicationStatus =
         manifest.deliveryCapabilities.onlineAccess ||
         (options.activateForLocalDevelopment &&
@@ -413,46 +413,46 @@ export const importPublicationBundle = (
                     resource_revision: manifest.revision,
                     offline_entry: manifest.offlineArtifact.entry,
                   }
-            : isInterlinearBiblePublicationBundleManifest(manifest)
-              ? {
-                  version_id: manifest.identity.versionId,
-                  dataset_id: manifest.identity.datasetId,
-                  language: manifest.identity.language,
-                  delivery_capabilities: manifest.deliveryCapabilities,
-                  dependencies: manifest.dependencies,
-                  counts: manifest.counts,
-                  canonical_schema_version: manifest.canonical.schemaVersion,
-                  resource_revision: manifest.revision,
-                  text_revision: manifest.dependencies.bible.revision,
-                  text_sha256: manifest.dependencies.bible.textSha256,
-                  offline_entry: manifest.offlineArtifact.entry,
-                }
-              : isStrongLexiconPublicationBundleManifest(manifest)
-                ? {
-                    module_id: manifest.identity.moduleId,
-                    delivery_capabilities: manifest.deliveryCapabilities,
-                    dependencies: manifest.dependencies,
-                    counts: manifest.counts,
-                    canonical_schema_version: manifest.canonical.schemaVersion,
-                    resource_revision: manifest.revision,
-                    offline_entry: manifest.offlineArtifact.entry,
-                  }
-                : {
-                    version_id: manifest.identity.versionId,
-                    dataset_id: manifest.identity.datasetId,
-                    delivery_capabilities: manifest.deliveryCapabilities,
-                    dependencies: manifest.dependencies,
-                    counts: manifest.counts,
-                    canonical_schema_version: manifest.canonical.schemaVersion,
-                    resource_revision: manifest.revision,
-                    text_revision: manifest.dependencies.bible.revision,
-                    text_sha256: manifest.dependencies.bible.textSha256,
-                    strong_revision:
-                      canonical.format === 'bible-strong-canonical-strong-index'
-                        ? canonical.strongRevision
-                        : undefined,
-                    offline_entry: manifest.offlineArtifact.entry,
-                  }
+                : isInterlinearBiblePublicationBundleManifest(manifest)
+                  ? {
+                      version_id: manifest.identity.versionId,
+                      dataset_id: manifest.identity.datasetId,
+                      language: manifest.identity.language,
+                      delivery_capabilities: manifest.deliveryCapabilities,
+                      dependencies: manifest.dependencies,
+                      counts: manifest.counts,
+                      canonical_schema_version: manifest.canonical.schemaVersion,
+                      resource_revision: manifest.revision,
+                      text_revision: manifest.dependencies.bible.revision,
+                      text_sha256: manifest.dependencies.bible.textSha256,
+                      offline_entry: manifest.offlineArtifact.entry,
+                    }
+                  : isStrongLexiconPublicationBundleManifest(manifest)
+                    ? {
+                        module_id: manifest.identity.moduleId,
+                        delivery_capabilities: manifest.deliveryCapabilities,
+                        dependencies: manifest.dependencies,
+                        counts: manifest.counts,
+                        canonical_schema_version: manifest.canonical.schemaVersion,
+                        resource_revision: manifest.revision,
+                        offline_entry: manifest.offlineArtifact.entry,
+                      }
+                    : {
+                        version_id: manifest.identity.versionId,
+                        dataset_id: manifest.identity.datasetId,
+                        delivery_capabilities: manifest.deliveryCapabilities,
+                        dependencies: manifest.dependencies,
+                        counts: manifest.counts,
+                        canonical_schema_version: manifest.canonical.schemaVersion,
+                        resource_revision: manifest.revision,
+                        text_revision: manifest.dependencies.bible.revision,
+                        text_sha256: manifest.dependencies.bible.textSha256,
+                        strong_revision:
+                          canonical.format === 'bible-strong-canonical-strong-index'
+                            ? canonical.strongRevision
+                            : undefined,
+                        offline_entry: manifest.offlineArtifact.entry,
+                      }
       const publicationMetadata = { ...metadata, manifest_sha256: manifestSha256 }
       const makeResult = (status: PublicationImportResult['status']): PublicationImportResult =>
         isBiblePublicationBundleManifest(manifest)
@@ -476,43 +476,43 @@ export const importPublicationBundle = (
                   revision: manifest.revision,
                   itemCount: manifest.counts.entries,
                 }
-            : isCommentaryPublicationBundleManifest(manifest)
-              ? {
-                  status,
-                  resourceIdentity,
-                  revision: manifest.revision,
-                  itemCount: manifest.counts.verses,
-                }
-              : isCrossReferencePublicationBundleManifest(manifest)
+              : isCommentaryPublicationBundleManifest(manifest)
                 ? {
                     status,
                     resourceIdentity,
                     revision: manifest.revision,
-                    itemCount: manifest.counts.references,
+                    itemCount: manifest.counts.verses,
                   }
-            : isInterlinearBiblePublicationBundleManifest(manifest)
-                ? {
-                    status,
-                    resourceIdentity,
-                    revision: manifest.revision,
-                    itemCount: manifest.counts.segments,
-                  }
-                : isStrongLexiconPublicationBundleManifest(manifest)
+                : isCrossReferencePublicationBundleManifest(manifest)
                   ? {
                       status,
                       resourceIdentity,
                       revision: manifest.revision,
-                      itemCount: Object.values(manifest.counts).reduce(
-                        (total, count) => total + count,
-                        0
-                      ),
+                      itemCount: manifest.counts.references,
                     }
-                  : {
-                      status,
-                      resourceIdentity,
-                      revision: manifest.revision,
-                      itemCount: manifest.counts.occurrences,
-                    }
+                  : isInterlinearBiblePublicationBundleManifest(manifest)
+                    ? {
+                        status,
+                        resourceIdentity,
+                        revision: manifest.revision,
+                        itemCount: manifest.counts.segments,
+                      }
+                    : isStrongLexiconPublicationBundleManifest(manifest)
+                      ? {
+                          status,
+                          resourceIdentity,
+                          revision: manifest.revision,
+                          itemCount: Object.values(manifest.counts).reduce(
+                            (total, count) => total + count,
+                            0
+                          ),
+                        }
+                      : {
+                          status,
+                          resourceIdentity,
+                          revision: manifest.revision,
+                          itemCount: manifest.counts.occurrences,
+                        }
 
       return tryDatabasePromise(
         'publication.import',

--- a/resource-service/src/repositories/supplementaryRepository.ts
+++ b/resource-service/src/repositories/supplementaryRepository.ts
@@ -1,0 +1,129 @@
+import { Effect } from 'effect'
+import { type Kysely } from 'kysely'
+
+import { tryDatabasePromise } from '../database/databaseEffect'
+import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
+import type { ResourceDatabase } from '../database/types'
+import {
+  ActiveSupplementaryPublicationUnavailable,
+  SupplementaryContentNotFound,
+  SupplementaryRepositoryFailure,
+  type SupplementaryRepositoryService,
+} from '../domain/supplementary'
+
+const commentaryIdentity = 'commentary:MHY:fr'
+const crossReferenceIdentity = 'cross-references:fr'
+
+export const makeKyselySupplementaryRepository = (
+  database: Kysely<ResourceDatabase>
+): SupplementaryRepositoryService => {
+  const findActivePublication = (resourceIdentity: string) =>
+    tryDatabasePromise('supplementary.publication.read-active', () =>
+      database
+        .selectFrom('resource_publications')
+        .select(['id', 'revision'])
+        .where('resource_identity', '=', resourceIdentity)
+        .where('status', '=', 'active')
+        .executeTakeFirst()
+    ).pipe(Effect.mapError(cause => new SupplementaryRepositoryFailure({ cause })))
+
+  return {
+    findCommentaryVerse: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(commentaryIdentity)
+        if (!publication) {
+          return yield* new ActiveSupplementaryPublicationUnavailable({
+            resourceIdentity: commentaryIdentity,
+          })
+        }
+        const row = yield* tryDatabasePromise('supplementary.commentary.read-verse', () =>
+          database
+            .selectFrom('commentary_verses')
+            .select(['verse_key', 'content'])
+            .where('publication_id', '=', publication.id)
+            .where('verse_key', '=', input.verseKey)
+            .executeTakeFirst()
+        ).pipe(Effect.mapError(cause => new SupplementaryRepositoryFailure({ cause })))
+        if (!row) {
+          return yield* new SupplementaryContentNotFound({
+            resourceIdentity: commentaryIdentity,
+            verseKey: input.verseKey,
+          })
+        }
+        return {
+          ...input,
+          revision: publication.revision,
+          verseKey: row.verse_key,
+          content: row.content,
+        }
+      }),
+    findCommentaryChapter: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(commentaryIdentity)
+        if (!publication) {
+          return yield* new ActiveSupplementaryPublicationUnavailable({
+            resourceIdentity: commentaryIdentity,
+          })
+        }
+        const prefix = `${input.book}-${input.chapter}-`
+        const rows = yield* tryDatabasePromise('supplementary.commentary.read-chapter', () =>
+          database
+            .selectFrom('commentary_verses')
+            .select(['verse_key', 'content'])
+            .where('publication_id', '=', publication.id)
+            .where('verse_key', 'like', `${prefix}%`)
+            .orderBy('verse_key')
+            .execute()
+        ).pipe(Effect.mapError(cause => new SupplementaryRepositoryFailure({ cause })))
+        if (rows.length === 0) {
+          return yield* new SupplementaryContentNotFound({
+            resourceIdentity: commentaryIdentity,
+          })
+        }
+        return {
+          ...input,
+          revision: publication.revision,
+          comments: Object.fromEntries(
+            rows.map(row => [row.verse_key.slice(prefix.length), row.content])
+          ),
+        }
+      }),
+    findCrossReferences: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(crossReferenceIdentity)
+        if (!publication) {
+          return yield* new ActiveSupplementaryPublicationUnavailable({
+            resourceIdentity: crossReferenceIdentity,
+          })
+        }
+        const rows = yield* tryDatabasePromise('supplementary.cross-references.read-verse', () =>
+          database
+            .selectFrom('cross_reference_links')
+            .select(['reference'])
+            .where('publication_id', '=', publication.id)
+            .where('verse_key', '=', input.verseKey)
+            .orderBy('ordinal')
+            .execute()
+        ).pipe(Effect.mapError(cause => new SupplementaryRepositoryFailure({ cause })))
+        if (rows.length === 0) {
+          return yield* new SupplementaryContentNotFound({
+            resourceIdentity: crossReferenceIdentity,
+            verseKey: input.verseKey,
+          })
+        }
+        return {
+          ...input,
+          revision: publication.revision,
+          references: rows.map(row => row.reference),
+        }
+      }),
+  }
+}
+
+export const makeNeonSupplementaryRepository = (config: NeonDatabaseConfig) => {
+  const database = makeNeonDatabase(config)
+  return {
+    repository: makeKyselySupplementaryRepository(database),
+    dispose: () => database.destroy(),
+  }
+}

--- a/resource-service/src/runtime/developmentArtifacts.ts
+++ b/resource-service/src/runtime/developmentArtifacts.ts
@@ -18,8 +18,15 @@ export const createDevelopmentArtifact = (
     manifest.identity.kind === 'nave' && manifest.identity.language === 'en'
       ? '/databases/en'
       : '/databases'
+  const databaseKinds = new Set([
+    'nave',
+    'dictionary',
+    'commentary',
+    'cross-references',
+    'strong-lexicon-module',
+  ])
   return {
-    route: `${manifest.identity.kind === 'nave' || manifest.identity.kind === 'strong-lexicon-module' ? databasePrefix : '/bibles'}/${filename}`,
+    route: `${databaseKinds.has(manifest.identity.kind) ? databasePrefix : '/bibles'}/${filename}`,
     bytes,
     headers: {
       'content-type': manifest.offlineArtifact.mediaType,

--- a/resource-service/src/runtime/node.ts
+++ b/resource-service/src/runtime/node.ts
@@ -11,6 +11,7 @@ import { DictionaryRepository } from '../domain/dictionary'
 import { StrongBibleRepository } from '../domain/strongBible'
 import { InterlinearBibleRepository } from '../domain/interlinearBible'
 import { StrongLexiconRepository } from '../domain/strongLexicon'
+import { SupplementaryRepository } from '../domain/supplementary'
 import { ResourceApiLive } from '../http/app'
 import { makeKyselyBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeKyselyNaveRepository } from '../repositories/naveRepository'
@@ -18,6 +19,7 @@ import { makeKyselyDictionaryRepository } from '../repositories/dictionaryReposi
 import { makeKyselyStrongBibleRepository } from '../repositories/strongBibleRepository'
 import { makeKyselyInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeKyselyStrongLexiconRepository } from '../repositories/strongLexiconRepository'
+import { makeKyselySupplementaryRepository } from '../repositories/supplementaryRepository'
 
 const port = Number(process.env.RESOURCE_API_PORT ?? 8787)
 const database = makeLocalDatabase({
@@ -37,7 +39,8 @@ const RepositoryLive = Layer.mergeAll(
   Layer.succeed(DictionaryRepository, makeKyselyDictionaryRepository(database)),
   Layer.succeed(StrongBibleRepository, makeKyselyStrongBibleRepository(database)),
   Layer.succeed(InterlinearBibleRepository, makeKyselyInterlinearBibleRepository(database)),
-  Layer.succeed(StrongLexiconRepository, makeKyselyStrongLexiconRepository(database))
+  Layer.succeed(StrongLexiconRepository, makeKyselyStrongLexiconRepository(database)),
+  Layer.succeed(SupplementaryRepository, makeKyselySupplementaryRepository(database))
 )
 const ApiLive = ResourceApiLive.pipe(Layer.provide(RepositoryLive))
 

--- a/resource-service/src/runtime/worker.ts
+++ b/resource-service/src/runtime/worker.ts
@@ -5,12 +5,14 @@ import type { DictionaryRepositoryService } from '../domain/dictionary'
 import type { StrongBibleRepositoryService } from '../domain/strongBible'
 import type { InterlinearBibleRepositoryService } from '../domain/interlinearBible'
 import type { StrongLexiconRepositoryService } from '../domain/strongLexicon'
+import type { SupplementaryRepositoryService } from '../domain/supplementary'
 import { makeNeonBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeNeonNaveRepository } from '../repositories/naveRepository'
 import { makeNeonDictionaryRepository } from '../repositories/dictionaryRepository'
 import { makeNeonStrongBibleRepository } from '../repositories/strongBibleRepository'
 import { makeNeonInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeNeonStrongLexiconRepository } from '../repositories/strongLexiconRepository'
+import { makeNeonSupplementaryRepository } from '../repositories/supplementaryRepository'
 
 export type ResourceWorkerBindings = {
   RESOURCE_DATABASE_URL: string
@@ -22,13 +24,15 @@ export const makeResourceWorkerHandler = (
   dictionaryRepository?: DictionaryRepositoryService,
   strongBibleRepository?: StrongBibleRepositoryService,
   interlinearBibleRepository?: InterlinearBibleRepositoryService,
-  strongLexiconRepository?: StrongLexiconRepositoryService
+  strongLexiconRepository?: StrongLexiconRepositoryService,
+  supplementaryRepository?: SupplementaryRepositoryService
 ) =>
   makeResourceWebHandler(repository, naveRepository, {
     dictionary: dictionaryRepository,
     strongBible: strongBibleRepository,
     interlinearBible: interlinearBibleRepository,
     strongLexicon: strongLexiconRepository,
+    supplementary: supplementaryRepository,
   })
 
 let cached:
@@ -50,13 +54,17 @@ const getWorkerHandler = (connectionString: string) => {
   const { repository: strongLexiconRepository } = makeNeonStrongLexiconRepository({
     connectionString,
   })
+  const { repository: supplementaryRepository } = makeNeonSupplementaryRepository({
+    connectionString,
+  })
   const web = makeResourceWorkerHandler(
     repository,
     naveRepository,
     dictionaryRepository,
     strongBibleRepository,
     interlinearBibleRepository,
-    strongLexiconRepository
+    strongLexiconRepository,
+    supplementaryRepository
   )
   cached = { connectionString, web }
   return web

--- a/scripts/smokeSupplementaryResourceArtifacts.mjs
+++ b/scripts/smokeSupplementaryResourceArtifacts.mjs
@@ -1,0 +1,17 @@
+const baseUrl = process.env.RESOURCE_ARTIFACT_BASE_URL ?? 'http://127.0.0.1:8789'
+const artifacts = [
+  ['/databases/commentaires-mhy.sqlite.zip', process.env.MHY_BUNDLE],
+  ['/databases/commentaires-tresor.sqlite.zip', process.env.TRESOR_BUNDLE],
+]
+
+for (const [path, bundle] of artifacts) {
+  const manifest = JSON.parse(await readFile(`${bundle}/manifest.json`, 'utf8'))
+  const response = await fetch(`${baseUrl}${path}`, { method: 'HEAD' })
+  if (response.status !== 200) throw new Error(`supplementary-artifact-http:${path}:${response.status}`)
+  if (Number(response.headers.get('content-length')) !== manifest.offlineArtifact.bytes) {
+    throw new Error(`supplementary-artifact-size:${path}`)
+  }
+}
+
+console.log('supplementary-resource-artifacts-smoke:ok')
+import { readFile } from 'node:fs/promises'

--- a/scripts/smokeSupplementaryResourceArtifacts.mjs
+++ b/scripts/smokeSupplementaryResourceArtifacts.mjs
@@ -7,7 +7,8 @@ const artifacts = [
 for (const [path, bundle] of artifacts) {
   const manifest = JSON.parse(await readFile(`${bundle}/manifest.json`, 'utf8'))
   const response = await fetch(`${baseUrl}${path}`, { method: 'HEAD' })
-  if (response.status !== 200) throw new Error(`supplementary-artifact-http:${path}:${response.status}`)
+  if (response.status !== 200)
+    throw new Error(`supplementary-artifact-http:${path}:${response.status}`)
   if (Number(response.headers.get('content-length')) !== manifest.offlineArtifact.bytes) {
     throw new Error(`supplementary-artifact-size:${path}`)
   }

--- a/scripts/smokeSupplementaryResourceService.mjs
+++ b/scripts/smokeSupplementaryResourceService.mjs
@@ -1,0 +1,39 @@
+const baseUrl = process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787'
+
+const getJson = async path => {
+  const response = await fetch(`${baseUrl}${path}`, { headers: { accept: 'application/json' } })
+  const body = await response.json().catch(() => undefined)
+  if (!response.ok) throw new Error(`supplementary-smoke-http:${path}:${response.status}`)
+  return { body, headers: response.headers }
+}
+
+const commentary = await getJson('/v1/commentaries/MHY/fr/verses/1-1-1')
+if (commentary.body.resource.resourceId !== 'MHY' || commentary.body.content.length === 0) {
+  throw new Error('supplementary-smoke-commentary-invalid')
+}
+const chapter = await getJson('/v1/commentaries/MHY/fr/chapters/1/1')
+const chapterComments = JSON.parse(chapter.body.serializedComments)
+if (chapter.body.book !== 1 || chapterComments['1'] !== commentary.body.content) {
+  throw new Error('supplementary-smoke-chapter-invalid')
+}
+const references = await getJson('/v1/cross-references/fr/verses/1-1-1')
+if (
+  references.body.resource.resourceId !== 'TRESOR' ||
+  !Array.isArray(references.body.references) ||
+  references.body.references.length === 0
+) {
+  throw new Error('supplementary-smoke-cross-references-invalid')
+}
+const cached = await fetch(`${baseUrl}/v1/commentaries/MHY/fr/verses/1-1-1`, {
+  headers: { accept: 'application/json', 'if-none-match': commentary.headers.get('etag') },
+})
+if (cached.status !== 304) throw new Error(`supplementary-smoke-etag:${cached.status}`)
+
+console.log(
+  JSON.stringify({
+    commentaryRevision: commentary.body.resource.revision,
+    commentaryBytes: commentary.body.content.length,
+    crossReferenceCount: references.body.references.length,
+    etag: cached.status,
+  })
+)

--- a/src/assets/mobile-resource-catalog.json
+++ b/src/assets/mobile-resource-catalog.json
@@ -1497,15 +1497,15 @@
       "entries": {
         "canonical": {
           "entry": "commentaires-mhy.sqlite",
-          "sha256": "163c2e15d40394b6f141f8e1b0c748697f0c7c509be3a85205d70f6b42728fc5",
-          "bytes": 6574080
+          "sha256": "5f5d6e28f561957be09c8eaa1bee51afd52b073c4a572ae0b6474b90fe7ce111",
+          "bytes": 6575104
         }
       },
-      "archiveSha256": "1e6bf8466591fc846e1c4ec239c4821e7e1efb2a545e1b907f2716160c9b8aaa",
-      "archiveBytes": 1916604,
-      "contentSha256": "163c2e15d40394b6f141f8e1b0c748697f0c7c509be3a85205d70f6b42728fc5",
-      "contentBytes": 6574080,
-      "installedBytes": 6574080,
+      "archiveSha256": "12cb45899b302190c362b39158bc399bc7e5d2d035ae9c25e49d396b1ff63031",
+      "archiveBytes": 1943754,
+      "contentSha256": "5f5d6e28f561957be09c8eaa1bee51afd52b073c4a572ae0b6474b90fe7ce111",
+      "contentBytes": 6575104,
+      "installedBytes": 6575104,
       "peakInstallationBytes": 9764287,
       "strategy": "archive-extract"
     },
@@ -1597,15 +1597,15 @@
       "entries": {
         "canonical": {
           "entry": "commentaires-tresor.sqlite",
-          "sha256": "94d4dc0303f081ebc617ffb935437d8e4a44114c68e3d84d8e7d98701f7afebd",
-          "bytes": 5434368
+          "sha256": "cc5575bdf73ff43c2e44d1f5fe2de2a480f9d12e57e2152b7b437ff6c1771032",
+          "bytes": 5435392
         }
       },
-      "archiveSha256": "130696759f14fa1eeb30ea5edc9fd51a954168ffd55467a674133c0eaf3bda1a",
-      "archiveBytes": 1851318,
-      "contentSha256": "94d4dc0303f081ebc617ffb935437d8e4a44114c68e3d84d8e7d98701f7afebd",
-      "contentBytes": 5434368,
-      "installedBytes": 5434368,
+      "archiveSha256": "77a06354a28689085dec7c5c3e1593bdbf7944db22d075c42b67a24b32789f9c",
+      "archiveBytes": 1887092,
+      "contentSha256": "cc5575bdf73ff43c2e44d1f5fe2de2a480f9d12e57e2152b7b437ff6c1771032",
+      "contentBytes": 5435392,
+      "installedBytes": 5435392,
       "peakInstallationBytes": 8378539,
       "strategy": "archive-extract"
     },

--- a/src/features/resources/bibleReadingResourceAccess.ts
+++ b/src/features/resources/bibleReadingResourceAccess.ts
@@ -15,6 +15,7 @@ import type { OfflineCopyIdentity } from '~helpers/offlineCopyId'
 import { getCanonicalChapterPericope } from '~helpers/canonicalBibleHeadings'
 import { Schema } from 'effect'
 import { BiblePericopeIndexDto } from './bibleChapterContract'
+import { CommentaryChapterResponseDto, CrossReferenceResponseDto } from './supplementaryContract'
 
 export type BibleChapterComments = { serializedComments: string }
 
@@ -146,7 +147,12 @@ export const createHttpBibleReadingResourceAccess = ({
   timeoutMs = 8_000,
 }: HttpBibleReadingOptions): Pick<
   BibleReadingResourceAccess,
-  'getPericopeAvailability' | 'loadPericope'
+  | 'getPericopeAvailability'
+  | 'loadPericope'
+  | 'getMhyAvailability'
+  | 'loadMhyComments'
+  | 'getTresorAvailability'
+  | 'loadTresorReferences'
 > => ({
   getPericopeAvailability: async () =>
     (await isOnline()) ? { status: 'available' } : { status: 'unsupported' },
@@ -174,11 +180,83 @@ export const createHttpBibleReadingResourceAccess = ({
       clearTimeout(timeout)
     }
   },
+  getMhyAvailability: async language =>
+    language === 'fr'
+      ? (await isOnline())
+        ? { status: 'available' }
+        : {
+            status: 'unavailable',
+            reason: 'offline-copy-required',
+            recoveryIdentity: { kind: 'database', databaseId: 'MHY', language: 'fr' },
+          }
+      : { status: 'unsupported' },
+  loadMhyComments: async (book, chapter) => {
+    if (!(await isOnline())) throw new Error('COMMENTARY_HTTP_OFFLINE')
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(
+        `${baseUrl.replace(/\/$/, '')}/v1/commentaries/MHY/fr/chapters/${book}/${chapter}`,
+        { headers: { accept: 'application/json' }, signal: controller.signal }
+      )
+      if (!response.ok) {
+        if (response.status === 404) return undefined
+        throw new Error(`COMMENTARY_HTTP_${response.status}`)
+      }
+      const decoded = Schema.decodeUnknownSync(CommentaryChapterResponseDto)(await response.json())
+      if (decoded.book !== book || decoded.chapter !== chapter) {
+        throw new Error('COMMENTARY_HTTP_INTEGRITY')
+      }
+      return { serializedComments: decoded.serializedComments }
+    } finally {
+      clearTimeout(timeout)
+    }
+  },
+  getTresorAvailability: async language =>
+    language === 'fr'
+      ? (await isOnline())
+        ? { status: 'available' }
+        : {
+            status: 'unavailable',
+            reason: 'offline-copy-required',
+            recoveries: ['acquire-offline-copy'],
+          }
+      : {
+          status: 'unavailable',
+          reason: 'offline-copy-required',
+          recoveries: ['acquire-offline-copy'],
+        },
+  loadTresorReferences: async verse => {
+    if (!(await isOnline())) throw new Error('CROSS_REFERENCES_HTTP_OFFLINE')
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(
+        `${baseUrl.replace(/\/$/, '')}/v1/cross-references/fr/verses/${encodeURIComponent(verse)}`,
+        { headers: { accept: 'application/json' }, signal: controller.signal }
+      )
+      if (!response.ok) {
+        if (response.status === 404) return undefined
+        throw new Error(`CROSS_REFERENCES_HTTP_${response.status}`)
+      }
+      const decoded = Schema.decodeUnknownSync(CrossReferenceResponseDto)(await response.json())
+      if (decoded.verseKey !== verse) throw new Error('CROSS_REFERENCES_HTTP_INTEGRITY')
+      return [...decoded.references]
+    } finally {
+      clearTimeout(timeout)
+    }
+  },
 })
 
 export const createHybridBibleReadingResourceAccess = (options: {
   local: BibleReadingResourceAccess
-  online: Pick<BibleReadingResourceAccess, 'getPericopeAvailability' | 'loadPericope'>
+  online: Pick<BibleReadingResourceAccess, 'getPericopeAvailability' | 'loadPericope'> &
+    Partial<
+      Pick<
+        BibleReadingResourceAccess,
+        'getMhyAvailability' | 'loadMhyComments' | 'getTresorAvailability' | 'loadTresorReferences'
+      >
+    >
   remotelyReadableVersions: ReadonlySet<string>
   isOnline: () => Promise<boolean>
 }): BibleReadingResourceAccess => ({
@@ -198,5 +276,43 @@ export const createHybridBibleReadingResourceAccess = (options: {
       return options.online.loadPericope(version)
     }
     return options.local.loadPericope(version)
+  },
+  getMhyAvailability: async language => {
+    const local = await options.local.getMhyAvailability?.(language)
+    if (local?.status === 'available') return local
+    if (language === 'fr' && (await options.isOnline()) && options.online.getMhyAvailability) {
+      return options.online.getMhyAvailability(language)
+    }
+    return local ?? { status: 'unsupported' }
+  },
+  loadMhyComments: async (book, chapter) => {
+    const local = await options.local.getMhyAvailability?.('fr')
+    if (local?.status === 'available') return options.local.loadMhyComments(book, chapter)
+    if ((await options.isOnline()) && options.online.loadMhyComments) {
+      return options.online.loadMhyComments(book, chapter)
+    }
+    return options.local.loadMhyComments(book, chapter)
+  },
+  getTresorAvailability: async language => {
+    const local = await options.local.getTresorAvailability?.(language)
+    if (local?.status === 'available') return local
+    if (language === 'fr' && (await options.isOnline()) && options.online.getTresorAvailability) {
+      return options.online.getTresorAvailability(language)
+    }
+    return (
+      local ?? {
+        status: 'unavailable',
+        reason: 'offline-copy-required',
+        recoveries: ['acquire-offline-copy'],
+      }
+    )
+  },
+  loadTresorReferences: async verse => {
+    const local = await options.local.getTresorAvailability?.('fr')
+    if (local?.status === 'available') return options.local.loadTresorReferences(verse)
+    if ((await options.isOnline()) && options.online.loadTresorReferences) {
+      return options.online.loadTresorReferences(verse)
+    }
+    return options.local.loadTresorReferences(verse)
   },
 })

--- a/src/features/resources/commentaryAccess.ts
+++ b/src/features/resources/commentaryAccess.ts
@@ -5,6 +5,8 @@ import type { ResourceLanguage } from '~helpers/databaseTypes'
 import { firebaseDb } from '~helpers/firebase'
 import loadMhyComments from '~helpers/loadMhyComments'
 import { getLocalResourceAvailability } from './resourceAvailability'
+import { Schema } from 'effect'
+import { CommentaryVerseResponseDto } from './supplementaryContract'
 import {
   mapLocalResourceError,
   ResourceAccessError,
@@ -141,14 +143,92 @@ export const firestoreCommentaryAccess: CommentaryAccess = {
   },
 }
 
+type HttpCommentaryAccessOptions = {
+  baseUrl: string
+  fetcher?: typeof fetch
+  isOnline: () => Promise<boolean>
+  timeoutMs?: number
+}
+
+export const createHttpCommentaryAccess = ({
+  baseUrl,
+  fetcher = fetch,
+  isOnline,
+  timeoutMs = 8_000,
+}: HttpCommentaryAccessOptions): CommentaryAccess => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const loadVersePage = async (verse: string, afterOrder?: number): Promise<Comments> => {
+    if (afterOrder != null) return { id: verse, count: 1, comments: [] }
+    if (!(await isOnline())) throw new ResourceAccessError('NETWORK_OFFLINE')
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(
+        `${normalizedBaseUrl}/v1/commentaries/MHY/fr/verses/${encodeURIComponent(verse)}`,
+        { headers: { accept: 'application/json' }, signal: controller.signal }
+      )
+      const payload: unknown = await response.json().catch(() => undefined)
+      if (!response.ok) {
+        const code =
+          payload && typeof payload === 'object' && 'code' in payload ? payload.code : undefined
+        if (response.status === 404 && code === 'SUPPLEMENTARY_CONTENT_NOT_FOUND') {
+          throw new CommentaryAccessError('NOT_FOUND')
+        }
+        throw new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+      }
+      let decoded: Schema.Schema.Type<typeof CommentaryVerseResponseDto>
+      try {
+        decoded = Schema.decodeUnknownSync(CommentaryVerseResponseDto)(payload)
+      } catch {
+        throw new ResourceAccessError('INTEGRITY_FAILURE')
+      }
+      if (decoded.verseKey !== verse || decoded.resource.resourceId !== 'MHY') {
+        throw new ResourceAccessError('INTEGRITY_FAILURE')
+      }
+      return {
+        id: verse,
+        count: 1,
+        comments: [
+          {
+            id: `MHY-${verse}`,
+            verseId: verse,
+            content: decoded.content,
+            resource: {
+              name: 'Commentaire concis de la Bible',
+              code: 'MHY',
+              logo: '',
+              author: 'Matthew Henry',
+            },
+            order: 0,
+            type: 'comment',
+            isSDA: false,
+          },
+        ],
+      }
+    } catch (error) {
+      if (error instanceof CommentaryAccessError || error instanceof ResourceAccessError) {
+        throw error
+      }
+      throw new ResourceAccessError(
+        (await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE'
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+  return { loadVersePage }
+}
+
 export const createCommentaryAccess = ({
   isOnline = async () => onlineManager.isOnline(),
   local = localMhyCommentaryAccess,
   remote = firestoreCommentaryAccess,
+  combineResults = true,
 }: {
   isOnline?: () => Promise<boolean>
   local?: CommentaryAccess
   remote?: CommentaryAccess
+  combineResults?: boolean
 } = {}): CommentaryAccess => ({
   async loadVersePage(verse, afterOrder, language = 'fr') {
     if (language !== 'fr') {
@@ -169,6 +249,7 @@ export const createCommentaryAccess = ({
         : Promise.reject(new ResourceAccessError('TEMPORARY_UNAVAILABLE')),
     ])
 
+    if (localResult.status === 'fulfilled' && !combineResults) return localResult.value
     if (localResult.status === 'fulfilled' && remoteResult.status === 'fulfilled') {
       return {
         id: verse,

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -64,6 +64,8 @@ import {
 } from '~features/resources/interlinearBibleResourceAccess'
 import { localTimelineAccess, type TimelineAccess } from '~features/resources/timelineAccess'
 import {
+  createHttpCommentaryAccess,
+  createCommentaryAccess,
   defaultCommentaryAccess,
   type CommentaryAccess,
 } from '~features/resources/commentaryAccess'
@@ -139,12 +141,19 @@ const onlineNaveAccess = resourceApiBaseUrl
       isOnline: async () => onlineManager.isOnline(),
     })
   : unavailableHttpNaveAccess
+const onlineCommentaryAccess = resourceApiBaseUrl
+  ? createHttpCommentaryAccess({
+      baseUrl: resourceApiBaseUrl,
+      isOnline: async () => onlineManager.isOnline(),
+    })
+  : undefined
 const remotelyReadableDictionaryLanguages = new Set<ResourceLanguage>(
   resourceApiBaseUrl ? ['fr', 'en'] : []
 )
 const remotelyReadableNaveLanguages = new Set<ResourceLanguage>(
   resourceApiBaseUrl ? ['fr', 'en'] : []
 )
+const remotelyReadableCommentaryCollections = new Set<string>(resourceApiBaseUrl ? ['MHY'] : [])
 const onlineDictionaryAccess = resourceApiBaseUrl
   ? createHttpDictionaryAccess({
       baseUrl: resourceApiBaseUrl,
@@ -216,7 +225,22 @@ const onlineBibleReadingAccess = resourceApiBaseUrl
       loadPericope: async () => {
         throw new Error('BIBLE_PERICOPE_HTTP_UNCONFIGURED')
       },
+      getMhyAvailability: async () => ({ status: 'unsupported' as const }),
+      loadMhyComments: async () => {
+        throw new Error('COMMENTARY_HTTP_UNCONFIGURED')
+      },
+      getTresorAvailability: async () => ({
+        status: 'unavailable' as const,
+        reason: 'offline-copy-required' as const,
+        recoveries: ['acquire-offline-copy' as const],
+      }),
+      loadTresorReferences: async () => {
+        throw new Error('CROSS_REFERENCES_HTTP_UNCONFIGURED')
+      },
     }
+const commentaryAccess = onlineCommentaryAccess
+  ? createCommentaryAccess({ remote: onlineCommentaryAccess, combineResults: false })
+  : defaultCommentaryAccess
 
 export const defaultResourceAccess: ResourceAccessRegistry = {
   bibleContent: createBibleContentAccess(
@@ -249,7 +273,7 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
   strongBible: strongBibleAccess,
   interlinearBible: interlinearBibleAccess,
   timeline: localTimelineAccess,
-  commentary: defaultCommentaryAccess,
+  commentary: commentaryAccess,
   offlineCopies: { isAvailable: isLocalResourceAvailable },
   capabilities: {
     getOnlineAccess: identity =>
@@ -260,7 +284,9 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
         remotelyReadableStrongBibleVersions,
         remotelyReadableInterlinearLocales,
         remotelyReadableStrongLexiconModules,
-        remotelyReadableDictionaryLanguages
+        remotelyReadableDictionaryLanguages,
+        remotelyReadableCommentaryCollections,
+        Boolean(resourceApiBaseUrl)
       ),
   },
 }

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -78,7 +78,9 @@ export const getResourceOnlineAccess = (
   remotelyReadableStrongBibleVersions: ReadonlySet<string> = new Set(),
   remotelyReadableInterlinearLanguages: ReadonlySet<ResourceLanguage> = new Set(),
   remotelyReadableStrongLexiconModules: ReadonlySet<string> = new Set(),
-  remotelyReadableDictionaryLanguages: ReadonlySet<ResourceLanguage> = new Set()
+  remotelyReadableDictionaryLanguages: ReadonlySet<ResourceLanguage> = new Set(),
+  remotelyReadableCommentaryCollections: ReadonlySet<string> = new Set(),
+  remotelyReadableCrossReferences = false
 ): OnlineAccessState =>
   (identity.kind === 'bible-text' && remotelyReadableBibleVersions.has(identity.versionId)) ||
   (identity.kind === 'strong-bible-index' &&
@@ -89,7 +91,9 @@ export const getResourceOnlineAccess = (
     remotelyReadableStrongLexiconModules.has(identity.moduleId)) ||
   (identity.kind === 'dictionary' && remotelyReadableDictionaryLanguages.has(identity.language)) ||
   (identity.kind === 'nave' && remotelyReadableNaveLanguages.has(identity.language)) ||
-  (identity.kind === 'commentary' && identity.collection === 'FIRESTORE')
+  (identity.kind === 'commentary' &&
+    remotelyReadableCommentaryCollections.has(identity.collection)) ||
+  (identity.kind === 'cross-references' && remotelyReadableCrossReferences)
     ? { status: 'remotely-readable' }
     : { status: 'unsupported' }
 

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -92,7 +92,8 @@ export const getResourceOnlineAccess = (
   (identity.kind === 'dictionary' && remotelyReadableDictionaryLanguages.has(identity.language)) ||
   (identity.kind === 'nave' && remotelyReadableNaveLanguages.has(identity.language)) ||
   (identity.kind === 'commentary' &&
-    remotelyReadableCommentaryCollections.has(identity.collection)) ||
+    (identity.collection === 'FIRESTORE' ||
+      remotelyReadableCommentaryCollections.has(identity.collection))) ||
   (identity.kind === 'cross-references' && remotelyReadableCrossReferences)
     ? { status: 'remotely-readable' }
     : { status: 'unsupported' }

--- a/src/features/resources/supplementaryContract.ts
+++ b/src/features/resources/supplementaryContract.ts
@@ -1,0 +1,57 @@
+import { Schema } from 'effect'
+
+const VerseKey = Schema.String.pipe(Schema.pattern(/^[1-9]\d*-[1-9]\d*-(?:0|[1-9]\d*)$/u))
+
+export class CommentaryPath extends Schema.Class<CommentaryPath>('CommentaryPath')({
+  collection: Schema.Literal('MHY'),
+  language: Schema.Literal('fr'),
+  verseKey: VerseKey,
+}) {}
+
+export class CommentaryChapterPath extends Schema.Class<CommentaryChapterPath>(
+  'CommentaryChapterPath'
+)({
+  collection: Schema.Literal('MHY'),
+  language: Schema.Literal('fr'),
+  book: Schema.NumberFromString.pipe(Schema.int(), Schema.positive()),
+  chapter: Schema.NumberFromString.pipe(Schema.int(), Schema.positive()),
+}) {}
+
+export class CrossReferencePath extends Schema.Class<CrossReferencePath>('CrossReferencePath')({
+  language: Schema.Literal('fr'),
+  verseKey: VerseKey,
+}) {}
+
+export class SupplementaryRevisionDto extends Schema.Class<SupplementaryRevisionDto>(
+  'SupplementaryRevisionDto'
+)({
+  kind: Schema.Literal('commentary', 'cross-references'),
+  resourceId: Schema.Literal('MHY', 'TRESOR'),
+  language: Schema.Literal('fr'),
+  revision: Schema.NonEmptyString,
+}) {}
+
+export class CommentaryVerseResponseDto extends Schema.Class<CommentaryVerseResponseDto>(
+  'CommentaryVerseResponseDto'
+)({
+  resource: SupplementaryRevisionDto,
+  verseKey: VerseKey,
+  content: Schema.String,
+}) {}
+
+export class CommentaryChapterResponseDto extends Schema.Class<CommentaryChapterResponseDto>(
+  'CommentaryChapterResponseDto'
+)({
+  resource: SupplementaryRevisionDto,
+  book: Schema.Int.pipe(Schema.positive()),
+  chapter: Schema.Int.pipe(Schema.positive()),
+  serializedComments: Schema.String,
+}) {}
+
+export class CrossReferenceResponseDto extends Schema.Class<CrossReferenceResponseDto>(
+  'CrossReferenceResponseDto'
+)({
+  resource: SupplementaryRevisionDto,
+  verseKey: VerseKey,
+  references: Schema.Array(Schema.String),
+}) {}


### PR DESCRIPTION
## Summary
- publish real Matthew Henry and Trésor SQLite sources through the BLM supplementary exporter
- add typed PostgreSQL tables, local publication import, Effect/Kysely repositories, and HTTP endpoints
- wire installed-first/HTTP fallback for commentary and cross-reference readers
- add local artifact and API smoke scripts (no E2E)

## Local proof
- BLM publication smoke: MHY 1,188 chapters / 4,145 verses; Trésor 29,671 anchors / 368,858 references
- `yarn typecheck`
- `yarn resources:architecture:check`
- `yarn resources:migrate`
- bundles validated and imported into local PostgreSQL
- `yarn resources:smoke:supplementary`
- `yarn resources:smoke:supplementary:artifacts`
