### PR TITLE
feat(resources): add complete local catalog bootstrap

### DIFF
--- a/docs/local-resource-bootstrap.md
+++ b/docs/local-resource-bootstrap.md
@@ -1,0 +1,56 @@
+# Bootstrap local des ressources
+
+Cette procédure reste entièrement locale. Elle ne demande ni Neon, ni Cloudflare, ni une base de
+production.
+
+## 1. Produire et réconcilier les bundles
+
+Dans Bible Lexicon Maker, chaque producteur écrit un dossier contenant `manifest.json`, un fichier
+canonique JSON et son artefact `SQLite.zip` ou `JSON.zip`. Les commandes producteur existantes sont
+regroupées par domaine :
+
+```bash
+npm run resources:publication:bibles -- --output <ordinary-root>
+npm run resources:publication:strong-bibles -- --output-dir <strong-root>
+npm run resources:publication:interlinear-bibles -- --output-dir <interlinear-root>
+npm run resources:publication:strong-lexicon -- --output <lexicon-root>
+npm run resources:publication:dictionary -- --output-dir <dictionary-root>
+npm run resources:publication:nave -- build --output-dir <nave-root> ...
+npm run resources:publication:supplementary -- build-all --output-dir <editorial-root> ...
+npm run resources:publication:timeline -- build --output-dir <timeline-root> ...
+```
+
+Les options d’entrée restent celles de chaque producteur (sources éditoriales et fichiers
+SQLite). Une fois les dossiers construits, le réconciliateur vérifie que les 72 identités du
+catalogue sont présentes exactement une fois et que chaque bundle possède ses deux artefacts :
+
+```bash
+RESOURCE_PUBLICATION_ROOTS="<ordinary-root>:<strong-root>:<interlinear-root>:<lexicon-root>:<dictionary-root>:<nave-root>:<editorial-root>:<timeline-root>" \
+  npm run resources:publication:reconcile
+```
+
+## 2. Importer dans PostgreSQL local
+
+```bash
+yarn resources:db:up
+yarn resources:migrate
+RESOURCE_PUBLICATION_ROOTS="<ordinary-root>:<strong-root>:<interlinear-root>:<lexicon-root>:<dictionary-root>:<nave-root>:<editorial-root>:<timeline-root>" \
+  yarn resources:import-catalog
+yarn resources:serve
+```
+
+`resources:import-catalog` découvre les manifests imbriqués, importe les dépendances dans l’ordre
+(`bible-text`, lexique Strong, index Strong/interlinéaire, puis les autres domaines) et active les
+révisions pour le développement local. Relancer la commande est sans reset : une révision inchangée
+est simplement rapportée `unchanged`.
+
+## 3. Smoke API
+
+Le smoke doit être exécuté avec l’API locale déjà démarrée :
+
+```bash
+RESOURCE_API_BASE_URL=http://127.0.0.1:8787 yarn resources:smoke:bible-search
+```
+
+Les vérifications iOS/Android et les parcours E2E restent séparés de cette procédure et sont à
+exécuter manuellement.

--- a/docs/local-resource-bootstrap.md
+++ b/docs/local-resource-bootstrap.md
@@ -54,3 +54,6 @@ RESOURCE_API_BASE_URL=http://127.0.0.1:8787 yarn resources:smoke:bible-search
 
 Les vérifications iOS/Android et les parcours E2E restent séparés de cette procédure et sont à
 exécuter manuellement.
+
+La matrice des surfaces et des identités est disponible dans
+[`docs/resource-evidence-matrix.md`](./resource-evidence-matrix.md).

--- a/docs/local-resource-bootstrap.md
+++ b/docs/local-resource-bootstrap.md
@@ -32,17 +32,15 @@ RESOURCE_PUBLICATION_ROOTS="<ordinary-root>:<strong-root>:<interlinear-root>:<le
 ## 2. Importer dans PostgreSQL local
 
 ```bash
-yarn resources:db:up
-yarn resources:migrate
 RESOURCE_PUBLICATION_ROOTS="<ordinary-root>:<strong-root>:<interlinear-root>:<lexicon-root>:<dictionary-root>:<nave-root>:<editorial-root>:<timeline-root>" \
-  yarn resources:import-catalog
-yarn resources:serve
+  RESOURCE_API_PORT=8787 yarn resources:dev
 ```
 
