### PR TITLE
feat(resources): add local Bible search API

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "resources:smoke:supplementary:artifacts": "node scripts/smokeSupplementaryResourceArtifacts.mjs",
     "resources:smoke:timeline": "node scripts/smokeTimelineResourceService.mjs",
     "resources:smoke:timeline:artifacts": "node scripts/smokeTimelineResourceArtifacts.mjs",
+    "resources:smoke:bible-search": "node scripts/smokeBibleSearchResourceService.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/src/domain/bibleSearch.ts
+++ b/resource-service/src/domain/bibleSearch.ts
@@ -1,0 +1,81 @@
+import { Context, Data, Effect } from 'effect'
+
+import {
+  BibleSearchResponseDto,
+  BibleSearchResultDto,
+  BibleTextRevisionDto,
+} from '../../../src/features/resources/bibleChapterContract'
+import { isOrdinaryBibleVersionId } from '../../../src/helpers/ordinaryBibleVersions'
+import { UnsupportedBibleVersion } from './bibleChapter'
+
+export type BibleSearchInput = {
+  versionId: string
+  query: string
+  book?: number
+  section?: 'ot' | 'nt'
+  sortOrder?: 'relevance' | 'book'
+  limit?: number
+  offset?: number
+}
+
+export type ActiveBibleSearch = {
+  versionId: string
+  revision: string
+  textRevision: string
+  textSha256?: string
+  count: number
+  results: Array<{
+    version: string
+    book: number
+    chapter: number
+    verse: number
+    text: string
+    highlighted: string
+  }>
+}
+
+export class BibleSearchRepositoryFailure extends Data.TaggedError('BibleSearchRepositoryFailure')<{
+  readonly cause: unknown
+}> {}
+
+export class ActiveBibleSearchPublicationUnavailable extends Data.TaggedError(
+  'ActiveBibleSearchPublicationUnavailable'
+)<{ readonly versionId: string }> {}
+
+export type BibleSearchRepositoryError =
+  | BibleSearchRepositoryFailure
+  | ActiveBibleSearchPublicationUnavailable
+
+export type BibleSearchRepositoryService = {
+  search: (input: BibleSearchInput) => Effect.Effect<ActiveBibleSearch, BibleSearchRepositoryError>
+}
+
+export class BibleSearchRepository extends Context.Tag('BibleSearchRepository')<
+  BibleSearchRepository,
+  BibleSearchRepositoryService
+>() {}
+
+export const readBibleSearch = (
+  input: BibleSearchInput
+): Effect.Effect<
+  BibleSearchResponseDto,
+  BibleSearchRepositoryError | UnsupportedBibleVersion,
+  BibleSearchRepository
+> =>
+  Effect.gen(function* () {
+    if (!isOrdinaryBibleVersionId(input.versionId)) {
+      return yield* new UnsupportedBibleVersion({ versionId: input.versionId })
+    }
+    const active = yield* (yield* BibleSearchRepository).search(input)
+    return new BibleSearchResponseDto({
+      resource: new BibleTextRevisionDto({
+        kind: 'bible-text',
+        versionId: active.versionId,
+        revision: active.revision,
+        textRevision: active.textRevision,
+        ...(active.textSha256 ? { textSha256: active.textSha256 } : {}),
+      }),
+      count: active.count,
+      results: active.results.map(result => new BibleSearchResultDto(result)),
+    })
+  })

