### PR TITLE
feat(resources): publish and serve timeline locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "resources:smoke:nave:artifacts": "node scripts/smokeNaveResourceArtifacts.mjs",
     "resources:smoke:supplementary": "node scripts/smokeSupplementaryResourceService.mjs",
     "resources:smoke:supplementary:artifacts": "node scripts/smokeSupplementaryResourceArtifacts.mjs",
+    "resources:smoke:timeline": "node scripts/smokeTimelineResourceService.mjs",
+    "resources:smoke:timeline:artifacts": "node scripts/smokeTimelineResourceArtifacts.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/drizzle/0013_timeline_resources.sql
+++ b/resource-service/drizzle/0013_timeline_resources.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "timeline_events" (
+	"publication_id" integer NOT NULL,
+	"event_id" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"slug" text NOT NULL,
+	"title" text NOT NULL,
+	"description" text NOT NULL,
+	"article" text NOT NULL,
+	"period" text NOT NULL,
+	"dates" text NOT NULL,
+	"related" jsonb NOT NULL,
+	"images" jsonb NOT NULL,
+	"videos" jsonb NOT NULL,
+	"scriptures" jsonb NOT NULL,
+	CONSTRAINT "timeline_events_publication_event_primary" PRIMARY KEY("publication_id","event_id")
+);
+--> statement-breakpoint
+ALTER TABLE "timeline_events" ADD CONSTRAINT "timeline_events_publication_id_resource_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."resource_publications"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "timeline_events_publication_slug_unique" ON "timeline_events" USING btree ("publication_id","slug");
+--> statement-breakpoint
+CREATE INDEX "timeline_events_browse" ON "timeline_events" USING btree ("publication_id","ordinal");

--- a/resource-service/drizzle/meta/_journal.json
+++ b/resource-service/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1786953000000,
       "tag": "0012_supplementary_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1786953300000,
+      "tag": "0013_timeline_resources",
+      "breakpoints": true
     }
   ]
 }

--- a/resource-service/src/database/schema.ts
+++ b/resource-service/src/database/schema.ts
@@ -174,6 +174,37 @@ export const crossReferenceLinks = pgTable(
   ]
 )
 