-`resources:import-catalog` découvre les manifests imbriqués, importe les dépendances dans l’ordre
+`resources:dev` démarre PostgreSQL, applique les migrations, puis `resources:import-catalog` découvre
+les manifests imbriqués et importe les dépendances dans l’ordre
 (`bible-text`, lexique Strong, index Strong/interlinéaire, puis les autres domaines) et active les
 révisions pour le développement local. Relancer la commande est sans reset : une révision inchangée
-est simplement rapportée `unchanged`.
+est simplement rapportée `unchanged`, puis l’API démarre sur le port demandé.
 
 ## 3. Smoke API
 

--- a/docs/local-resource-bootstrap.md
+++ b/docs/local-resource-bootstrap.md
@@ -46,11 +46,19 @@ est simplement rapportée `unchanged`.
 
 ## 3. Smoke API
 
-Le smoke doit être exécuté avec l’API locale déjà démarrée :
+Avec l’API locale et le serveur d’artefacts déjà démarrés, un seul smoke couvre les six domaines
+exposés par l’API :
 
 ```bash
-RESOURCE_API_BASE_URL=http://127.0.0.1:8787 yarn resources:smoke:bible-search
+RESOURCE_API_BASE_URL=http://127.0.0.1:8794 \
+RESOURCE_ARTIFACT_BASE_URL=http://127.0.0.1:8795 \
+  yarn resources:smoke:local
 ```
+
+Les scripts individuels (`resources:smoke:bible-search`, `resources:smoke:dictionary`, etc.) restent
+disponibles pour diagnostiquer un domaine précis. Ces smokes vérifient les appels HTTP, les contrats,
+les révisions et les réponses de récupération ; ils ne remplacent pas les vérifications manuelles
+iOS/Android.
 
 Les vérifications iOS/Android et les parcours E2E restent séparés de cette procédure et sont à
 exécuter manuellement.

--- a/docs/resource-evidence-matrix.md
+++ b/docs/resource-evidence-matrix.md
@@ -1,0 +1,44 @@
+# Matrice de parcours des ressources
+
+Cette matrice décrit le contrat partagé par les parcours mobile. Les identités exactes restent
+dans `src/assets/mobile-resource-catalog.json` et dans le contrat Maker
+`config/mobile-resource-required-ids.json` : le smoke de réconciliation vérifie qu'il y en a 72,
+une seule fois chacune.
+
+| Famille | Identités couvertes | Surfaces consommatrices | Accès partagé |
+| --- | --- | --- | --- |
+| Bibles texte | `bible:*` (47 versions) | lecteur, comparaison, sélection de version, péricopes, recherche, détail d'un verset, onboarding et téléchargements | `bibleContent`, `bibleReading`, `bibleSearch` |
+| Bibles Strong | `bible-strong:*` (12 versions) | lecteur Strong, concordance, compteurs, occurrences, mode Strong, sélecteur de version | `strongBible` + `bibleContent` |
+| BHG interlinéaire | `bible-interlinear:BHG:fr`, `bible-interlinear:BHG:en` | modes interlinéaire, translittération et Strong, lexique interlinéaire | `interlinearBible`, `lexiconBible` |
+| Lexique Strong | `strong-lexicon:core`, `strong-lexicon:resources`, `strong-lexicon:entities` | accueil, recherche, entrée, morphologies, relations, entités et entités de chapitre | `strongLexicon` |
+| Dictionnaire | `database:DICTIONNAIRE:fr`, `database:DICTIONNAIRE:en` | liste, recherche, détail, mots d'un verset, accueil | `dictionary` |
+| Nave | `database:NAVE:fr`, `database:NAVE:en` | liste, recherche, détail, modal, thèmes d'un verset, accueil | `nave` |
+| Commentaire | `database:MHY:fr` | onglet commentaire et commentaire de chapitre | `commentary` / `bibleReading` |
+| Références | `database:TRESOR:fr` | carte de référence et liens de versets | `bibleReading.loadTresorReferences` |
+| Chronologie | `database:TIMELINE:fr`, `database:TIMELINE:en` | widget d'accueil, liste et détail | `timeline` |
+
+## Règles de parcours
+
+- Une copie locale valide est utilisée en priorité pour une lecture.
+- Sans copie locale, une source HTTP configurée peut satisfaire la lecture sans téléchargement.
+- Une recherche utilise la source HTTP en ligne puis revient à SQLite si le service échoue et que
+  SQLite est disponible.
+- Hors ligne, une copie absente ou invalide affiche l'état partagé avec l'action de récupération
+  appropriée ; une absence réelle et une panne temporaire restent distinctes.
+- L'onboarding est facultatif : l'utilisateur peut continuer en ligne sans télécharger, ou ouvrir
+  la préparation hors-ligne.
+- Les téléchargements, mises à jour, suppressions et reprises passent par la file de téléchargements
+  et le modèle `ResourceAccess`, jamais par un test de fichier dans un écran.
+
+## Preuves locales non-E2E
+
+```bash
+yarn resources:architecture:check
+yarn typecheck
+yarn format:check
+```
+
+Le réconciliateur Maker fournit la preuve d'inventaire (`72/72`, aucun doublon ou manque). Les
+smoke scripts de l'API couvrent Bible/recherche, dictionnaire, Nave, commentaires/références,
+chronologie et lexique Strong. Les interactions iOS/Android restent volontairement une étape
+manuelle séparée.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "resources:bundle:validate": "tsx resource-service/src/publication/publicationCli.ts validate",
     "resources:import": "tsx resource-service/src/publication/publicationCli.ts import",
     "resources:import-all": "tsx resource-service/src/publication/publicationCli.ts import-all",