--- a/resource-service/src/http/api.ts
+++ b/resource-service/src/http/api.ts
@@ -7,6 +7,8 @@ import {
   BibleChapterRequest,
   BibleVersionCoverageDto,
   BibleVersionPath,
+  BibleSearchQuery,
+  BibleSearchResponseDto,
 } from '../../../src/features/resources/bibleChapterContract'
 import {
   NaveLanguagePath,
@@ -92,6 +94,16 @@ const SystemApi = HttpApiGroup.make('system').add(
 )
 
 const BibleApi = HttpApiGroup.make('bibles')
+  .add(
+    HttpApiEndpoint.get('searchBible', '/v1/bibles/:version/search')
+      .setPath(BibleVersionPath)
+      .setUrlParams(BibleSearchQuery)
+      .addSuccess(BibleSearchResponseDto)
+      .addError(InvalidResourceRequestProblem, { status: 400 })
+      .addError(ResourceNotFoundProblem, { status: 404 })
+      .addError(ResourceUnavailableProblem, { status: 503 })
+      .addError(ResourceInternalProblem, { status: 500 })
+  )
   .add(
     HttpApiEndpoint.get('getBibleChapter', '/v1/bibles/:version/books/:book/chapters/:chapter')
       .setPath(BibleChapterRequest)

--- a/resource-service/src/http/app.ts
+++ b/resource-service/src/http/app.ts
@@ -13,6 +13,13 @@ import {
   type BibleChapterRepositoryService,
 } from '../domain/bibleChapter'
 import {
+  ActiveBibleSearchPublicationUnavailable,
+  BibleSearchRepository,
+  BibleSearchRepositoryFailure,
+  readBibleSearch,
+  type BibleSearchRepositoryService,
+} from '../domain/bibleSearch'
+import {
   ActiveNavePublicationUnavailable,
   browseNaveTopics,
   NaveRepository,
@@ -120,6 +127,8 @@ const toHttpProblem = (
     | ActiveBiblePublicationUnavailable
     | BibleChapterNotFound
     | BibleChapterRepositoryFailure
+    | ActiveBibleSearchPublicationUnavailable
+    | BibleSearchRepositoryFailure
     | UnsupportedNaveLanguage
     | ActiveNavePublicationUnavailable
     | NaveTopicNotFound
@@ -168,6 +177,7 @@ const toHttpProblem = (
         retryAfterSeconds: 30,
       })
     case 'BibleChapterRepositoryFailure':
+    case 'BibleSearchRepositoryFailure':
     case 'NaveRepositoryFailure':
     case 'DictionaryRepositoryFailure':
     case 'StrongBibleRepositoryFailure':
@@ -178,6 +188,13 @@ const toHttpProblem = (
         ...problemFields(requestId, 'The Resource service could not complete the request.'),
         status: 500,
         code: 'RESOURCE_INTERNAL_FAILURE',
+      })
+    case 'ActiveBibleSearchPublicationUnavailable':
+      return new ResourceUnavailableProblem({
+        ...problemFields(requestId, 'The Bible publication is temporarily unavailable.'),
+        status: 503,
+        code: 'BIBLE_PUBLICATION_INACTIVE',
+        retryAfterSeconds: 30,
       })
     case 'TimelineRepositoryFailure':
       return new ResourceInternalProblem({
@@ -333,6 +350,32 @@ const addResponseHeaders = (headers: Record<string, string>) =>
 
 const BibleApiLive = HttpApiBuilder.group(ResourceApi, 'bibles', handlers =>
   handlers
+    .handle('searchBible', ({ path, urlParams, request }) => {
+      const requestId = requestIdFrom(request.headers['x-request-id'])
+      return serveRevisionedResponse(
+        readBibleSearch({
+          versionId: path.version,
+          query: urlParams.q,
+          book: urlParams.book,
+          section: urlParams.section,
+          sortOrder: urlParams.sortOrder,
+          limit: urlParams.limit,
+          offset: urlParams.offset,
+        }).pipe(Effect.mapError(cause => toHttpProblem(cause, requestId))),
+        requestId,
+        request.headers['if-none-match'],
+        [
+          'bible-search',
+          path.version,
+          urlParams.q,
+          urlParams.book ?? '*',
+          urlParams.section ?? '*',
+          urlParams.sortOrder ?? 'relevance',
+          urlParams.limit ?? 100,
+          urlParams.offset ?? 0,
+        ]
+      )
+    })
     .handle('getBibleChapter', ({ path, request }) => {
       const requestId = requestIdFrom(request.headers['x-request-id'])
 
@@ -761,6 +804,11 @@ const unavailableRepository: BibleChapterRepositoryService = {
     Effect.fail(new ActiveBiblePublicationUnavailable({ versionId })),
 }
 
+const unavailableBibleSearchRepository: BibleSearchRepositoryService = {
+  search: input =>
+    Effect.fail(new ActiveBibleSearchPublicationUnavailable({ versionId: input.versionId })),
+}
+
 const unavailableNaveRepository: NaveRepositoryService = {
   findTopic: input =>
     Effect.fail(new ActiveNavePublicationUnavailable({ language: input.language })),
@@ -850,12 +898,14 @@ export const provideResourceRepositories = (
   interlinearBibleRepository: InterlinearBibleRepositoryService = unavailableInterlinearBibleRepository,
   strongLexiconRepository: StrongLexiconRepositoryService = unavailableStrongLexiconRepository,
   supplementaryRepository: SupplementaryRepositoryService = unavailableSupplementaryRepository,
-  timelineRepository: TimelineRepositoryService = unavailableTimelineRepository
+  timelineRepository: TimelineRepositoryService = unavailableTimelineRepository,
+  bibleSearchRepository: BibleSearchRepositoryService = unavailableBibleSearchRepository
 ) =>
   ResourceApiLive.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.succeed(BibleChapterRepository, repository),
+        Layer.succeed(BibleSearchRepository, bibleSearchRepository),
         Layer.succeed(NaveRepository, naveRepository),
         Layer.succeed(DictionaryRepository, dictionaryRepository),
         Layer.succeed(StrongBibleRepository, strongBibleRepository),
@@ -882,7 +932,8 @@ export const makeResourceWebHandler = (
         overrides.interlinearBible ?? unavailableInterlinearBibleRepository,
         overrides.strongLexicon ?? unavailableStrongLexiconRepository,
         overrides.supplementary ?? unavailableSupplementaryRepository,
-        overrides.timeline ?? unavailableTimelineRepository
+        overrides.timeline ?? unavailableTimelineRepository,
+        overrides.bibleSearch ?? unavailableBibleSearchRepository
       ),
       HttpServer.layerContext
     )
@@ -917,6 +968,7 @@ export const makeResourceWebHandler = (
 }
 
 export type ResourceRepositoryOverrides = {
+  bibleSearch?: BibleSearchRepositoryService
   dictionary?: DictionaryRepositoryService
   strongBible?: StrongBibleRepositoryService
   interlinearBible?: InterlinearBibleRepositoryService

--- a/resource-service/src/repositories/bibleSearchRepository.ts
+++ b/resource-service/src/repositories/bibleSearchRepository.ts
@@ -1,0 +1,108 @@
+import { Effect } from 'effect'
+import { type Kysely } from 'kysely'
+
+import { tryDatabasePromise } from '../database/databaseEffect'
+import { makeNeonDatabase, type NeonDatabaseConfig } from '../database/neonDatabase'
+import type { ResourceDatabase } from '../database/types'
+import {
+  ActiveBibleSearchPublicationUnavailable,
+  BibleSearchRepositoryFailure,
+  type BibleSearchInput,
+  type BibleSearchRepositoryService,
+} from '../domain/bibleSearch'
+
+type BibleMetadata = {
+  resource_revision?: string
+  text_revision?: string
+  text_sha256?: string
+}
+
+const metadata = (value: Record<string, unknown>) => value as BibleMetadata
+
+const highlight = (text: string, query: string) => {
+  const terms = query
+    .trim()
+    .split(/\s+/u)
+    .filter(Boolean)
+    .map(term => term.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&'))
+  if (terms.length === 0) return text
+  const pattern = new RegExp(`(${terms.join('|')})`, 'giu')
+  return text.replace(pattern, '{{$1}}')
+}
+
+export const makeKyselyBibleSearchRepository = (
+  database: Kysely<ResourceDatabase>
+): BibleSearchRepositoryService => ({
+  search: input =>
+    Effect.gen(function* () {
+      const publication = yield* tryDatabasePromise('bible.search.read-publication', () =>
+        database
+          .selectFrom('resource_publications')
+          .select(['id', 'revision', 'metadata'])
+          .where('resource_identity', '=', `bible-text:${input.versionId}`)
+          .where('status', '=', 'active')
+          .executeTakeFirst()
+      ).pipe(Effect.mapError(cause => new BibleSearchRepositoryFailure({ cause })))
+      if (!publication) {
+        return yield* new ActiveBibleSearchPublicationUnavailable({ versionId: input.versionId })
+      }
+
+      const query = input.query.trim()
+      const pattern = `%${query}%`
+      let filtered = database
+        .selectFrom('bible_verses')
+        .select(['book', 'chapter', 'verse', 'text'])
+        .where('publication_id', '=', publication.id)
+        .where('text', 'ilike', pattern)
+      if (input.book !== undefined) filtered = filtered.where('book', '=', input.book)
+      if (input.section === 'ot') filtered = filtered.where('book', '<=', 39)
+      if (input.section === 'nt') filtered = filtered.where('book', '>=', 40)
+
+      const countRow = yield* tryDatabasePromise('bible.search.count', () =>
+        filtered
+          .clearSelect()
+          .select(expression => expression.fn.count('verse').as('count'))
+          .executeTakeFirst()
+      ).pipe(Effect.mapError(cause => new BibleSearchRepositoryFailure({ cause })))
+      const count = Number(countRow?.count ?? 0)
+      const sortOrder = input.sortOrder ?? 'relevance'
+      const rows = yield* tryDatabasePromise('bible.search.read-results', () => {
+        let ordered = filtered
+        if (sortOrder === 'book') {
+          ordered = ordered.orderBy('book').orderBy('chapter').orderBy('verse')
+        } else {
+          ordered = ordered.orderBy('book').orderBy('chapter').orderBy('verse')
+        }
+        return ordered
+          .limit(input.limit ?? 100)
+          .offset(input.offset ?? 0)
+          .execute()
+      }).pipe(Effect.mapError(cause => new BibleSearchRepositoryFailure({ cause })))
+      const bibleMetadata = metadata(publication.metadata)
+      return {
+        versionId: input.versionId,
+        revision:
+          bibleMetadata.resource_revision ?? bibleMetadata.text_revision ?? publication.revision,
+        textRevision:
+          bibleMetadata.text_revision ?? bibleMetadata.resource_revision ?? publication.revision,
+        ...(bibleMetadata.text_sha256 ? { textSha256: bibleMetadata.text_sha256 } : {}),
+        count,
+        results: rows.map(row => ({
+          version: input.versionId,
+          book: row.book,
+          chapter: row.chapter,
+          verse: row.verse,
+          text: row.text,
+          highlighted: highlight(row.text, query),
+        })),
+      }
+    }),
+})
+
+export const makeNeonBibleSearchRepository = (config: NeonDatabaseConfig) => {
+  const database = makeNeonDatabase(config)
+  return {
+    repository: makeKyselyBibleSearchRepository(database),
+    dispose: () => database.destroy(),
+  }
+}

--- a/resource-service/src/runtime/node.ts
+++ b/resource-service/src/runtime/node.ts
@@ -6,6 +6,7 @@ import { createServer } from 'node:http'
 
 import { makeLocalDatabase } from '../database/localDatabase'
 import { BibleChapterRepository } from '../domain/bibleChapter'
+import { BibleSearchRepository } from '../domain/bibleSearch'
 import { NaveRepository } from '../domain/nave'
 import { DictionaryRepository } from '../domain/dictionary'
 import { StrongBibleRepository } from '../domain/strongBible'
@@ -15,6 +16,7 @@ import { SupplementaryRepository } from '../domain/supplementary'
 import { TimelineRepository } from '../domain/timeline'
 import { ResourceApiLive } from '../http/app'
 import { makeKyselyBibleChapterRepository } from '../repositories/bibleChapterRepository'
+import { makeKyselyBibleSearchRepository } from '../repositories/bibleSearchRepository'
 import { makeKyselyNaveRepository } from '../repositories/naveRepository'
 import { makeKyselyDictionaryRepository } from '../repositories/dictionaryRepository'
 import { makeKyselyStrongBibleRepository } from '../repositories/strongBibleRepository'
@@ -37,6 +39,7 @@ const RepositoryLive = Layer.mergeAll(
       Effect.promise(() => database.destroy())
     )
   ),
+  Layer.succeed(BibleSearchRepository, makeKyselyBibleSearchRepository(database)),
   Layer.succeed(NaveRepository, makeKyselyNaveRepository(database)),
   Layer.succeed(DictionaryRepository, makeKyselyDictionaryRepository(database)),
   Layer.succeed(StrongBibleRepository, makeKyselyStrongBibleRepository(database)),

--- a/resource-service/src/runtime/worker.ts
+++ b/resource-service/src/runtime/worker.ts
@@ -1,5 +1,6 @@
 import { makeResourceWebHandler } from '../http/app'
 import type { BibleChapterRepositoryService } from '../domain/bibleChapter'
+import type { BibleSearchRepositoryService } from '../domain/bibleSearch'
 import type { NaveRepositoryService } from '../domain/nave'
 import type { DictionaryRepositoryService } from '../domain/dictionary'
 import type { StrongBibleRepositoryService } from '../domain/strongBible'
@@ -8,6 +9,7 @@ import type { StrongLexiconRepositoryService } from '../domain/strongLexicon'
 import type { SupplementaryRepositoryService } from '../domain/supplementary'
 import type { TimelineRepositoryService } from '../domain/timeline'
 import { makeNeonBibleChapterRepository } from '../repositories/bibleChapterRepository'
+import { makeNeonBibleSearchRepository } from '../repositories/bibleSearchRepository'
 import { makeNeonNaveRepository } from '../repositories/naveRepository'
 import { makeNeonDictionaryRepository } from '../repositories/dictionaryRepository'
 import { makeNeonStrongBibleRepository } from '../repositories/strongBibleRepository'
@@ -28,9 +30,11 @@ export const makeResourceWorkerHandler = (
   interlinearBibleRepository?: InterlinearBibleRepositoryService,
   strongLexiconRepository?: StrongLexiconRepositoryService,
   supplementaryRepository?: SupplementaryRepositoryService,
-  timelineRepository?: TimelineRepositoryService
+  timelineRepository?: TimelineRepositoryService,
+  bibleSearchRepository?: BibleSearchRepositoryService
 ) =>
   makeResourceWebHandler(repository, naveRepository, {
+    bibleSearch: bibleSearchRepository,
     dictionary: dictionaryRepository,
     strongBible: strongBibleRepository,
     interlinearBible: interlinearBibleRepository,
@@ -49,6 +53,7 @@ let cached:
 const getWorkerHandler = (connectionString: string) => {
   if (cached?.connectionString === connectionString) return cached.web
   const { repository } = makeNeonBibleChapterRepository({ connectionString })
+  const { repository: bibleSearchRepository } = makeNeonBibleSearchRepository({ connectionString })
   const { repository: naveRepository } = makeNeonNaveRepository({ connectionString })
   const { repository: dictionaryRepository } = makeNeonDictionaryRepository({ connectionString })
   const { repository: strongBibleRepository } = makeNeonStrongBibleRepository({ connectionString })
@@ -70,7 +75,8 @@ const getWorkerHandler = (connectionString: string) => {
     interlinearBibleRepository,
     strongLexiconRepository,
     supplementaryRepository,
-    timelineRepository
+    timelineRepository,
+    bibleSearchRepository
   )
   cached = { connectionString, web }
   return web

--- a/scripts/smokeBibleSearchResourceService.mjs
+++ b/scripts/smokeBibleSearchResourceService.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+
+const baseUrl = process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787'
+
+const request = async path => {
+  const response = await fetch(`${baseUrl}${path}`, { headers: { accept: 'application/json' } })
+  const body = await response.json().catch(() => undefined)
+  return { response, body }
+}
+
+const search = await request('/v1/bibles/LSG/search?q=Dieu&limit=3&sortOrder=book')
+assert.equal(search.response.status, 200)
+assert.equal(search.body.resource.versionId, 'LSG')
+assert.equal(search.body.results.length, 3)
+assert.ok(search.body.count > search.body.results.length)
+assert.match(search.body.results[0].highlighted, /\{\{Dieu\}\}/u)
+assert.deepEqual(
+  search.body.results.map(result => [result.book, result.chapter, result.verse]),
+  [
+    [1, 1, 1],
+    [1, 1, 2],
+    [1, 1, 3],
+  ]
+)
+
+const nt = await request('/v1/bibles/LSG/search?q=Dieu&section=nt&limit=2')
+assert.equal(nt.response.status, 200)
+assert.ok(nt.body.results.every(result => result.book >= 40))
+
+const cached = await fetch(`${baseUrl}/v1/bibles/LSG/search?q=Dieu&limit=3&sortOrder=book`, {
+  headers: { 'if-none-match': search.response.headers.get('etag') },
+})
+assert.equal(cached.status, 304)
+
+console.log(
+  JSON.stringify({
+    revision: search.body.resource.revision,
+    resultCount: search.body.count,
+    ntCount: nt.body.count,
+    cached: cached.status,
+  })
+)

--- a/src/features/resources/bibleChapterContract.ts
+++ b/src/features/resources/bibleChapterContract.ts
@@ -10,6 +10,26 @@ export class BibleVersionPath extends Schema.Class<BibleVersionPath>('BibleVersi
   version: BibleChapterRequest.fields.version,
 }) {}
 
+export class BibleSearchQuery extends Schema.Class<BibleSearchQuery>('BibleSearchQuery')({
+  q: Schema.NonEmptyString,
+  book: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 77))),
+  section: Schema.optional(Schema.Literal('ot', 'nt')),
+  sortOrder: Schema.optional(Schema.Literal('relevance', 'book')),
+  limit: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.between(1, 100))),
+  offset: Schema.optional(Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative())),
+}) {}
+
+export class BibleSearchResultDto extends Schema.Class<BibleSearchResultDto>(
+  'BibleSearchResultDto'
+)({
+  version: Schema.NonEmptyString,
+  book: Schema.Int.pipe(Schema.positive()),
+  chapter: Schema.Int.pipe(Schema.positive()),
+  verse: Schema.Int.pipe(Schema.nonNegative()),
+  text: Schema.String,
+  highlighted: Schema.String,
+}) {}
+
 export class BibleVersePresentationDto extends Schema.Class<BibleVersePresentationDto>(
   'BibleVersePresentationDto'
 )({
@@ -67,6 +87,14 @@ export class BibleTextRevisionDto extends Schema.Class<BibleTextRevisionDto>(
   revision: Schema.NonEmptyString,
   textRevision: Schema.optional(Schema.NonEmptyString),
   textSha256: Schema.optional(Schema.String.pipe(Schema.pattern(/^[a-f0-9]{64}$/))),
+}) {}
+
+export class BibleSearchResponseDto extends Schema.Class<BibleSearchResponseDto>(
+  'BibleSearchResponseDto'
+)({
+  resource: BibleTextRevisionDto,
+  results: Schema.Array(BibleSearchResultDto),
+  count: Schema.NonNegativeInt,
 }) {}
 
 export class BibleChapterDto extends Schema.Class<BibleChapterDto>('BibleChapterDto')({

--- a/src/features/resources/bibleSearchAccess.ts
+++ b/src/features/resources/bibleSearchAccess.ts
@@ -5,6 +5,9 @@ import {
   type SearchOptions,
   type SearchResult,
 } from '~helpers/biblesDb'
+import { Schema } from 'effect'
+import { BibleSearchResponseDto } from './bibleChapterContract'
+import { ResourceAccessError } from './resourceAccessError'
 
 export type { SearchOptions, SearchResult, SearchSortOrder } from '~helpers/biblesDb'
 
@@ -18,4 +21,142 @@ export const localBibleSearchAccess: BibleSearchAccess = {
   getInstalledVersions,
   searchVerses,
   searchVersesCount,
+}
+
+type HttpBibleSearchAccessOptions = {
+  baseUrl: string
+  versions: readonly string[]
+  fetcher?: typeof fetch
+  isOnline: () => Promise<boolean>
+  timeoutMs?: number
+}
+
+const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '')
+
+const requestError = (status: number, code: unknown) => {
+  if (status === 404 && code === 'BIBLE_UNSUPPORTED') {
+    return new ResourceAccessError('RESOURCE_UNSUPPORTED', ['acquire-offline-copy'])
+  }
+  if (status === 503) return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+  return new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+}
+
+export const createHttpBibleSearchAccess = ({
+  baseUrl,
+  versions,
+  fetcher = fetch,
+  isOnline,
+  timeoutMs = 10_000,
+}: HttpBibleSearchAccessOptions): BibleSearchAccess => {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+
+  const searchVersion = async (version: string, query: string, options: SearchOptions = {}) => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const params = new URLSearchParams({ q: query })
+      if (options.book !== undefined) params.set('book', String(options.book))
+      if (options.section) params.set('section', options.section)
+      if (options.sortOrder) params.set('sortOrder', options.sortOrder)
+      if (options.limit !== undefined) params.set('limit', String(options.limit))
+      if (options.offset !== undefined) params.set('offset', String(options.offset))
+      const response = await fetcher(
+        `${normalizedBaseUrl}/v1/bibles/${encodeURIComponent(version)}/search?${params}`,
+        { headers: { accept: 'application/json' }, signal: controller.signal }
+      )
+      const payload: unknown = await response.json().catch(() => undefined)
+      if (!response.ok) {
+        const code =
+          payload && typeof payload === 'object' && 'code' in payload ? payload.code : undefined
+        throw requestError(response.status, code)
+      }
+      try {
+        return Schema.decodeUnknownSync(BibleSearchResponseDto)(payload)
+      } catch {
+        throw new ResourceAccessError('INTEGRITY_FAILURE')
+      }
+    } catch (error) {
+      if (error instanceof ResourceAccessError) throw error
+      throw new ResourceAccessError(
+        (await isOnline()) ? 'TEMPORARY_UNAVAILABLE' : 'NETWORK_OFFLINE'
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  const run = async (query: string, options: SearchOptions = {}) => {
+    const requestedVersions = options.version ? [options.version] : [...versions]
+    if (requestedVersions.length === 0) throw new ResourceAccessError('RESOURCE_UNSUPPORTED')
+    const results = await Promise.allSettled(
+      requestedVersions.map(version => searchVersion(version, query, options))
+    )
+    const fulfilled = results.flatMap(result =>
+      result.status === 'fulfilled' ? [result.value] : []
+    )
+    if (fulfilled.length === 0) {
+      const failure = results.find(result => result.status === 'rejected')
+      throw failure?.reason ?? new ResourceAccessError('TEMPORARY_UNAVAILABLE')
+    }
+    return {
+      results: fulfilled.flatMap(value => Array.from(value.results)),
+      count: fulfilled.reduce((total, value) => total + value.count, 0),
+    }
+  }
+
+  return {
+    getInstalledVersions: async () => [...versions],
+    searchVerses: async (query, options) => {
+      const result = await run(query, options)
+      return result.results
+    },
+    searchVersesCount: async (query, options) => {
+      const result = await run(query, options)
+      return result.count
+    },
+  }
+}
+
+export const createHybridBibleSearchAccess = ({
+  offline,
+  online,
+  remotelyReadableVersions,
+  isOnline,
+}: {
+  offline: BibleSearchAccess
+  online: BibleSearchAccess
+  remotelyReadableVersions: ReadonlySet<string>
+  isOnline: () => Promise<boolean>
+}): BibleSearchAccess => {
+  const run = async <T>(
+    operation: (access: BibleSearchAccess) => Promise<T>,
+    fallback: () => Promise<T>
+  ) => {
+    if (await isOnline()) {
+      try {
+        return await operation(online)
+      } catch (error) {
+        if (!(error instanceof ResourceAccessError) || error.code === 'INTEGRITY_FAILURE') {
+          throw error
+        }
+      }
+    }
+    return fallback()
+  }
+  return {
+    getInstalledVersions: async () => {
+      const local = await offline.getInstalledVersions()
+      return Array.from(new Set([...local, ...remotelyReadableVersions]))
+    },
+    searchVerses: (query, options) =>
+      run(
+        access => access.searchVerses(query, options),
+        () => offline.searchVerses(query, options)
+      ),
+    searchVersesCount: (query, options) =>
+      run(
+        access => access.searchVersesCount(query, options),
+        () => offline.searchVersesCount(query, options)
+      ),
+  }
 }

--- a/src/features/resources/resourceAccess.tsx
+++ b/src/features/resources/resourceAccess.tsx
@@ -21,6 +21,8 @@ import {
   type BibleReadingResourceAccess,
 } from '~features/resources/bibleReadingResourceAccess'
 import {
+  createHttpBibleSearchAccess,
+  createHybridBibleSearchAccess,
   localBibleSearchAccess,
   type BibleSearchAccess,
 } from '~features/resources/bibleSearchAccess'
@@ -223,6 +225,13 @@ const remotelyReadableStrongLexiconModules = new Set(
 const remotelyReadableBibleVersions = new Set(
   resourceApiBaseUrl ? (__DEV__ ? getMobileBibleVersionIds() : PUBLIC_ONLINE_BIBLE_VERSION_IDS) : []
 )
+const onlineBibleSearchAccess = resourceApiBaseUrl
+  ? createHttpBibleSearchAccess({
+      baseUrl: resourceApiBaseUrl,
+      versions: [...remotelyReadableBibleVersions],
+      isOnline: async () => onlineManager.isOnline(),
+    })
+  : localBibleSearchAccess
 const onlineBibleReadingAccess = resourceApiBaseUrl
   ? createHttpBibleReadingResourceAccess({
       baseUrl: resourceApiBaseUrl,
@@ -269,7 +278,12 @@ export const defaultResourceAccess: ResourceAccessRegistry = {
     remotelyReadableVersions: remotelyReadableBibleVersions,
     isOnline: async () => onlineManager.isOnline(),
   }),
-  bibleSearch: localBibleSearchAccess,
+  bibleSearch: createHybridBibleSearchAccess({
+    offline: localBibleSearchAccess,
+    online: onlineBibleSearchAccess,
+    remotelyReadableVersions: remotelyReadableBibleVersions,
+    isOnline: async () => onlineManager.isOnline(),
+  }),
   dictionary: createHybridDictionaryAccess({
     offline: localDictionaryAccess,
     online: onlineDictionaryAccess,


### PR DESCRIPTION
## Résumé
- ajoute la recherche Bible via le service HTTP local/Postgres ;
- conserve le fallback local et le mode online-first dans l’application ;
- ajoute un smoke script reproductible, sans E2E.

## Vérifications
- `yarn typecheck`
- `yarn resources:architecture:check`
- `yarn format:check`
- `RESOURCE_API_BASE_URL=http://127.0.0.1:8793 yarn resources:smoke:bible-search`

La mise en ligne de la base et les tests E2E restent hors périmètre.