+export const timelineEvents = pgTable(
+  'timeline_events',
+  {
+    publication_id: integer('publication_id')
+      .notNull()
+      .references(() => resourcePublications.id, { onDelete: 'cascade' }),
+    event_id: text('event_id').notNull(),
+    ordinal: integer('ordinal').notNull(),
+    slug: text('slug').notNull(),
+    title: text('title').notNull(),
+    description: text('description').notNull(),
+    article: text('article').notNull(),
+    period: text('period').notNull(),
+    dates: text('dates').notNull(),
+    related: jsonb('related').$type<Array<{ slug: string; title: string }>>().notNull(),
+    images: jsonb('images').$type<Array<{ caption: string; file: string }>>().notNull(),
+    videos: jsonb('videos')
+      .$type<Array<{ title: string; caption: string; filename: string }>>()
+      .notNull(),
+    scriptures: jsonb('scriptures').$type<string[]>().notNull(),
+  },
+  table => [
+    primaryKey({
+      name: 'timeline_events_publication_event_primary',
+      columns: [table.publication_id, table.event_id],
+    }),
+    uniqueIndex('timeline_events_publication_slug_unique').on(table.publication_id, table.slug),
+    index('timeline_events_browse').on(table.publication_id, table.ordinal),
+  ]
+)
+
 export const dictionaryEntries = pgTable(
   'dictionary_entries',
   {

--- a/resource-service/src/database/types.ts
+++ b/resource-service/src/database/types.ts
@@ -4,6 +4,7 @@ import type {
   bibleVerses,
   commentaryVerses,
   crossReferenceLinks,
+  timelineEvents,
   interlinearBibleSegmentIdentities,
   interlinearBibleSegments,
   interlinearBibleTokens,
@@ -39,6 +40,7 @@ export type ResourcePublicationRow = Kyselify<typeof resourcePublications>
 export type BibleVerseRow = Kyselify<typeof bibleVerses>
 export type CommentaryVerseRow = Kyselify<typeof commentaryVerses>
 export type CrossReferenceLinkRow = Kyselify<typeof crossReferenceLinks>
+export type TimelineEventRow = Kyselify<typeof timelineEvents>
 export type NaveTopicRow = Kyselify<typeof naveTopics>
 export type NaveVerseLinkRow = Kyselify<typeof naveVerseLinks>
 export type DictionaryEntryRow = Kyselify<typeof dictionaryEntries>
@@ -75,6 +77,7 @@ export type ResourceDatabase = {
   bible_verses: BibleVerseRow
   commentary_verses: CommentaryVerseRow
   cross_reference_links: CrossReferenceLinkRow
+  timeline_events: TimelineEventRow
   nave_topics: NaveTopicRow
   nave_verse_links: NaveVerseLinkRow
   dictionary_entries: DictionaryEntryRow

--- a/resource-service/src/domain/timeline.ts
+++ b/resource-service/src/domain/timeline.ts
@@ -1,0 +1,88 @@
+import { Context, Data, Effect } from 'effect'
+
+import {
+  TimelineImageDto,
+  TimelineRelatedDto,
+  TimelineVideoDto,
+  TimelineEventDto,
+  TimelineEventsResponseDto,
+  TimelineEventResponseDto,
+  TimelineRevisionDto,
+} from '../../../src/features/resources/timelineContract'
+
+export type TimelineLanguage = 'fr' | 'en'
+export type TimelineEvent = {
+  id: string
+  slug: string
+  title: string
+  description: string
+  article: string
+  period: string
+  dates: string
+  related: Array<{ slug: string; title: string }>
+  images: Array<{ caption: string; file: string }>
+  videos: Array<{ title: string; caption: string; filename: string }>
+  scriptures: string[]
+}
+
+export class ActiveTimelinePublicationUnavailable extends Data.TaggedError(
+  'ActiveTimelinePublicationUnavailable'
+)<{ readonly language: TimelineLanguage }> {}
+export class TimelineEventNotFound extends Data.TaggedError('TimelineEventNotFound')<{
+  readonly language: TimelineLanguage
+  readonly slug: string
+}> {}
+export class TimelineRepositoryFailure extends Data.TaggedError('TimelineRepositoryFailure')<{
+  readonly cause: unknown
+}> {}
+export type TimelineRepositoryError =
+  | ActiveTimelinePublicationUnavailable
+  | TimelineEventNotFound
+  | TimelineRepositoryFailure
+export type TimelineRepositoryService = {
+  listEvents: (
+    language: TimelineLanguage
+  ) => Effect.Effect<
+    { language: TimelineLanguage; revision: string; events: TimelineEvent[] },
+    TimelineRepositoryError
+  >
+  findEvent: (input: {
+    language: TimelineLanguage
+    slug: string
+  }) => Effect.Effect<
+    { language: TimelineLanguage; revision: string; event: TimelineEvent },
+    TimelineRepositoryError
+  >
+}
+export class TimelineRepository extends Context.Tag('TimelineRepository')<
+  TimelineRepository,
+  TimelineRepositoryService
+>() {}
+
+const revisionDto = (language: TimelineLanguage, revision: string) =>
+  new TimelineRevisionDto({ kind: 'timeline', language, revision })
+const eventDto = (event: TimelineEvent) =>
+  new TimelineEventDto({
+    ...event,
+    related: event.related.map(related => new TimelineRelatedDto(related)),
+    images: event.images.map(image => new TimelineImageDto(image)),
+    videos: event.videos.map(video => new TimelineVideoDto(video)),
+  })
+
+export const readTimelineEvents = (language: TimelineLanguage) =>
+  Effect.gen(function* () {
+    const active = yield* (yield* TimelineRepository).listEvents(language)
+    return new TimelineEventsResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      events: active.events.map(eventDto),
+    })
+  })
+
+export const readTimelineEvent = (input: { language: TimelineLanguage; slug: string }) =>
+  Effect.gen(function* () {
+    const active = yield* (yield* TimelineRepository).findEvent(input)
+    return new TimelineEventResponseDto({
+      resource: revisionDto(active.language, active.revision),
+      event: eventDto(active.event),
+    })
+  })

--- a/resource-service/src/http/api.ts
+++ b/resource-service/src/http/api.ts
@@ -71,6 +71,12 @@ import {
   CrossReferenceResponseDto,
 } from '../../../src/features/resources/supplementaryContract'
 import {
+  TimelineEventPath,
+  TimelineEventResponseDto,
+  TimelineEventsResponseDto,
+  TimelineLanguagePath,
+} from '../../../src/features/resources/timelineContract'
+import {
   InvalidResourceRequestProblem,
   ResourceInternalProblem,
   ResourceNotFoundProblem,
@@ -379,6 +385,26 @@ const SupplementaryApi = HttpApiGroup.make('supplementary')
       .addError(ResourceInternalProblem, { status: 500 })
   )
 
+const TimelineApi = HttpApiGroup.make('timelines')
+  .add(
+    HttpApiEndpoint.get('listTimelineEvents', '/v1/timelines/:language/events')
+      .setPath(TimelineLanguagePath)
+      .addSuccess(TimelineEventsResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+  .add(
+    HttpApiEndpoint.get('getTimelineEvent', '/v1/timelines/:language/events/:slug')
+      .setPath(TimelineEventPath)
+      .addSuccess(TimelineEventResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
+
 export class ResourceApi extends HttpApi.make('resource-api')
   .add(SystemApi)
   .add(BibleApi)
@@ -387,4 +413,5 @@ export class ResourceApi extends HttpApi.make('resource-api')
   .add(StrongBibleApi)
   .add(InterlinearBibleApi)
   .add(StrongLexiconApi)
-  .add(SupplementaryApi) {}
+  .add(SupplementaryApi)
+  .add(TimelineApi) {}

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -83,6 +83,15 @@ import {
   SupplementaryRepositoryFailure,
   type SupplementaryRepositoryService,
 } from '../domain/supplementary'
+import {
+  ActiveTimelinePublicationUnavailable,
+  TimelineEventNotFound,
+  TimelineRepository,
+  TimelineRepositoryFailure,
+  readTimelineEvent,
+  readTimelineEvents,
+  type TimelineRepositoryService,
+} from '../domain/timeline'
 import { HealthResponse, ResourceApi } from './api'
 import {
   InvalidResourceRequestProblem,
@@ -132,7 +141,10 @@ const toHttpProblem = (
     | StrongLexiconRepositoryFailure
     | ActiveSupplementaryPublicationUnavailable
     | SupplementaryContentNotFound
-    | SupplementaryRepositoryFailure,
+    | SupplementaryRepositoryFailure
+    | ActiveTimelinePublicationUnavailable
+    | TimelineEventNotFound
+    | TimelineRepositoryFailure,
   requestId: string
 ) => {
   switch (cause._tag) {
@@ -166,6 +178,25 @@ const toHttpProblem = (
         ...problemFields(requestId, 'The Resource service could not complete the request.'),
         status: 500,
         code: 'RESOURCE_INTERNAL_FAILURE',
+      })
+    case 'TimelineRepositoryFailure':
+      return new ResourceInternalProblem({
+        ...problemFields(requestId, 'The Resource service could not complete the request.'),
+        status: 500,
+        code: 'RESOURCE_INTERNAL_FAILURE',
+      })
+    case 'TimelineEventNotFound':
+      return new ResourceNotFoundProblem({
+        ...problemFields(requestId, 'This timeline event does not exist.'),
+        status: 404,
+        code: 'TIMELINE_EVENT_NOT_FOUND',
+      })
+    case 'ActiveTimelinePublicationUnavailable':
+      return new ResourceUnavailableProblem({
+        ...problemFields(requestId, 'The timeline publication is temporarily unavailable.'),
+        status: 503,
+        code: 'TIMELINE_PUBLICATION_INACTIVE',
+        retryAfterSeconds: 30,
       })
     case 'SupplementaryContentNotFound':
       return new ResourceNotFoundProblem({
@@ -685,6 +716,30 @@ const SupplementaryApiLive = HttpApiBuilder.group(ResourceApi, 'supplementary', 
     })
 )
 
+const TimelineApiLive = HttpApiBuilder.group(ResourceApi, 'timelines', handlers =>
+  handlers
+    .handle('listTimelineEvents', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readTimelineEvents(path.language).pipe(
+          Effect.mapError(cause => toHttpProblem(cause, requestId))
+        ),
+        requestId,
+        request.headers['if-none-match'],
+        ['timeline', path.language, 'events']
+      )
+    })
+    .handle('getTimelineEvent', ({ path, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readTimelineEvent(path).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        ['timeline', path.language, 'event', path.slug]
+      )
+    })
+)
+
 export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(SystemApiLive),
   Layer.provide(BibleApiLive),
@@ -693,7 +748,8 @@ export const ResourceApiLive = HttpApiBuilder.api(ResourceApi).pipe(
   Layer.provide(StrongBibleApiLive),
   Layer.provide(InterlinearBibleApiLive),
   Layer.provide(StrongLexiconApiLive),
-  Layer.provide(SupplementaryApiLive)
+  Layer.provide(SupplementaryApiLive),
+  Layer.provide(TimelineApiLive)
 )
 
 const unavailableRepository: BibleChapterRepositoryService = {
@@ -780,6 +836,12 @@ const unavailableSupplementaryRepository: SupplementaryRepositoryService = {
     ),
 }
 
+const unavailableTimelineRepository: TimelineRepositoryService = {
+  listEvents: language => Effect.fail(new ActiveTimelinePublicationUnavailable({ language })),
+  findEvent: input =>
+    Effect.fail(new ActiveTimelinePublicationUnavailable({ language: input.language })),
+}
+
 export const provideResourceRepositories = (
   repository: BibleChapterRepositoryService,
   naveRepository: NaveRepositoryService,
@@ -787,7 +849,8 @@ export const provideResourceRepositories = (
   strongBibleRepository: StrongBibleRepositoryService = unavailableStrongBibleRepository,
   interlinearBibleRepository: InterlinearBibleRepositoryService = unavailableInterlinearBibleRepository,
   strongLexiconRepository: StrongLexiconRepositoryService = unavailableStrongLexiconRepository,
-  supplementaryRepository: SupplementaryRepositoryService = unavailableSupplementaryRepository
+  supplementaryRepository: SupplementaryRepositoryService = unavailableSupplementaryRepository,
+  timelineRepository: TimelineRepositoryService = unavailableTimelineRepository
 ) =>
   ResourceApiLive.pipe(
     Layer.provide(
@@ -798,7 +861,8 @@ export const provideResourceRepositories = (
         Layer.succeed(StrongBibleRepository, strongBibleRepository),
         Layer.succeed(InterlinearBibleRepository, interlinearBibleRepository),
         Layer.succeed(StrongLexiconRepository, strongLexiconRepository),
-        Layer.succeed(SupplementaryRepository, supplementaryRepository)
+        Layer.succeed(SupplementaryRepository, supplementaryRepository),
+        Layer.succeed(TimelineRepository, timelineRepository)
       )
     )
   )
@@ -817,7 +881,8 @@ export const makeResourceWebHandler = (
         overrides.strongBible ?? unavailableStrongBibleRepository,
         overrides.interlinearBible ?? unavailableInterlinearBibleRepository,
         overrides.strongLexicon ?? unavailableStrongLexiconRepository,
-        overrides.supplementary ?? unavailableSupplementaryRepository
+        overrides.supplementary ?? unavailableSupplementaryRepository,
+        overrides.timeline ?? unavailableTimelineRepository
       ),
       HttpServer.layerContext
     )
@@ -857,4 +922,5 @@ export type ResourceRepositoryOverrides = {
   interlinearBible?: InterlinearBibleRepositoryService
   strongLexicon?: StrongLexiconRepositoryService
   supplementary?: SupplementaryRepositoryService
+  timeline?: TimelineRepositoryService
 }

--- a/resource-service/src/http/problems.ts
+++ b/resource-service/src/http/problems.ts
@@ -34,7 +34,8 @@ export class ResourceNotFoundProblem extends Schema.TaggedError<ResourceNotFound
       'INTERLINEAR_CHAPTER_NOT_FOUND',
       'STRONG_LEXICON_ENTRY_NOT_FOUND',
       'STRONG_LEXICON_ENTITY_NOT_FOUND',
-      'SUPPLEMENTARY_CONTENT_NOT_FOUND'
+      'SUPPLEMENTARY_CONTENT_NOT_FOUND',
+      'TIMELINE_EVENT_NOT_FOUND'
     ),
   }
 ) {}
@@ -51,7 +52,8 @@ export class ResourceUnavailableProblem extends Schema.TaggedError<ResourceUnava
       'STRONG_BIBLE_PUBLICATION_INACTIVE',
       'INTERLINEAR_PUBLICATION_INACTIVE',
       'STRONG_LEXICON_PUBLICATION_INACTIVE',
-      'SUPPLEMENTARY_PUBLICATION_INACTIVE'
+      'SUPPLEMENTARY_PUBLICATION_INACTIVE',
+      'TIMELINE_PUBLICATION_INACTIVE'
     ),
     retryAfterSeconds: Schema.Int.pipe(Schema.positive()),
   }

--- a/resource-service/src/publication/publicationBundle.ts
+++ b/resource-service/src/publication/publicationBundle.ts
@@ -213,6 +213,28 @@ const CrossReferencePublicationBundleManifestSchema = Schema.Struct({
   }),
 })
 