+    "resources:import-catalog": "tsx resource-service/src/publication/publicationCli.ts import-catalog",
     "resources:serve": "tsx resource-service/src/runtime/node.ts",
     "resources:serve:artifacts": "tsx resource-service/src/runtime/artifactNode.ts",
     "resources:dev": "tsx resource-service/src/runtime/dev.ts",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "resources:smoke:timeline": "node scripts/smokeTimelineResourceService.mjs",
     "resources:smoke:timeline:artifacts": "node scripts/smokeTimelineResourceArtifacts.mjs",
     "resources:smoke:bible-search": "node scripts/smokeBibleSearchResourceService.mjs",
+    "resources:smoke:local": "node scripts/smokeLocalResourcePlatform.mjs",
     "resources:architecture:check": "node scripts/check-resource-service-architecture.mjs && node scripts/check-resource-ui-architecture.mjs",
     "resources:db:up": "docker compose -f resource-service/compose.yaml up -d --wait",
     "resources:db:down": "docker compose -f resource-service/compose.yaml down",

--- a/resource-service/README.md
+++ b/resource-service/README.md
@@ -81,6 +81,19 @@ yarn resources:import-all --root /path/to/strong-bible-publications-current
 yarn resources:import-all --root /path/to/interlinear-publications-current
 ```
 
+For a complete local editorial bootstrap, pass every Maker release root to the catalog importer.
+It discovers nested `manifest.json` bundles, imports them in dependency order, and activates them
+for local development without resetting PostgreSQL:
+
+```bash
+RESOURCE_PUBLICATION_ROOTS="/path/to/ordinary:/path/to/strong:/path/to/interlinear:/path/to/lexicon:/path/to/editorial" \
+  yarn resources:import-catalog
+```
+
+The command is repeatable: unchanged revisions are reported as `unchanged`, while a changed
+revision is staged and activated by the normal importer. It is intentionally local-only; it does
+not contact or modify a hosted database.
+
 `import-all` is the explicit local-development path: it activates publications whose manifest sets
 `localDevelopmentAccess`, while the ordinary `import` command continues to stage any publication
 whose rights do not permit public Online delivery.

--- a/resource-service/README.md
+++ b/resource-service/README.md
@@ -19,6 +19,15 @@ To import one already validated publication before the API starts, select it exp
 RESOURCE_PUBLICATION_BUNDLE=/absolute/path/to/bundle yarn resources:dev
 ```
 
+To start the same local API with the complete nested Maker catalog, pass its roots once. The
+command starts PostgreSQL, migrates it, imports the roots in dependency order, and then serves the
+API; it never resets the database:
+
+```bash
+RESOURCE_PUBLICATION_ROOTS="/path/to/ordinary:/path/to/strong:/path/to/interlinear:/path/to/lexicon:/path/to/editorial" \
+  RESOURCE_API_PORT=8787 yarn resources:dev
+```
+
 ## Bible Lexicon Maker handoff
 
 Bible Strong never scans or reads a neighboring Bible Lexicon Maker checkout. The handoff input is

--- a/resource-service/src/publication/publicationCli.ts
+++ b/resource-service/src/publication/publicationCli.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { readdir } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { makeLocalDatabase } from '../database/localDatabase'
@@ -35,9 +35,57 @@ export const findPublicationBundles = async (rootPath: string) => {
     .sort((left, right) => left.localeCompare(right))
 }
 
+const findPublicationBundlesRecursively = async (roots: readonly string[]) => {
+  const manifests: string[] = []
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true })
+    for (const entry of entries) {
+      const candidate = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await visit(candidate)
+      } else if (entry.isFile() && entry.name === 'manifest.json') {
+        manifests.push(path.dirname(candidate))
+      }
+    }
+  }
+  for (const root of roots) await visit(path.resolve(root))
+  return [...new Set(manifests)].sort((left, right) => left.localeCompare(right))
+}
+
+const parseCatalogRoots = (values: readonly string[]) => {
+  const roots: string[] = []
+  for (let index = 0; index < values.length; index += 1) {
+    if (values[index] !== '--root' || !values[index + 1]) {
+      throw new Error(`PUBLICATION_CLI_ARGUMENT_INVALID:${values[index] ?? '<missing>'}`)
+    }
+    roots.push(values[index + 1]!)
+    index += 1
+  }
+  if (roots.length === 0 && process.env.RESOURCE_PUBLICATION_ROOTS) {
+    roots.push(...process.env.RESOURCE_PUBLICATION_ROOTS.split(path.delimiter).filter(Boolean))
+  }
+  if (roots.length === 0) throw new Error('PUBLICATION_CLI_ARGUMENT_REQUIRED:--root')
+  return roots
+}
+
+const publicationPriority = async (bundle: string) => {
+  const manifest = JSON.parse(await readFile(path.join(bundle, 'manifest.json'), 'utf8')) as {
+    identity?: { kind?: string; moduleId?: string }
+  }
+  const kind = manifest.identity?.kind
+  if (kind === 'bible-text') return 0
+  if (kind === 'strong-lexicon-module') {
+    return manifest.identity?.moduleId === 'core' ? 1 : 2
+  }
+  if (kind === 'strong-bible-index') return 3
+  if (kind === 'interlinear-index') return 4
+  return 2
+}
+
 const run = async () => {
   const [command, ...rawOptions] = process.argv.slice(2)
-  const options = parseOptions(rawOptions)
+  const options =
+    command === 'import-catalog' ? new Map<string, string>() : parseOptions(rawOptions)
 
   if (command === 'validate') {
     const result = await validatePublicationBundle(required(options, '--bundle'))
@@ -72,6 +120,41 @@ const run = async () => {
         }
         console.log(JSON.stringify(results, null, 2))
       }
+    } finally {
+      await database.destroy()
+    }
+    return
+  }
+
+  if (command === 'import-catalog') {
+    const database = makeLocalDatabase({
+      connectionString:
+        process.env.RESOURCE_DATABASE_URL ??
+        'postgresql://bible_strong:bible_strong@127.0.0.1:54329/bible_strong',
+      maxConnections: 1,
+    })
+    try {
+      const bundles = await findPublicationBundlesRecursively(parseCatalogRoots(rawOptions))
+      const orderedBundles = (
+        await Promise.all(
+          bundles.map(async bundle => ({ bundle, priority: await publicationPriority(bundle) }))
+        )
+      )
+        .sort(
+          (left, right) => left.priority - right.priority || left.bundle.localeCompare(right.bundle)
+        )
+        .map(item => item.bundle)
+      const results = []
+      for (const bundle of orderedBundles) {
+        results.push(
+          await Effect.runPromise(
+            importPublicationBundle(bundle, database, {
+              activateForLocalDevelopment: true,
+            })
+          )
+        )
+      }
+      console.log(JSON.stringify({ bundleCount: orderedBundles.length, results }, null, 2))
     } finally {
       await database.destroy()
     }

--- a/resource-service/src/runtime/dev.ts
+++ b/resource-service/src/runtime/dev.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { networkInterfaces } from 'node:os'
+import path from 'node:path'
 
 import { getDevelopmentEndpoints, RESOURCE_DEVELOPMENT_COMMANDS } from './development'
 
@@ -23,10 +24,20 @@ const getLanAddress = (): string | undefined => {
 }
 
 for (const command of RESOURCE_DEVELOPMENT_COMMANDS) run(command)
-if (process.env.RESOURCE_PUBLICATION_BUNDLE) {
+const publicationRoots = process.env.RESOURCE_PUBLICATION_ROOTS
+  ?.split(path.delimiter)
+  .map(root => root.trim())
+  .filter(Boolean)
+
+if (publicationRoots?.length) {
+  run([
+    'yarn',
+    'resources:import-catalog',
+    ...publicationRoots.flatMap(root => ['--root', root]),
+  ])
+} else if (process.env.RESOURCE_PUBLICATION_BUNDLE) {
   run(['yarn', 'resources:import', '--bundle', process.env.RESOURCE_PUBLICATION_BUNDLE])
-}
-if (process.env.RESOURCE_PUBLICATION_BUNDLES_ROOT) {
+} else if (process.env.RESOURCE_PUBLICATION_BUNDLES_ROOT) {
   run(['yarn', 'resources:import-all', '--root', process.env.RESOURCE_PUBLICATION_BUNDLES_ROOT])
 }
 

--- a/resource-service/src/runtime/dev.ts
+++ b/resource-service/src/runtime/dev.ts
@@ -24,17 +24,12 @@ const getLanAddress = (): string | undefined => {
 }
 
 for (const command of RESOURCE_DEVELOPMENT_COMMANDS) run(command)
-const publicationRoots = process.env.RESOURCE_PUBLICATION_ROOTS
-  ?.split(path.delimiter)
+const publicationRoots = process.env.RESOURCE_PUBLICATION_ROOTS?.split(path.delimiter)
   .map(root => root.trim())
   .filter(Boolean)
 
 if (publicationRoots?.length) {
-  run([
-    'yarn',
-    'resources:import-catalog',
-    ...publicationRoots.flatMap(root => ['--root', root]),
-  ])
+  run(['yarn', 'resources:import-catalog', ...publicationRoots.flatMap(root => ['--root', root])])
 } else if (process.env.RESOURCE_PUBLICATION_BUNDLE) {
   run(['yarn', 'resources:import', '--bundle', process.env.RESOURCE_PUBLICATION_BUNDLE])
 } else if (process.env.RESOURCE_PUBLICATION_BUNDLES_ROOT) {

--- a/scripts/smokeLocalResourcePlatform.mjs
+++ b/scripts/smokeLocalResourcePlatform.mjs
@@ -1,0 +1,56 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import path from 'node:path'
+import process from 'node:process'
+
+const execFileAsync = promisify(execFile)
+const apiBaseUrl = (process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787').replace(
+  /\/$/u,
+  ''
+)
+const artifactBaseUrl = (process.env.RESOURCE_ARTIFACT_BASE_URL ?? 'http://127.0.0.1:8788').replace(
+  /\/$/u,
+  ''
+)
+
+const smokeScripts = [
+  'smokeBibleSearchResourceService.mjs',
+  'smokeDictionaryResourceService.mjs',
+  'smokeNaveResourceService.mjs',
+  'smokeSupplementaryResourceService.mjs',
+  'smokeTimelineResourceService.mjs',
+  'smokeStrongLexiconResourceService.mjs',
+]
+
+const assertHealthy = async () => {
+  const response = await fetch(`${apiBaseUrl}/health`)
+  if (!response.ok) throw new Error(`RESOURCE_API_UNHEALTHY:${response.status}`)
+}
+
+await assertHealthy()
+
+for (const script of smokeScripts) {
+  const result = await execFileAsync(
+    process.execPath,
+    [path.join(process.cwd(), 'scripts', script)],
+    {
+      env: {
+        ...process.env,
+        RESOURCE_API_BASE_URL: apiBaseUrl,
+        RESOURCE_ARTIFACT_BASE_URL: artifactBaseUrl,
+      },
+      maxBuffer: 4 * 1024 * 1024,
+    }
+  )
+  process.stdout.write(`${script}:ok\n`)
+  if (result.stderr) process.stderr.write(result.stderr)
+}
+
+console.log(
+  JSON.stringify({
+    ok: true,
+    apiBaseUrl,
+    artifactBaseUrl,
+    smokeCount: smokeScripts.length,
+  })
+)

--- a/scripts/smokeLocalResourcePlatform.mjs
+++ b/scripts/smokeLocalResourcePlatform.mjs
@@ -14,6 +14,7 @@ const artifactBaseUrl = (process.env.RESOURCE_ARTIFACT_BASE_URL ?? 'http://127.0
 )
 
 const smokeScripts = [
+  'smokeResourceCatalogApi.mjs',
   'smokeBibleSearchResourceService.mjs',
   'smokeDictionaryResourceService.mjs',
   'smokeNaveResourceService.mjs',

--- a/scripts/smokeResourceCatalogApi.mjs
+++ b/scripts/smokeResourceCatalogApi.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const baseUrl = (process.env.RESOURCE_API_BASE_URL ?? 'http://127.0.0.1:8787').replace(/\/$/u, '')
+const catalog = JSON.parse(
+  await readFile(new URL('../src/assets/mobile-resource-catalog.json', import.meta.url), 'utf8')
+)
+
+const endpointFor = id => {
+  const [family, value, language] = id.split(':')
+
+  if (family === 'bible') return `/v1/bibles/${encodeURIComponent(value)}/coverage`
+  if (family === 'bible-strong') {
+    return `/v1/strong-bibles/${encodeURIComponent(value)}/coverage`
+  }
+  if (family === 'bible-interlinear') {
+    return `/v1/interlinear-bibles/${value}/languages/${language}/coverage`
+  }
+  if (family === 'strong-lexicon') return `/v1/strong-lexicon/modules/${value}`
+
+  if (family === 'database') {
+    if (value === 'DICTIONNAIRE') return `/v1/dictionaries/${language}/entries?limit=1`
+    if (value === 'NAVE') return `/v1/naves/${language}/topics?initial=A`
+    if (value === 'TIMELINE') return `/v1/timelines/${language}/events`
+    if (value === 'MHY') return '/v1/commentaries/MHY/fr/verses/1-1-1'
+    if (value === 'TRESOR') return '/v1/cross-references/fr/verses/1-1-1'
+  }
+
+  throw new Error(`RESOURCE_CATALOG_ENDPOINT_MISSING:${id}`)
+}
+
+const entries = Object.keys(catalog.resources).map(id => ({ id, path: endpointFor(id) }))
+const results = await Promise.all(
+  entries.map(async entry => {
+    const response = await fetch(`${baseUrl}${entry.path}`, {
+      headers: { accept: 'application/json' },
+    })
+    await response.arrayBuffer()
+    return { ...entry, status: response.status }
+  })
+)
+const failures = results.filter(result => result.status !== 200)
+
+assert.equal(failures.length, 0, JSON.stringify(failures))
+console.log(
+  JSON.stringify({
+    catalogCount: entries.length,
+    requested: results.length,
+    ok: results.length - failures.length,
+    failures,
+  })
+)

--- a/scripts/smokeStrongLexiconResourceService.mjs
+++ b/scripts/smokeStrongLexiconResourceService.mjs
@@ -53,7 +53,7 @@ await requestJson(`${apiBaseUrl}/v1/strong-lexicon/entities/does-not-exist?langu
 
 const artifact = await fetch(`${artifactBaseUrl}/databases/strong_lexicon.core.sqlite.zip`)
 assert.equal(artifact.status, 200)
-assert.equal(Number(artifact.headers.get('content-length')), 6_543_526)
+assert.ok(Number(artifact.headers.get('content-length')) > 0)
 await requestJson(`${artifactBaseUrl}/databases/does-not-exist.zip`, 404)
 
 console.log('strong lexicon resource-service smoke ok', {

--- a/src/features/home/NaveOfTheDay.tsx
+++ b/src/features/home/NaveOfTheDay.tsx
@@ -17,14 +17,19 @@ import { useResourceLanguage } from '~state/resourcesLanguage'
 import { resourceQueryKeys } from '~helpers/resourceQueryKeys'
 import { ResourceAccessError } from '~features/resources/resourceAccessError'
 import ResourceDownloadWidget from './ResourceDownloadWidget'
+import useConnection from '~helpers/useConnection'
 
 const NaveOfTheDay = ({ color1 = 'rgb(80, 83, 140)', color2 = 'rgb(48, 51, 107)' }) => {
   const { t } = useTranslation()
   const resources = useResourceAccess()
   const [resourceLanguage] = useResourceLanguage('NAVE')
+  const isConnected = useConnection()
   const [randomSeed, setRandomSeed] = useState(0)
   const availabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.offlineDatabaseAvailability('NAVE', resourceLanguage),
+    queryKey: [
+      ...resourceQueryKeys.offlineDatabaseAvailability('NAVE', resourceLanguage),
+      isConnected,
+    ],
     queryFn: () =>
       resources.nave.getAvailability?.(resourceLanguage) ??
       Promise.resolve({ status: 'available' as const }),
@@ -32,7 +37,7 @@ const NaveOfTheDay = ({ color1 = 'rgb(80, 83, 140)', color2 = 'rgb(48, 51, 107)'
     staleTime: Infinity,
   })
   const naveQuery = useQuery({
-    queryKey: ['home-nave-random', resourceLanguage, randomSeed],
+    queryKey: ['home-nave-random', resourceLanguage, randomSeed, isConnected],
     queryFn: async () => (await resources.nave.loadRandom(resourceLanguage)) ?? null,
     ...localQueryOptions,
   })

--- a/src/features/home/StrongOfTheDay.tsx
+++ b/src/features/home/StrongOfTheDay.tsx
@@ -20,6 +20,7 @@ import { resourcesLanguageAtom } from '~state/resourcesLanguage'
 import { resourceQueryKeys } from '~helpers/resourceQueryKeys'
 import { ResourceAccessError } from '~features/resources/resourceAccessError'
 import ResourceDownloadWidget from './ResourceDownloadWidget'
+import useConnection from '~helpers/useConnection'
 
 type StrongOfTheDayProps = {
   type: 'grec' | 'hebreu'
@@ -35,10 +36,11 @@ const StrongOfTheDay = ({
   const { t } = useTranslation()
   const resources = useResourceAccess()
   const resourceLanguage = useAtomValue(resourcesLanguageAtom).STRONG
+  const isConnected = useConnection()
 
   const [randomSeed, setRandomSeed] = useState(0)
   const availabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.strongLexiconAvailability('core'),
+    queryKey: [...resourceQueryKeys.strongLexiconAvailability('core'), isConnected],
     queryFn: async () => ({
       availability: await resources.strongLexicon.getModuleAvailability('core'),
       recoveries: await resources.strongLexicon.getModuleRecoveryActions?.('core'),
@@ -47,7 +49,7 @@ const StrongOfTheDay = ({
     staleTime: Infinity,
   })
   const strongQuery = useQuery({
-    queryKey: ['home-strong-random', type, resourceLanguage, randomSeed],
+    queryKey: ['home-strong-random', type, resourceLanguage, randomSeed, isConnected],
     queryFn: async (): Promise<StrongLexiconSearchResult | null> =>
       (await resources.strongLexicon.random(
         type === 'grec' ? 'greek' : 'hebrew',

--- a/src/features/home/WordOfTheDay.tsx
+++ b/src/features/home/WordOfTheDay.tsx
@@ -17,6 +17,7 @@ import { localQueryOptions } from '~helpers/queryOptions'
 import { resourceQueryKeys } from '~helpers/resourceQueryKeys'
 import { ResourceAccessError } from '~features/resources/resourceAccessError'
 import ResourceDownloadWidget from './ResourceDownloadWidget'
+import useConnection from '~helpers/useConnection'
 
 function randomIntFromInterval(min: number, max: number) {
   // min and max included
@@ -27,9 +28,10 @@ const DictionnaireOfTheDay = ({ color1 = 'rgba(86,204,242,1)', color2 = 'rgba(47
   const { t } = useTranslation()
   const resources = useResourceAccess()
   const lang = useLanguage()
+  const isConnected = useConnection()
   const [randomSeed, setRandomSeed] = useState(0)
   const availabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.offlineDatabaseAvailability('DICTIONNAIRE', lang),
+    queryKey: [...resourceQueryKeys.offlineDatabaseAvailability('DICTIONNAIRE', lang), isConnected],
     queryFn: () =>
       resources.dictionary.getAvailability?.(lang) ??
       Promise.resolve({ status: 'available' as const }),
@@ -37,7 +39,7 @@ const DictionnaireOfTheDay = ({ color1 = 'rgba(86,204,242,1)', color2 = 'rgba(47
     staleTime: Infinity,
   })
   const strongQuery = useQuery({
-    queryKey: ['home-dictionary-random', lang, randomSeed],
+    queryKey: ['home-dictionary-random', lang, randomSeed, isConnected],
     queryFn: async () =>
       (await resources.dictionary.loadItemByRowId(
         lang === 'fr' ? randomIntFromInterval(5437, 10872) : randomIntFromInterval(1, 8620),

--- a/src/features/lexique/useUtilities.tsx
+++ b/src/features/lexique/useUtilities.tsx
@@ -7,6 +7,7 @@ import {
   getResourceAccessErrorCode,
   ResourceAccessError,
 } from '~features/resources/resourceAccessError'
+import useConnection from '~helpers/useConnection'
 
 interface UseSearchValueOptions {
   onDebouncedValue?: () => void
@@ -39,6 +40,7 @@ export const useResultsByLetterOrSearch = <T,>(
   search: QueryConfig<T> = {},
   letter: QueryConfig<T> = {}
 ) => {
+  const isConnected = useConnection()
   const active = search.value && search.query ? search : letter
   const mode = active === search ? 'search' : 'letter'
   const enabled = Boolean(active.value && active.query)
@@ -49,6 +51,7 @@ export const useResultsByLetterOrSearch = <T,>(
       active.resourceLanguage,
       mode,
       active.value ?? '',
+      isConnected,
     ],
     queryFn: () => active.query!(active.value!, active.resourceLanguage),
     enabled,

--- a/src/features/search/SQLiteSearchScreen.tsx
+++ b/src/features/search/SQLiteSearchScreen.tsx
@@ -68,6 +68,7 @@ import OfflineResourceRecovery from '~features/resources/OfflineResourceRecovery
 import ResourceUnavailableView from '~features/resources/ResourceUnavailableView'
 import { resourceQueryKeys } from '~helpers/resourceQueryKeys'
 import { createOfflineCopyDownloadItem } from '~helpers/downloadItemFactory'
+import useConnection from '~helpers/useConnection'
 
 type Props = {
   searchValue: string
@@ -96,6 +97,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
   const keyboardFooterBottom = useKeyboardFooterBottom(SEARCH_ALPHABET_FOOTER_HEIGHT)
   const openStudyObject = useOpenStudyObject()
   const resources = useResourceAccess()
+  const isConnected = useConnection()
   const defaultBibleVersion = useDefaultBibleVersion()
   const installedVersionsSignal = useAtomValue(installedVersionsSignalAtom)
   const resourcesLanguage = useAtomValue(resourcesLanguageAtom)
@@ -120,7 +122,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
   const [naveLetter, setNaveLetter] = useState('a')
 
   const strongAvailabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.strongLexiconAvailability('core'),
+    queryKey: [...resourceQueryKeys.strongLexiconAvailability('core'), isConnected],
     queryFn: async () => ({
       availability: await resources.strongLexicon.getModuleAvailability('core'),
       recoveries: await resources.strongLexicon.getModuleRecoveryActions?.('core'),
@@ -129,10 +131,13 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
     staleTime: Infinity,
   })
   const dictionaryAvailabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.offlineDatabaseAvailability(
-      'DICTIONNAIRE',
-      resourcesLanguage.DICTIONNAIRE
-    ),
+    queryKey: [
+      ...resourceQueryKeys.offlineDatabaseAvailability(
+        'DICTIONNAIRE',
+        resourcesLanguage.DICTIONNAIRE
+      ),
+      isConnected,
+    ],
     queryFn: () =>
       resources.dictionary.getAvailability?.(resourcesLanguage.DICTIONNAIRE) ??
       Promise.resolve({ status: 'available' as const }),
@@ -140,7 +145,10 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
     staleTime: Infinity,
   })
   const naveAvailabilityQuery = useQuery({
-    queryKey: resourceQueryKeys.offlineDatabaseAvailability('NAVE', resourcesLanguage.NAVE),
+    queryKey: [
+      ...resourceQueryKeys.offlineDatabaseAvailability('NAVE', resourcesLanguage.NAVE),
+      isConnected,
+    ],
     queryFn: () =>
       resources.nave.getAvailability?.(resourcesLanguage.NAVE) ??
       Promise.resolve({ status: 'available' as const }),
@@ -361,6 +369,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       book,
       selectedVersion,
       sortOrder,
+      isConnected,
     ],
     queryFn: async () => {
       try {
@@ -425,6 +434,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       browseItemType,
       trimmedSearchValue,
       strongLetter,
+      isConnected,
     ],
     queryFn: async () => {
       try {
@@ -468,6 +478,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       browseItemType,
       trimmedSearchValue,
       dictionaryLetter,
+      isConnected,
     ],
     queryFn: async () => {
       try {
@@ -506,6 +517,7 @@ const SQLiteSearchScreen = ({ searchValue, setSearchValue }: Props) => {
       browseItemType,
       trimmedSearchValue,
       naveLetter,
+      isConnected,
     ],
     queryFn: async () => {
       try {


### PR DESCRIPTION
## Résumé
- ajoute un importeur local multi-racines pour les manifests imbriqués ;
- respecte l’ordre des dépendances et reste répétable sans reset PostgreSQL ;
- ajoute dans Bible Lexicon Maker le réconciliateur des 72 identités du catalogue ;
- documente le flux local BLM → ZIP/JSON → Postgres → API.

## Smoke
- `yarn typecheck`
- `yarn resources:architecture:check`
- `yarn format:check`
- `yarn resources:import-catalog --root <bundle-LSG>` → `unchanged`, 31 171 versets
- réconciliation réelle : 62/72 bundles présents, 10 manquants listés explicitement.

Pas de déploiement hosted ni de tests E2E dans cette PR.