+const TimelinePublicationBundleManifestSchema = Schema.Struct({
+  ...PublicationBundleCommonFields,
+  canonical: Schema.Struct({
+    ...PublicationBundleCommonFields.canonical.fields,
+    schemaVersion: Schema.Literal(1),
+  }),
+  offlineArtifact: Schema.Struct({
+    ...PublicationBundleCommonFields.offlineArtifact.fields,
+    entry: Schema.Literal('bible-timeline-events.json'),
+  }),
+  identity: Schema.Struct({
+    kind: Schema.Literal('timeline'),
+    resourceId: Schema.Literal('TIMELINE'),
+    language: Schema.Literal('fr', 'en'),
+  }),
+  counts: Schema.Struct({
+    events: Schema.NonNegativeInt,
+    relations: Schema.NonNegativeInt,
+    scriptures: Schema.NonNegativeInt,
+  }),
+})
+
 const StrongBiblePublicationBundleManifestSchema = Schema.Struct({
   ...PublicationBundleCommonFields,
   identity: Schema.Struct({
@@ -316,6 +338,7 @@ const PublicationBundleManifestSchema = Schema.Union(
   DictionaryPublicationBundleManifestSchema,
   CommentaryPublicationBundleManifestSchema,
   CrossReferencePublicationBundleManifestSchema,
+  TimelinePublicationBundleManifestSchema,
   StrongBiblePublicationBundleManifestSchema,
   InterlinearBiblePublicationBundleManifestSchema,
   StrongLexiconPublicationBundleManifestSchema
@@ -329,6 +352,7 @@ export type CommentaryPublicationBundleManifest =
   typeof CommentaryPublicationBundleManifestSchema.Type
 export type CrossReferencePublicationBundleManifest =
   typeof CrossReferencePublicationBundleManifestSchema.Type
+export type TimelinePublicationBundleManifest = typeof TimelinePublicationBundleManifestSchema.Type
 export type StrongBiblePublicationBundleManifest =
   typeof StrongBiblePublicationBundleManifestSchema.Type
 export type InterlinearBiblePublicationBundleManifest =
@@ -341,6 +365,7 @@ export type PublicationBundleManifest =
   | DictionaryPublicationBundleManifest
   | CommentaryPublicationBundleManifest
   | CrossReferencePublicationBundleManifest
+  | TimelinePublicationBundleManifest
   | StrongBiblePublicationBundleManifest
   | InterlinearBiblePublicationBundleManifest
   | StrongLexiconPublicationBundleManifest
@@ -365,6 +390,10 @@ export const isCrossReferencePublicationBundleManifest = (
   manifest: PublicationBundleManifest
 ): manifest is CrossReferencePublicationBundleManifest =>
   manifest.identity.kind === 'cross-references'
+
+export const isTimelinePublicationBundleManifest = (
+  manifest: PublicationBundleManifest
+): manifest is TimelinePublicationBundleManifest => manifest.identity.kind === 'timeline'
 
 export const isStrongBiblePublicationBundleManifest = (
   manifest: PublicationBundleManifest
@@ -468,6 +497,31 @@ export type CanonicalCrossReferencePublication = {
   verseAnchors: Array<{ verseKey: string; references: string[] }>
 }
 
+export type CanonicalTimelineEvent = {
+  id: string
+  slug: string
+  title: string
+  description: string
+  article: string
+  period: string
+  dates: string
+  related: Array<{ slug: string; title: string }>
+  images: Array<{ caption: string; file: string }>
+  videos: Array<{ title: string; caption: string; filename: string }>
+  scriptures: string[]
+}
+
+export type CanonicalTimelinePublication = {
+  format: 'bible-strong-canonical-timeline'
+  schemaVersion: 1
+  resourceId: 'TIMELINE'
+  language: 'fr' | 'en'
+  revision: string
+  sourceVersion: string
+  sourceSha256: string
+  events: CanonicalTimelineEvent[]
+}
+
 export type CanonicalStrongBibleVerse = { book: number; chapter: number; verse: number }
 export type CanonicalStrongBibleLexeme = { id: number; lemma: string; partOfSpeech: string }
 export type CanonicalStrongBibleIdentity = {
@@ -554,6 +608,7 @@ export type CanonicalPublication =
   | CanonicalDictionaryPublication
   | CanonicalCommentaryPublication
   | CanonicalCrossReferencePublication
+  | CanonicalTimelinePublication
   | CanonicalStrongBiblePublication
   | CanonicalInterlinearBiblePublication
   | CanonicalStrongLexiconModulePublication
@@ -591,9 +646,11 @@ export const derivePublicationRevision = (manifest: PublicationBundleManifest): 
           ? `commentary-${manifest.identity.resourceId.toLowerCase()}-${manifest.identity.language}`
           : manifest.identity.kind === 'cross-references'
             ? `cross-references-${manifest.identity.language}`
-            : manifest.identity.kind === 'strong-lexicon-module'
-              ? manifest.identity.resourceId
-              : manifest.identity.versionId.toLowerCase()
+            : manifest.identity.kind === 'timeline'
+              ? `timeline-${manifest.identity.language}`
+              : manifest.identity.kind === 'strong-lexicon-module'
+                ? manifest.identity.resourceId
+                : manifest.identity.versionId.toLowerCase()
   const digest = createHash('sha256')
     .update(JSON.stringify(normalizeJson(envelope)))
     .digest('hex')
@@ -679,6 +736,13 @@ export const decodePublicationBundleManifest = (value: unknown): PublicationBund
     (manifest.identity.resourceId !== 'TRESOR' ||
       manifest.offlineArtifact.entry !== 'commentaires-tresor.sqlite' ||
       manifest.counts.verseAnchors === 0)
+  ) {
+    throw new Error('PUBLICATION_BUNDLE_MANIFEST_INVALID')
+  }
+  if (
+    isTimelinePublicationBundleManifest(manifest) &&
+    (manifest.offlineArtifact.entry !== 'bible-timeline-events.json' ||
+      manifest.counts.events === 0)
   ) {
     throw new Error('PUBLICATION_BUNDLE_MANIFEST_INVALID')
   }
@@ -969,6 +1033,72 @@ export const decodeCanonicalCrossReferences = (
     keys.add(anchor.verseKey)
   }
   return candidate as CanonicalCrossReferencePublication
+}
+
+export const decodeCanonicalTimeline = (value: unknown): CanonicalTimelinePublication => {
+  if (!value || typeof value !== 'object') throw new Error('CANONICAL_TIMELINE_INVALID')
+  const candidate = value as Partial<CanonicalTimelinePublication>
+  if (
+    candidate.format !== 'bible-strong-canonical-timeline' ||
+    candidate.schemaVersion !== 1 ||
+    candidate.resourceId !== 'TIMELINE' ||
+    (candidate.language !== 'fr' && candidate.language !== 'en') ||
+    !isNonEmptyString(candidate.revision) ||
+    !isNonEmptyString(candidate.sourceVersion) ||
+    !/^[a-f0-9]{64}$/u.test(candidate.sourceSha256 ?? '') ||
+    !Array.isArray(candidate.events) ||
+    candidate.events.length === 0
+  ) {
+    throw new Error('CANONICAL_TIMELINE_INVALID')
+  }
+  const slugs = new Set<string>()
+  const ids = new Set<string>()
+  for (const event of candidate.events) {
+    if (
+      !event ||
+      !isNonEmptyString(event.id) ||
+      !isNonEmptyString(event.slug) ||
+      !isNonEmptyString(event.title) ||
+      typeof event.description !== 'string' ||
+      typeof event.article !== 'string' ||
+      typeof event.period !== 'string' ||
+      typeof event.dates !== 'string' ||
+      !Array.isArray(event.related) ||
+      !Array.isArray(event.images) ||
+      !Array.isArray(event.videos) ||
+      !Array.isArray(event.scriptures) ||
+      slugs.has(event.slug) ||
+      ids.has(event.id)
+    ) {
+      throw new Error('CANONICAL_TIMELINE_EVENT_INVALID')
+    }
+    for (const related of event.related) {
+      if (!related || !isNonEmptyString(related.slug) || !isNonEmptyString(related.title)) {
+        throw new Error('CANONICAL_TIMELINE_RELATED_INVALID')
+      }
+    }
+    for (const image of event.images) {
+      if (!image || typeof image.caption !== 'string' || !isNonEmptyString(image.file)) {
+        throw new Error('CANONICAL_TIMELINE_IMAGE_INVALID')
+      }
+    }
+    for (const video of event.videos) {
+      if (
+        !video ||
+        typeof video.title !== 'string' ||
+        typeof video.caption !== 'string' ||
+        !isNonEmptyString(video.filename)
+      ) {
+        throw new Error('CANONICAL_TIMELINE_VIDEO_INVALID')
+      }
+    }
+    if (event.scriptures.some(scripture => typeof scripture !== 'string')) {
+      throw new Error('CANONICAL_TIMELINE_SCRIPTURE_INVALID')
+    }
+    slugs.add(event.slug)
+    ids.add(event.id)
+  }
+  return candidate as CanonicalTimelinePublication
 }
 
 const isPositiveInteger = (value: unknown): value is number =>
@@ -1365,6 +1495,21 @@ export const deriveInterlinearBibleResourceRevision = (
     .digest('hex')
   return `bhg-interlinear-${publication.language}-${digest.slice(0, 20)}`
 }
+
+export const deriveTimelineResourceRevision = (
+  publication: Pick<CanonicalTimelinePublication, 'language' | 'events'>
+): string => {
+  const digest = createHash('sha256')
+    .update(JSON.stringify(normalizeJson(publication.events)))
+    .digest('hex')
+  return `timeline-${publication.language}-${digest.slice(0, 20)}`
+}
+
+export const countCanonicalTimelineContent = (publication: CanonicalTimelinePublication) => ({
+  events: publication.events.length,
+  relations: publication.events.reduce((total, event) => total + event.related.length, 0),
+  scriptures: publication.events.reduce((total, event) => total + event.scriptures.length, 0),
+})
 
 export const getCanonicalNaveAlphabeticalBrowse = (publication: CanonicalNavePublication) => {
   const topicCountByInitial: Record<string, number> = {}
@@ -2876,6 +3021,31 @@ export const validatePublicationBundle = async (bundlePath: string) => {
       throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
     }
     await validateCrossReferenceOfflineParity(offlineContent, canonical)
+  } else if (isTimelinePublicationBundleManifest(manifest)) {
+    canonical = decodeCanonicalTimeline(canonicalValue)
+    if (
+      canonical.resourceId !== manifest.identity.resourceId ||
+      canonical.language !== manifest.identity.language ||
+      canonical.revision !== manifest.revision ||
+      deriveTimelineResourceRevision(canonical) !== manifest.revision ||
+      canonical.sourceVersion !== manifest.provenance.sourceVersion ||
+      canonical.sourceSha256 !== manifest.provenance.sourceSha256 ||
+      JSON.stringify(countCanonicalTimelineContent(canonical)) !== JSON.stringify(manifest.counts)
+    ) {
+      throw new Error('PUBLICATION_BUNDLE_IDENTITY_MISMATCH')
+    }
+    let archivedEvents: unknown
+    try {
+      archivedEvents = JSON.parse(Buffer.from(offlineContent).toString('utf8'))
+    } catch (cause) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_INVALID', { cause })
+    }
+    if (
+      !Array.isArray(archivedEvents) ||
+      JSON.stringify(archivedEvents) !== JSON.stringify(canonical.events)
+    ) {
+      throw new Error('OFFLINE_ARTIFACT_CONTENT_MISMATCH')
+    }
   } else if (isStrongBiblePublicationBundleManifest(manifest)) {
     canonical = decodeCanonicalStrongBible(canonicalValue)
     if (

--- a/resource-service/src/repositories/publicationImporter.ts
+++ b/resource-service/src/repositories/publicationImporter.ts
@@ -10,6 +10,7 @@ import {
   isDictionaryPublicationBundleManifest,
   isCommentaryPublicationBundleManifest,
   isCrossReferencePublicationBundleManifest,
+  isTimelinePublicationBundleManifest,
   isInterlinearBiblePublicationBundleManifest,
   isNavePublicationBundleManifest,
   isStrongLexiconPublicationBundleManifest,
@@ -18,6 +19,7 @@ import {
   type CanonicalDictionaryPublication,
   type CanonicalCommentaryPublication,
   type CanonicalCrossReferencePublication,
+  type CanonicalTimelinePublication,
 } from '../publication/publicationBundle'
 
 export class PublicationImportFailure extends Data.TaggedError('PublicationImportFailure')<{
@@ -333,11 +335,13 @@ export const importPublicationBundle = (
               ? `commentary:${manifest.identity.resourceId}:${manifest.identity.language}`
               : isCrossReferencePublicationBundleManifest(manifest)
                 ? `cross-references:${manifest.identity.language}`
-                : isInterlinearBiblePublicationBundleManifest(manifest)
-                  ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
-                  : isStrongLexiconPublicationBundleManifest(manifest)
-                    ? manifest.identity.resourceId
-                    : `strong-bible-index:${manifest.identity.versionId}`
+                : isTimelinePublicationBundleManifest(manifest)
+                  ? `timeline:${manifest.identity.language}`
+                  : isInterlinearBiblePublicationBundleManifest(manifest)
+                    ? `interlinear-index:${manifest.identity.versionId}:${manifest.identity.language}`
+                    : isStrongLexiconPublicationBundleManifest(manifest)
+                      ? manifest.identity.resourceId
+                      : `strong-bible-index:${manifest.identity.versionId}`
       const publicationStatus =
         manifest.deliveryCapabilities.onlineAccess ||
         (options.activateForLocalDevelopment &&
@@ -413,33 +417,21 @@ export const importPublicationBundle = (
                     resource_revision: manifest.revision,
                     offline_entry: manifest.offlineArtifact.entry,
                   }
-                : isInterlinearBiblePublicationBundleManifest(manifest)
+                : isTimelinePublicationBundleManifest(manifest)
                   ? {
-                      version_id: manifest.identity.versionId,
-                      dataset_id: manifest.identity.datasetId,
+                      resource_id: manifest.identity.resourceId,
                       language: manifest.identity.language,
                       delivery_capabilities: manifest.deliveryCapabilities,
-                      dependencies: manifest.dependencies,
                       counts: manifest.counts,
                       canonical_schema_version: manifest.canonical.schemaVersion,
                       resource_revision: manifest.revision,
-                      text_revision: manifest.dependencies.bible.revision,
-                      text_sha256: manifest.dependencies.bible.textSha256,
                       offline_entry: manifest.offlineArtifact.entry,
                     }
-                  : isStrongLexiconPublicationBundleManifest(manifest)
+                  : isInterlinearBiblePublicationBundleManifest(manifest)
                     ? {
-                        module_id: manifest.identity.moduleId,
-                        delivery_capabilities: manifest.deliveryCapabilities,
-                        dependencies: manifest.dependencies,
-                        counts: manifest.counts,
-                        canonical_schema_version: manifest.canonical.schemaVersion,
-                        resource_revision: manifest.revision,
-                        offline_entry: manifest.offlineArtifact.entry,
-                      }
-                    : {
                         version_id: manifest.identity.versionId,
                         dataset_id: manifest.identity.datasetId,
+                        language: manifest.identity.language,
                         delivery_capabilities: manifest.deliveryCapabilities,
                         dependencies: manifest.dependencies,
                         counts: manifest.counts,
@@ -447,12 +439,34 @@ export const importPublicationBundle = (
                         resource_revision: manifest.revision,
                         text_revision: manifest.dependencies.bible.revision,
                         text_sha256: manifest.dependencies.bible.textSha256,
-                        strong_revision:
-                          canonical.format === 'bible-strong-canonical-strong-index'
-                            ? canonical.strongRevision
-                            : undefined,
                         offline_entry: manifest.offlineArtifact.entry,
                       }
+                    : isStrongLexiconPublicationBundleManifest(manifest)
+                      ? {
+                          module_id: manifest.identity.moduleId,
+                          delivery_capabilities: manifest.deliveryCapabilities,
+                          dependencies: manifest.dependencies,
+                          counts: manifest.counts,
+                          canonical_schema_version: manifest.canonical.schemaVersion,
+                          resource_revision: manifest.revision,
+                          offline_entry: manifest.offlineArtifact.entry,
+                        }
+                      : {
+                          version_id: manifest.identity.versionId,
+                          dataset_id: manifest.identity.datasetId,
+                          delivery_capabilities: manifest.deliveryCapabilities,
+                          dependencies: manifest.dependencies,
+                          counts: manifest.counts,
+                          canonical_schema_version: manifest.canonical.schemaVersion,
+                          resource_revision: manifest.revision,
+                          text_revision: manifest.dependencies.bible.revision,
+                          text_sha256: manifest.dependencies.bible.textSha256,
+                          strong_revision:
+                            canonical.format === 'bible-strong-canonical-strong-index'
+                              ? canonical.strongRevision
+                              : undefined,
+                          offline_entry: manifest.offlineArtifact.entry,
+                        }
       const publicationMetadata = { ...metadata, manifest_sha256: manifestSha256 }
       const makeResult = (status: PublicationImportResult['status']): PublicationImportResult =>
         isBiblePublicationBundleManifest(manifest)
@@ -490,29 +504,36 @@ export const importPublicationBundle = (
                       revision: manifest.revision,
                       itemCount: manifest.counts.references,
                     }
-                  : isInterlinearBiblePublicationBundleManifest(manifest)
+                  : isTimelinePublicationBundleManifest(manifest)
                     ? {
                         status,
                         resourceIdentity,
                         revision: manifest.revision,
-                        itemCount: manifest.counts.segments,
+                        itemCount: manifest.counts.events,
                       }
-                    : isStrongLexiconPublicationBundleManifest(manifest)
+                    : isInterlinearBiblePublicationBundleManifest(manifest)
                       ? {
                           status,
                           resourceIdentity,
                           revision: manifest.revision,
-                          itemCount: Object.values(manifest.counts).reduce(
-                            (total, count) => total + count,
-                            0
-                          ),
+                          itemCount: manifest.counts.segments,
                         }
-                      : {
-                          status,
-                          resourceIdentity,
-                          revision: manifest.revision,
-                          itemCount: manifest.counts.occurrences,
-                        }
+                      : isStrongLexiconPublicationBundleManifest(manifest)
+                        ? {
+                            status,
+                            resourceIdentity,
+                            revision: manifest.revision,
+                            itemCount: Object.values(manifest.counts).reduce(
+                              (total, count) => total + count,
+                              0
+                            ),
+                          }
+                        : {
+                            status,
+                            resourceIdentity,
+                            revision: manifest.revision,
+                            itemCount: manifest.counts.occurrences,
+                          }
 
       return tryDatabasePromise(
         'publication.import',
@@ -733,6 +754,27 @@ export const importPublicationBundle = (
                     reference,
                   }))
                 )
+              )
+            } else if (canonical.format === 'bible-strong-canonical-timeline') {
+              const timelineCanonical = canonical as CanonicalTimelinePublication
+              await insertChunks(
+                transaction,
+                'timeline_events',
+                timelineCanonical.events.map((event, ordinal) => ({
+                  publication_id: publication.id,
+                  event_id: event.id,
+                  ordinal,
+                  slug: event.slug,
+                  title: event.title,
+                  description: event.description,
+                  article: event.article,
+                  period: event.period,
+                  dates: event.dates,
+                  related: sql`${JSON.stringify(event.related)}::jsonb`,
+                  images: sql`${JSON.stringify(event.images)}::jsonb`,
+                  videos: sql`${JSON.stringify(event.videos)}::jsonb`,
+                  scriptures: sql`${JSON.stringify(event.scriptures)}::jsonb`,
+                }))
               )
             } else if (canonical.format === 'bible-strong-canonical-strong-index') {
               for (let offset = 0; offset < canonical.verses.length; offset += 1_000) {

--- a/resource-service/src/repositories/timelineRepository.ts
+++ b/resource-service/src/repositories/timelineRepository.ts
@@ -1,0 +1,91 @@
+import { Effect } from 'effect'
+import { type Kysely } from 'kysely'
+
+import { tryDatabasePromise } from '../database/databaseEffect'
+import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
+import type { ResourceDatabase } from '../database/types'
+import {
+  ActiveTimelinePublicationUnavailable,
+  TimelineEventNotFound,
+  TimelineRepositoryFailure,
+  type TimelineEvent,
+  type TimelineRepositoryService,
+} from '../domain/timeline'
+
+const mapEvent = (row: {
+  event_id: string
+  slug: string
+  title: string
+  description: string
+  article: string
+  period: string
+  dates: string
+  related: Array<{ slug: string; title: string }>
+  images: Array<{ caption: string; file: string }>
+  videos: Array<{ title: string; caption: string; filename: string }>
+  scriptures: string[]
+}): TimelineEvent => ({
+  id: row.event_id,
+  slug: row.slug,
+  title: row.title,
+  description: row.description,
+  article: row.article,
+  period: row.period,
+  dates: row.dates,
+  related: row.related,
+  images: row.images,
+  videos: row.videos,
+  scriptures: row.scriptures,
+})
+
+export const makeKyselyTimelineRepository = (
+  database: Kysely<ResourceDatabase>
+): TimelineRepositoryService => {
+  const findActivePublication = (language: 'fr' | 'en') =>
+    tryDatabasePromise('timeline.publication.read-active', () =>
+      database
+        .selectFrom('resource_publications')
+        .select(['id', 'revision'])
+        .where('resource_identity', '=', `timeline:${language}`)
+        .where('status', '=', 'active')
+        .executeTakeFirst()
+    ).pipe(Effect.mapError(cause => new TimelineRepositoryFailure({ cause })))
+
+  return {
+    listEvents: language =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(language)
+        if (!publication) return yield* new ActiveTimelinePublicationUnavailable({ language })
+        const rows = yield* tryDatabasePromise('timeline.events.list', () =>
+          database
+            .selectFrom('timeline_events')
+            .selectAll()
+            .where('publication_id', '=', publication.id)
+            .orderBy('ordinal')
+            .execute()
+        ).pipe(Effect.mapError(cause => new TimelineRepositoryFailure({ cause })))
+        return { language, revision: publication.revision, events: rows.map(mapEvent) }
+      }),
+    findEvent: input =>
+      Effect.gen(function* () {
+        const publication = yield* findActivePublication(input.language)
+        if (!publication)
+          return yield* new ActiveTimelinePublicationUnavailable({ language: input.language })
+        const row = yield* tryDatabasePromise('timeline.event.read', () =>
+          database
+            .selectFrom('timeline_events')
+            .selectAll()
+            .where('publication_id', '=', publication.id)
+            .where('slug', '=', input.slug)
+            .executeTakeFirst()
+        ).pipe(Effect.mapError(cause => new TimelineRepositoryFailure({ cause })))
+        if (!row) return yield* new TimelineEventNotFound(input)
+        return { language: input.language, revision: publication.revision, event: mapEvent(row) }
+      }),
+  }
+}
+
+export const makeNeonTimelineRepository = (config: NeonDatabaseConfig) => {
+  const database = makeNeonDatabase(config)
+  return { repository: makeKyselyTimelineRepository(database), dispose: () => database.destroy() }
+}

--- a/resource-service/src/runtime/developmentArtifacts.ts
+++ b/resource-service/src/runtime/developmentArtifacts.ts
@@ -15,7 +15,8 @@ export const createDevelopmentArtifact = (
 ): DevelopmentArtifact => {
   const filename = path.basename(manifest.offlineArtifact.path)
   const databasePrefix =
-    manifest.identity.kind === 'nave' && manifest.identity.language === 'en'
+    (manifest.identity.kind === 'nave' || manifest.identity.kind === 'timeline') &&
+    manifest.identity.language === 'en'
       ? '/databases/en'
       : '/databases'
   const databaseKinds = new Set([
@@ -24,6 +25,7 @@ export const createDevelopmentArtifact = (
     'commentary',
     'cross-references',
     'strong-lexicon-module',
+    'timeline',
   ])
   return {
     route: `${databaseKinds.has(manifest.identity.kind) ? databasePrefix : '/bibles'}/${filename}`,

--- a/resource-service/src/runtime/node.ts
+++ b/resource-service/src/runtime/node.ts
@@ -12,6 +12,7 @@ import { StrongBibleRepository } from '../domain/strongBible'
 import { InterlinearBibleRepository } from '../domain/interlinearBible'
 import { StrongLexiconRepository } from '../domain/strongLexicon'
 import { SupplementaryRepository } from '../domain/supplementary'
+import { TimelineRepository } from '../domain/timeline'
 import { ResourceApiLive } from '../http/app'
 import { makeKyselyBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeKyselyNaveRepository } from '../repositories/naveRepository'
@@ -20,6 +21,7 @@ import { makeKyselyStrongBibleRepository } from '../repositories/strongBibleRepo
 import { makeKyselyInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeKyselyStrongLexiconRepository } from '../repositories/strongLexiconRepository'
 import { makeKyselySupplementaryRepository } from '../repositories/supplementaryRepository'
+import { makeKyselyTimelineRepository } from '../repositories/timelineRepository'
 
 const port = Number(process.env.RESOURCE_API_PORT ?? 8787)
 const database = makeLocalDatabase({
@@ -40,7 +42,8 @@ const RepositoryLive = Layer.mergeAll(
   Layer.succeed(StrongBibleRepository, makeKyselyStrongBibleRepository(database)),
   Layer.succeed(InterlinearBibleRepository, makeKyselyInterlinearBibleRepository(database)),
   Layer.succeed(StrongLexiconRepository, makeKyselyStrongLexiconRepository(database)),
-  Layer.succeed(SupplementaryRepository, makeKyselySupplementaryRepository(database))
+  Layer.succeed(SupplementaryRepository, makeKyselySupplementaryRepository(database)),
+  Layer.succeed(TimelineRepository, makeKyselyTimelineRepository(database))
 )
 const ApiLive = ResourceApiLive.pipe(Layer.provide(RepositoryLive))
 

--- a/resource-service/src/runtime/worker.ts
+++ b/resource-service/src/runtime/worker.ts
@@ -6,6 +6,7 @@ import type { StrongBibleRepositoryService } from '../domain/strongBible'
 import type { InterlinearBibleRepositoryService } from '../domain/interlinearBible'
 import type { StrongLexiconRepositoryService } from '../domain/strongLexicon'
 import type { SupplementaryRepositoryService } from '../domain/supplementary'
+import type { TimelineRepositoryService } from '../domain/timeline'
 import { makeNeonBibleChapterRepository } from '../repositories/bibleChapterRepository'
 import { makeNeonNaveRepository } from '../repositories/naveRepository'
 import { makeNeonDictionaryRepository } from '../repositories/dictionaryRepository'
@@ -13,6 +14,7 @@ import { makeNeonStrongBibleRepository } from '../repositories/strongBibleReposi
 import { makeNeonInterlinearBibleRepository } from '../repositories/interlinearBibleRepository'
 import { makeNeonStrongLexiconRepository } from '../repositories/strongLexiconRepository'
 import { makeNeonSupplementaryRepository } from '../repositories/supplementaryRepository'
+import { makeNeonTimelineRepository } from '../repositories/timelineRepository'
 
 export type ResourceWorkerBindings = {
   RESOURCE_DATABASE_URL: string
@@ -25,7 +27,8 @@ export const makeResourceWorkerHandler = (
   strongBibleRepository?: StrongBibleRepositoryService,
   interlinearBibleRepository?: InterlinearBibleRepositoryService,
   strongLexiconRepository?: StrongLexiconRepositoryService,
-  supplementaryRepository?: SupplementaryRepositoryService
+  supplementaryRepository?: SupplementaryRepositoryService,
+  timelineRepository?: TimelineRepositoryService
 ) =>
   makeResourceWebHandler(repository, naveRepository, {
     dictionary: dictionaryRepository,
@@ -33,6 +36,7 @@ export const makeResourceWorkerHandler = (
     interlinearBible: interlinearBibleRepository,
     strongLexicon: strongLexiconRepository,
     supplementary: supplementaryRepository,
+    timeline: timelineRepository,
   })
 
 let cached:
@@ -57,6 +61,7 @@ const getWorkerHandler = (connectionString: string) => {
   const { repository: supplementaryRepository } = makeNeonSupplementaryRepository({
     connectionString,
   })
+  const { repository: timelineRepository } = makeNeonTimelineRepository({ connectionString })
   const web = makeResourceWorkerHandler(
     repository,
     naveRepository,
@@ -64,7 +69,8 @@ const getWorkerHandler = (connectionString: string) => {
     strongBibleRepository,
     interlinearBibleRepository,
     strongLexiconRepository,
-    supplementaryRepository
+    supplementaryRepository,
+    timelineRepository
   )
   cached = { connectionString, web }
   return web

--- a/scripts/smokeTimelineResourceArtifacts.mjs
+++ b/scripts/smokeTimelineResourceArtifacts.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const baseUrl = process.env.RESOURCE_ARTIFACT_BASE_URL ?? 'http://127.0.0.1:8789'
+const artifacts = [
+  ['/databases/bible-timeline-events.json.zip', process.env.TIMELINE_FR_BUNDLE],
+  ['/databases/en/bible-timeline-events.json.zip', process.env.TIMELINE_EN_BUNDLE],
+]
+
+for (const [path, bundle] of artifacts) {
+  assert.ok(bundle, `missing bundle path for ${path}`)
+  const manifest = JSON.parse(await readFile(`${bundle}/manifest.json`, 'utf8'))
+  const response = await fetch(`${baseUrl}${path}`, { method: 'HEAD' })
+  assert.equal(response.status, 200)
+  assert.equal(Number(response.headers.get('content-length')), manifest.offlineArtifact.bytes)
+}
+
+console.log('timeline-resource-artifacts-smoke:ok')

--- a/scripts/smokeTimelineResourceService.mjs
+++ b/scripts/smokeTimelineResourceService.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+
+const baseUrl = process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787'
+
+const getJson = async path => {
+  const response = await fetch(`${baseUrl}${path}`, { headers: { accept: 'application/json' } })
+  const body = await response.json().catch(() => undefined)
+  return { response, body }
+}
+
+const french = await getJson('/v1/timelines/fr/events')
+assert.equal(french.response.status, 200)
+assert.equal(french.body.resource.language, 'fr')
+assert.equal(french.body.events.length, 625)
+assert.ok(french.body.events[0].slug)
+
+const event = await getJson('/v1/timelines/fr/events/1-corinthians-written')
+assert.equal(event.response.status, 200)
+assert.equal(event.body.event.slug, '1-corinthians-written')
+assert.equal(event.body.resource.revision, french.body.resource.revision)
+
+const english = await getJson('/v1/timelines/en/events')
+assert.equal(english.response.status, 200)
+assert.equal(english.body.resource.language, 'en')
+assert.equal(english.body.events.length, 625)
+
+const cached = await fetch(`${baseUrl}/v1/timelines/fr/events`, {
+  headers: { 'if-none-match': french.response.headers.get('etag') },
+})
+assert.equal(cached.status, 304)
+
+const missing = await getJson('/v1/timelines/fr/events/not-a-real-event')
+assert.equal(missing.response.status, 404)
+
+console.log(
+  JSON.stringify({
+    frenchRevision: french.body.resource.revision,
+    englishRevision: english.body.resource.revision,
+    events: french.body.events.length,
+    cached: cached.status,
+    missing: missing.response.status,
+  })
+)

--- a/src/assets/mobile-resource-catalog.json
+++ b/src/assets/mobile-resource-catalog.json
@@ -1557,16 +1557,16 @@
       "entries": {
         "canonical": {
           "entry": "bible-timeline-events.json",
-          "sha256": "786e785cbcb70e6fd800e7c508ef7ddd366e76007d95240caccdb6abf1e3da3d",
-          "bytes": 1822033
+          "sha256": "7cf9ff871b30f9d9cb235c9742d16d278e73da2e2c708235f2337bba18b5efc1",
+          "bytes": 1397921
         }
       },
-      "archiveSha256": "383ee138c4dfdd3d96333161a39f7e696a3aa0c6a2abe8f7e92f9fcd6f448d70",
-      "archiveBytes": 574945,
-      "contentSha256": "786e785cbcb70e6fd800e7c508ef7ddd366e76007d95240caccdb6abf1e3da3d",
-      "contentBytes": 1822033,
-      "installedBytes": 1822033,
-      "peakInstallationBytes": 2756525,
+      "archiveSha256": "7f6e4eb89eab97a3010e3664285b4fbe11abb6c9d9b991d5e23a12275cdce6a3",
+      "archiveBytes": 488026,
+      "contentSha256": "7cf9ff871b30f9d9cb235c9742d16d278e73da2e2c708235f2337bba18b5efc1",
+      "contentBytes": 1397921,
+      "installedBytes": 1397921,
+      "peakInstallationBytes": 1885947,
       "strategy": "archive-extract"
     },
     "database:TIMELINE:fr": {
@@ -1577,16 +1577,16 @@
       "entries": {
         "canonical": {
           "entry": "bible-timeline-events.json",
-          "sha256": "ee866711e30631cc525c156bbf971654990dec0605988f8b37bff072894dd1af",
-          "bytes": 1512391
+          "sha256": "fe4d7e06145f65683f2380e61f55b0d6cd53a8386bb1964da2de9971099da818",
+          "bytes": 1520517
         }
       },
-      "archiveSha256": "7cf06690f92a2430927e9414df21bc72ecac03911740be741f630d3b82254423",
-      "archiveBytes": 542735,
-      "contentSha256": "ee866711e30631cc525c156bbf971654990dec0605988f8b37bff072894dd1af",
-      "contentBytes": 1512391,
-      "installedBytes": 1512391,
-      "peakInstallationBytes": 2363395,
+      "archiveSha256": "d24b4c08e2f8f25e51256ecc01e98cb3fa7befbaff96da39eef0f5f75b709d84",
+      "archiveBytes": 532641,
+      "contentSha256": "fe4d7e06145f65683f2380e61f55b0d6cd53a8386bb1964da2de9971099da818",
+      "contentBytes": 1520517,
+      "installedBytes": 1520517,
+      "peakInstallationBytes": 2055793,
       "strategy": "archive-extract"
     },
     "database:TRESOR:fr": {

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -62,7 +62,12 @@ import {
   localInterlinearBibleResourceAdapter,
   type InterlinearBibleResourceAccess,
 } from '~features/resources/interlinearBibleResourceAccess'
-import { localTimelineAccess, type TimelineAccess } from '~features/resources/timelineAccess'
+import {
+  createHttpTimelineAccess,
+  createHybridTimelineAccess,
+  localTimelineAccess,
+  type TimelineAccess,
+} from '~features/resources/timelineAccess'
 import {
   createHttpCommentaryAccess,
   createCommentaryAccess,
@@ -154,6 +159,9 @@ const remotelyReadableNaveLanguages = new Set<ResourceLanguage>(
   resourceApiBaseUrl ? ['fr', 'en'] : []
 )
 const remotelyReadableCommentaryCollections = new Set<string>(resourceApiBaseUrl ? ['MHY'] : [])
+const remotelyReadableTimelineLanguages = new Set<ResourceLanguage>(
+  resourceApiBaseUrl ? ['fr', 'en'] : []
+)
 const onlineDictionaryAccess = resourceApiBaseUrl
   ? createHttpDictionaryAccess({
       baseUrl: resourceApiBaseUrl,
@@ -241,6 +249,12 @@ const onlineBibleReadingAccess = resourceApiBaseUrl
 const commentaryAccess = onlineCommentaryAccess
   ? createCommentaryAccess({ remote: onlineCommentaryAccess, combineResults: false })
   : defaultCommentaryAccess
+const onlineTimelineAccess = resourceApiBaseUrl
+  ? createHttpTimelineAccess({
+      baseUrl: resourceApiBaseUrl,
+      isOnline: async () => onlineManager.isOnline(),
+    })
+  : localTimelineAccess
 
 export const defaultResourceAccess: ResourceAccessRegistry = {
   bibleContent: createBibleContentAccess(
@@ -272,7 +286,12 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
   strongLexicon: strongLexiconAccess,
   strongBible: strongBibleAccess,
   interlinearBible: interlinearBibleAccess,
-  timeline: localTimelineAccess,
+  timeline: createHybridTimelineAccess({
+    offline: localTimelineAccess,
+    online: onlineTimelineAccess,
+    remotelyReadableLanguages: remotelyReadableTimelineLanguages,
+    isOnline: async () => onlineManager.isOnline(),
+  }),
   commentary: commentaryAccess,
   offlineCopies: { isAvailable: isLocalResourceAvailable },
   capabilities: {
@@ -286,7 +305,8 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
         remotelyReadableStrongLexiconModules,
         remotelyReadableDictionaryLanguages,
         remotelyReadableCommentaryCollections,
-        Boolean(resourceApiBaseUrl)
+        Boolean(resourceApiBaseUrl),
+        remotelyReadableTimelineLanguages
       ),
   },
 }

--- a/src/features/resources/resourceModel.ts
+++ b/src/features/resources/resourceModel.ts
@@ -80,7 +80,8 @@ export const getResourceOnlineAccess = (
   remotelyReadableStrongLexiconModules: ReadonlySet<string> = new Set(),
   remotelyReadableDictionaryLanguages: ReadonlySet<ResourceLanguage> = new Set(),
   remotelyReadableCommentaryCollections: ReadonlySet<string> = new Set(),
-  remotelyReadableCrossReferences = false
+  remotelyReadableCrossReferences = false,
+  remotelyReadableTimelineLanguages: ReadonlySet<ResourceLanguage> = new Set()
 ): OnlineAccessState =>
   (identity.kind === 'bible-text' && remotelyReadableBibleVersions.has(identity.versionId)) ||
   (identity.kind === 'strong-bible-index' &&
@@ -94,7 +95,8 @@ export const getResourceOnlineAccess = (
   (identity.kind === 'commentary' &&
     (identity.collection === 'FIRESTORE' ||
       remotelyReadableCommentaryCollections.has(identity.collection))) ||
-  (identity.kind === 'cross-references' && remotelyReadableCrossReferences)
+  (identity.kind === 'cross-references' && remotelyReadableCrossReferences) ||
+  (identity.kind === 'timeline' && remotelyReadableTimelineLanguages.has(identity.language))
     ? { status: 'remotely-readable' }
     : { status: 'unsupported' }
 

--- a/src/features/resources/timelineAccess.ts
+++ b/src/features/resources/timelineAccess.ts
@@ -1,4 +1,5 @@
 import * as FileSystem from 'expo-file-system/legacy'
+import { Schema } from 'effect'
 
 import type { TimelineEventDetail } from '~features/timeline/types'
 import type { ResourceLanguage } from '~helpers/databaseTypes'
@@ -8,6 +9,8 @@ import {
   type LocalResourceAvailability,
   type LocalResourceRef,
 } from './resourceAvailability'
+import { ResourceAccessError } from './resourceAccessError'
+import { TimelineEventsResponseDto } from './timelineContract'
 
 export type TimelineDetailsResult =
   | { status: 'available'; details: TimelineEventDetail[] }
@@ -18,6 +21,12 @@ export type TimelineDetailsResult =
     }
 
 export type TimelineAccess = {
+  getAvailability?: (language: ResourceLanguage) => Promise<
+    | {
+        status: 'available'
+      }
+    | (TimelineDetailsResult & { status: 'unavailable' })
+  >
   loadDetails: (language: ResourceLanguage) => Promise<TimelineDetailsResult>
 }
 
@@ -40,6 +49,21 @@ const isTimelineEventDetailList = (value: unknown): value is TimelineEventDetail
 export const createLocalTimelineAccess = (
   dependencies: TimelineAccessDependencies = defaultDependencies
 ): TimelineAccess => ({
+  getAvailability: async language => {
+    const availability = await dependencies.getAvailability({
+      kind: 'database',
+      databaseId: 'TIMELINE',
+      language,
+    })
+    return availability.status === 'available'
+      ? { status: 'available' }
+      : {
+          status: 'unavailable',
+          reason:
+            availability.status === 'missing' ? 'offline-copy-required' : 'invalid-offline-copy',
+          recoveries: ['acquire-offline-copy', 'manage-offline-copies'],
+        }
+  },
   loadDetails: async language => {
     const identity = { kind: 'database', databaseId: 'TIMELINE', language } as const
     const availability = await dependencies.getAvailability(identity)
@@ -73,6 +97,119 @@ export const createLocalTimelineAccess = (
         reason: 'invalid-offline-copy',
         recoveries: ['acquire-offline-copy', 'manage-offline-copies'],
       }
+    }
+  },
+})
+
+type HttpTimelineAccessOptions = {
+  baseUrl: string
+  fetcher?: typeof fetch
+  isOnline: () => Promise<boolean>
+  timeoutMs?: number
+}
+
+const timelineResourceError = (status: number, code: unknown) => {
+  if (status === 404 && code === 'TIMELINE_EVENT_NOT_FOUND') {
+    return new ResourceAccessError('NOT_FOUND')
+  }
+  if (status === 503 || code === 'TIMELINE_PUBLICATION_INACTIVE') {
+    return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+  }
+  return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+}
+
+export const createHttpTimelineAccess = ({
+  baseUrl,
+  fetcher = fetch,
+  isOnline,
+  timeoutMs = 10_000,
+}: HttpTimelineAccessOptions): TimelineAccess => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const loadDetails = async (language: ResourceLanguage): Promise<TimelineDetailsResult> => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetcher(`${normalizedBaseUrl}/v1/timelines/${language}/events`, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      })
+      const payload: unknown = await response.json().catch(() => undefined)
+      if (!response.ok) {
+        const code =
+          payload && typeof payload === 'object' && 'code' in payload ? payload.code : undefined
+        throw timelineResourceError(response.status, code)
+      }
+      const decoded = Schema.decodeUnknownSync(TimelineEventsResponseDto)(payload)
+      if (decoded.resource.language !== language) throw new ResourceAccessError('INTEGRITY_FAILURE')
+      return {
+        status: 'available',
+        details: Array.from(decoded.events).map(event => ({
+          ...event,
+          related: Array.from(event.related).map(related => ({ ...related })),
+          images: Array.from(event.images).map(image => ({ ...image })),
+          videos: Array.from(event.videos).map(video => ({ ...video })),
+          scriptures: Array.from(event.scriptures),
+        })),
+      }
+    } catch (error) {
+      if (error instanceof ResourceAccessError) throw error
+      throw new ResourceAccessError(
+        (await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE'
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+  return {
+    getAvailability: async language => {
+      try {
+        await loadDetails(language)
+        return { status: 'available' }
+      } catch {
+        return {
+          status: 'unavailable',
+          reason: 'temporary-unavailable',
+          recoveries: [],
+        }
+      }
+    },
+    loadDetails,
+  }
+}
+
+export const createHybridTimelineAccess = ({
+  offline,
+  online,
+  remotelyReadableLanguages,
+  isOnline,
+}: {
+  offline: TimelineAccess
+  online: TimelineAccess
+  remotelyReadableLanguages: ReadonlySet<ResourceLanguage>
+  isOnline: () => Promise<boolean>
+}): TimelineAccess => ({
+  getAvailability: async language => {
+    const local = await offline.getAvailability?.(language)
+    if (local?.status === 'available' || remotelyReadableLanguages.has(language)) {
+      return { status: 'available' }
+    }
+    return (
+      local ?? {
+        status: 'unavailable' as const,
+        reason: 'offline-copy-required' as const,
+        recoveries: ['acquire-offline-copy'] as const,
+      }
+    )
+  },
+  loadDetails: async language => {
+    const local = await offline.loadDetails(language)
+    if (local.status === 'available') return local
+    if (!remotelyReadableLanguages.has(language) || !(await isOnline())) return local
+    try {
+      return await online.loadDetails(language)
+    } catch (error) {
+      if (error instanceof ResourceAccessError && error.code === 'NETWORK_OFFLINE') return local
+      throw error
     }
   },
 })

--- a/src/features/resources/timelineContract.ts
+++ b/src/features/resources/timelineContract.ts
@@ -1,0 +1,64 @@
+import { Schema } from 'effect'
+
+const Language = Schema.Literal('fr', 'en')
+
+export class TimelineLanguagePath extends Schema.Class<TimelineLanguagePath>(
+  'TimelineLanguagePath'
+)({
+  language: Language,
+}) {}
+
+export class TimelineEventPath extends Schema.Class<TimelineEventPath>('TimelineEventPath')({
+  ...TimelineLanguagePath.fields,
+  slug: Schema.NonEmptyString,
+}) {}
+
+export class TimelineRevisionDto extends Schema.Class<TimelineRevisionDto>('TimelineRevisionDto')({
+  kind: Schema.Literal('timeline'),
+  language: Language,
+  revision: Schema.NonEmptyString,
+}) {}
+
+export class TimelineRelatedDto extends Schema.Class<TimelineRelatedDto>('TimelineRelatedDto')({
+  slug: Schema.NonEmptyString,
+  title: Schema.NonEmptyString,
+}) {}
+
+export class TimelineImageDto extends Schema.Class<TimelineImageDto>('TimelineImageDto')({
+  caption: Schema.String,
+  file: Schema.NonEmptyString,
+}) {}
+
+export class TimelineVideoDto extends Schema.Class<TimelineVideoDto>('TimelineVideoDto')({
+  title: Schema.String,
+  caption: Schema.String,
+  filename: Schema.NonEmptyString,
+}) {}
+
+export class TimelineEventDto extends Schema.Class<TimelineEventDto>('TimelineEventDto')({
+  id: Schema.NonEmptyString,
+  slug: Schema.NonEmptyString,
+  title: Schema.NonEmptyString,
+  description: Schema.String,
+  article: Schema.String,
+  period: Schema.String,
+  dates: Schema.String,
+  related: Schema.Array(TimelineRelatedDto),
+  images: Schema.Array(TimelineImageDto),
+  videos: Schema.Array(TimelineVideoDto),
+  scriptures: Schema.Array(Schema.String),
+}) {}
+
+export class TimelineEventsResponseDto extends Schema.Class<TimelineEventsResponseDto>(
+  'TimelineEventsResponseDto'
+)({
+  resource: TimelineRevisionDto,
+  events: Schema.Array(TimelineEventDto),
+}) {}
+
+export class TimelineEventResponseDto extends Schema.Class<TimelineEventResponseDto>(
+  'TimelineEventResponseDto'
+)({
+  resource: TimelineRevisionDto,
+  event: TimelineEventDto,
+}) {}


### PR DESCRIPTION
## Summary

- publish French and English timeline sources as reproducible canonical JSON + JSON.zip bundles in Bible Lexicon Maker
- import the timeline into the local PostgreSQL resource service with a typed Kysely/Effect repository
- expose list/detail HTTP endpoints and installed-first/HTTP fallback access in the app
- add focused local smoke scripts for API, ETag/not-found, and artifact routes

## Local proof (no E2E)

- BLM real FR/EN publication smoke: 625 events each, 1,160 relations, 769 scriptures
- app bundle validation: FR + EN pass
- local Postgres migration/import: `timeline:fr` and `timeline:en` activated
- API smoke: FR/EN list, detail, ETag 304, missing event 404
- artifact smoke: FR/EN JSON.zip routes and declared sizes
- `yarn typecheck`
- `yarn resources:architecture:check`
- `yarn format:check`

No production database deployment is included.
