### PR TITLE
fix(bible): streamline tab details and chapter loading

### DIFF
--- a/src/features/bible/BibleViewer.tsx
+++ b/src/features/bible/BibleViewer.tsx
@@ -103,6 +103,10 @@ import {
 import { getCanonicalChapterPericope } from '~helpers/canonicalBibleHeadings'
 import CrossVersionAnnotationsModal from './CrossVersionAnnotationsModal'
 import BibleFooter from './footer/BibleFooter'
+import {
+  getChapterEntityQueryPlan,
+  getDisplayedChapterEntityStrongCodes,
+} from './chapterEntityQueryPlan'
 import { useAnnotationMode } from './hooks'
 import ResourcesModal from './resources/ResourceModal'
 import {
@@ -270,6 +274,7 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
     queryKey: resourceQueryKeys.bibleCoverage(version),
     queryFn: () => resources.bibleContent.loadCoverage(version),
     enabled: !!version,
+    staleTime: Infinity,
     ...localQueryOptions,
   })
   const goToPrevAvailableChapter = () => actions.goToPrevChapter(coverageData)
@@ -422,19 +427,23 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
         >)
       : undefined
   const redWordsFailureIsTemporary = redWordsAvailabilityQuery.isError || redWordsQuery.isError
-  const displayedChapterEntityStrongCodes = [
-    ...new Set(
-      verses.flatMap(verse =>
-        (verse.StrongSpans ?? []).flatMap(span => span.identities.map(identity => identity.code))
-      )
-    ),
-  ]
+  const displayedChapterEntityStrongCodes = getDisplayedChapterEntityStrongCodes(verses)
+  const chapterStrongCodeSourcePlan = getChapterEntityQueryPlan({
+    chapterReady: extrasEnabled,
+    chapterKind: mainChapterData?.kind,
+    contextualInformationDisplay,
+    displayedStrongCodes: displayedChapterEntityStrongCodes,
+    isContextFocused,
+    strongCodesQueryFetched: false,
+  })
   const chapterStrongCodesQuery = useQuery({
     queryKey: resourceQueryKeys.strongBibleChapterCodes({
       currentVersionId: version,
       defaultVersionId: settings.defaultStrongBibleVersionId ?? 'LSG',
       book: book.Numero,
       chapter,
+      expectedTextRevision: mainChapterData?.textRevision,
+      expectedTextSha256: mainChapterData?.textSha256,
     }),
     queryFn: () =>
       resources.strongBible.loadChapterCodes({
@@ -442,20 +451,32 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
         defaultVersionId: settings.defaultStrongBibleVersionId ?? 'LSG',
         book: book.Numero,
         chapter,
+        expectedTextRevision: mainChapterData?.textRevision,
+        expectedTextSha256: mainChapterData?.textSha256,
       }),
-    enabled: extrasEnabled && contextualInformationDisplay && !isContextFocused,
+    enabled: chapterStrongCodeSourcePlan.shouldLoadStrongCodes,
     staleTime: Infinity,
     ...localQueryOptions,
   })
-  const chapterEntityStrongCodes =
-    chapterStrongCodesQuery.data?.status === 'available'
-      ? chapterStrongCodesQuery.data.codes
-      : displayedChapterEntityStrongCodes
+  const chapterEntityQueryPlan = getChapterEntityQueryPlan({
+    chapterReady: extrasEnabled,
+    chapterKind: mainChapterData?.kind,
+    contextualInformationDisplay,
+    displayedStrongCodes: displayedChapterEntityStrongCodes,
+    isContextFocused,
+    loadedStrongCodes:
+      chapterStrongCodesQuery.data?.status === 'available'
+        ? chapterStrongCodesQuery.data.codes
+        : undefined,
+    strongCodesQueryFetched: chapterStrongCodesQuery.isFetched,
+  })
+  const chapterEntityStrongCodes = chapterEntityQueryPlan.codes
   const chapterEntityAvailabilityQuery = useQuery({
-    queryKey: ['strong-lexicon', 'availability', 'entities'],
+    queryKey: resourceQueryKeys.strongLexiconAvailability('entities'),
     queryFn: () => resources.strongLexicon.getModuleAvailability('entities'),
-    enabled: contextualInformationDisplay,
+    enabled: chapterEntityQueryPlan.shouldCheckAvailability,
     networkMode: 'always',
+    staleTime: Infinity,
   })
   const chapterEntityDownload = useDownloadItemStatus(
     createOfflineCopyId({ kind: 'strong-lexicon-module', moduleId: 'entities' })
@@ -484,14 +505,12 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
     !isContextFocused &&
     chapterEntityAvailabilityQuery.data?.status === 'available'
   const chapterEntitiesQuery = useQuery({
-    queryKey: [
-      'strong-lexicon',
-      'chapter-entities',
-      lang,
-      book.Numero,
+    queryKey: resourceQueryKeys.strongLexiconChapterEntities({
+      language: lang,
+      book: book.Numero,
       chapter,
-      chapterEntityStrongCodes.join(','),
-    ],
+      strongCodes: chapterEntityStrongCodes,
+    }),
     queryFn: () =>
       resources.strongLexicon.loadChapterEntities(
         book.Numero,
@@ -499,7 +518,7 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
         lang,
         chapterEntityStrongCodes
       ),
-    enabled: extrasEnabled && chapterEntitiesAvailable,
+    enabled: chapterEntitiesAvailable && chapterEntityQueryPlan.shouldLoadEntities,
     staleTime: Infinity,
     ...localQueryOptions,
   })
@@ -1342,6 +1361,9 @@ const BibleViewer = ({ bibleAtom, settings, isFormSheet, isInTab }: BibleViewerP
           disabled={isLoading}
           book={book}
           chapter={chapter}
+          chapterVerses={
+            mainReadingQuery.isPlaceholderData || !mainChapterData ? undefined : verses
+          }
           coverage={coverageData}
           goToPrevChapter={goToPrevAvailableChapter}
           goToNextChapter={goToNextAvailableChapter}

--- a/src/features/bible/__tests__/chapterEntityQueryPlan-test.ts
+++ b/src/features/bible/__tests__/chapterEntityQueryPlan-test.ts
@@ -1,0 +1,143 @@
+import {
+  getChapterEntityQueryPlan,
+  getDisplayedChapterEntityStrongCodes,
+} from '../chapterEntityQueryPlan'
+
+describe('getDisplayedChapterEntityStrongCodes', () => {
+  it('collects and deduplicates codes from Strong and reverse-interlinear spans', () => {
+    expect(
+      getDisplayedChapterEntityStrongCodes([
+        {
+          Livre: 40,
+          Chapitre: 21,
+          Verset: 1,
+          Texte: 'Texte',
+          StrongSpans: [
+            {
+              ordinal: 0,
+              startOffset: 0,
+              length: 5,
+              identities: [{ kind: 'strong', code: 'G2064' }],
+            },
+          ],
+          ReverseInterlinearSpans: [
+            {
+              ordinal: 1,
+              startOffset: 6,
+              length: 5,
+              identities: [
+                { kind: 'strong', code: 'G2064' },
+                { kind: 'strong', code: 'G2414' },
+              ],
+              sourceTokens: [],
+            },
+          ],
+        },
+      ])
+    ).toEqual(['G2064', 'G2414'])
+  })
+})
+
+describe('getChapterEntityQueryPlan', () => {
+  it('waits for the Strong code query before loading entities for a plain chapter', () => {
+    expect(
+      getChapterEntityQueryPlan({
+        chapterReady: true,
+        chapterKind: 'plain',
+        contextualInformationDisplay: true,
+        displayedStrongCodes: [],
+        isContextFocused: false,
+        strongCodesQueryFetched: false,
+      })
+    ).toEqual({
+      codes: [],
+      codesReady: false,
+      shouldCheckAvailability: true,
+      shouldLoadEntities: false,
+      shouldLoadStrongCodes: true,
+    })
+  })
+
+  it('uses the resolved Strong codes for a plain chapter', () => {
+    expect(
+      getChapterEntityQueryPlan({
+        chapterReady: true,
+        chapterKind: 'plain',
+        contextualInformationDisplay: true,
+        displayedStrongCodes: [],
+        isContextFocused: false,
+        loadedStrongCodes: ['G2424', 'G5547'],
+        strongCodesQueryFetched: true,
+      })
+    ).toEqual({
+      codes: ['G2424', 'G5547'],
+      codesReady: true,
+      shouldCheckAvailability: true,
+      shouldLoadEntities: true,
+      shouldLoadStrongCodes: true,
+    })
+  })
+
+  it.each(['strong', 'reverse-interlinear'] as const)(
+    'reuses codes already present in a %s chapter',
+    chapterKind => {
+      expect(
+        getChapterEntityQueryPlan({
+          chapterReady: true,
+          chapterKind,
+          contextualInformationDisplay: true,
+          displayedStrongCodes: ['G2424'],
+          isContextFocused: false,
+          loadedStrongCodes: ['G0001'],
+          strongCodesQueryFetched: false,
+        })
+      ).toEqual({
+        codes: ['G2424'],
+        codesReady: true,
+        shouldCheckAvailability: true,
+        shouldLoadEntities: true,
+        shouldLoadStrongCodes: false,
+      })
+    }
+  )
+
+  it('falls back to displayed codes after an unavailable Strong code query', () => {
+    expect(
+      getChapterEntityQueryPlan({
+        chapterReady: true,
+        chapterKind: 'plain',
+        contextualInformationDisplay: true,
+        displayedStrongCodes: [],
+        isContextFocused: false,
+        strongCodesQueryFetched: true,
+      })
+    ).toEqual({
+      codes: [],
+      codesReady: true,
+      shouldCheckAvailability: true,
+      shouldLoadEntities: true,
+      shouldLoadStrongCodes: true,
+    })
+  })
+
+  it.each([
+    { chapterReady: false, contextualInformationDisplay: true, isContextFocused: false },
+    { chapterReady: true, contextualInformationDisplay: false, isContextFocused: false },
+    { chapterReady: true, contextualInformationDisplay: true, isContextFocused: true },
+  ])('does not budget contextual requests for an inactive context', context => {
+    expect(
+      getChapterEntityQueryPlan({
+        ...context,
+        chapterKind: 'plain',
+        displayedStrongCodes: [],
+        strongCodesQueryFetched: false,
+      })
+    ).toEqual({
+      codes: [],
+      codesReady: false,
+      shouldCheckAvailability: false,
+      shouldLoadEntities: false,
+      shouldLoadStrongCodes: false,
+    })
+  })
+})

--- a/src/features/bible/chapterEntityQueryPlan.ts
+++ b/src/features/bible/chapterEntityQueryPlan.ts
@@ -1,0 +1,62 @@
+import type { BibleChapterData } from '~features/resources/bibleContentAccess'
+import type { Verse } from '~common/types'
+
+type ChapterEntityQueryPlanInput = {
+  chapterReady: boolean
+  chapterKind?: BibleChapterData['kind']
+  contextualInformationDisplay: boolean
+  displayedStrongCodes: string[]
+  isContextFocused: boolean
+  loadedStrongCodes?: string[]
+  strongCodesQueryFetched: boolean
+}
+
+export type ChapterEntityQueryPlan = {
+  codes: string[]
+  codesReady: boolean
+  shouldCheckAvailability: boolean
+  shouldLoadEntities: boolean
+  shouldLoadStrongCodes: boolean
+}
+
+export const getDisplayedChapterEntityStrongCodes = (verses: Verse[]): string[] => [
+  ...new Set(
+    verses.flatMap(verse =>
+      [...(verse.StrongSpans ?? []), ...(verse.ReverseInterlinearSpans ?? [])].flatMap(span =>
+        span.identities.map(identity => identity.code)
+      )
+    )
+  ),
+]
+
+export const getChapterEntityQueryPlan = ({
+  chapterReady,
+  chapterKind,
+  contextualInformationDisplay,
+  displayedStrongCodes,
+  isContextFocused,
+  loadedStrongCodes,
+  strongCodesQueryFetched,
+}: ChapterEntityQueryPlanInput): ChapterEntityQueryPlan => {
+  const shouldCheckAvailability = chapterReady && contextualInformationDisplay && !isContextFocused
+  const chapterAlreadyContainsStrongCodes =
+    chapterKind === 'strong' || chapterKind === 'reverse-interlinear'
+
+  if (chapterAlreadyContainsStrongCodes) {
+    return {
+      codes: displayedStrongCodes,
+      codesReady: shouldCheckAvailability,
+      shouldCheckAvailability,
+      shouldLoadEntities: shouldCheckAvailability,
+      shouldLoadStrongCodes: false,
+    }
+  }
+
+  return {
+    codes: loadedStrongCodes ?? displayedStrongCodes,
+    codesReady: shouldCheckAvailability && strongCodesQueryFetched,
+    shouldCheckAvailability,
+    shouldLoadEntities: shouldCheckAvailability && strongCodesQueryFetched,
+    shouldLoadStrongCodes: shouldCheckAvailability,
+  }
+}

--- a/src/features/bible/footer/AudioTTSFooter.tsx
+++ b/src/features/bible/footer/AudioTTSFooter.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { Platform } from 'react-native'
 import { BibleTab, VersionCode } from 'src/state/tabs'
 import { Book } from '~assets/bible_versions/books-desc'
+import type { Verse } from '~common/types'
 import Box, { TouchableBox } from '~common/ui/Box'
 import { FeatherIcon } from '~common/ui/Icon'
 import { HStack } from '~common/ui/Stack'
@@ -19,7 +20,6 @@ import {
   resolveBibleCoverageCanonId,
 } from '~helpers/bibleCoverage'
 import type { BibleVersionCoverage } from '~helpers/biblesDb'
-import { useResourceAccess } from '~features/resources/resourceAccess'
 import AudioContainer from './AudioContainer'
 import BasicFooter from './BasicFooter'
 import ChapterButton from './ChapterButton'
@@ -35,6 +35,7 @@ import {
   ttsSpeedAtom,
   ttsVoiceAtom,
 } from './atom'
+import { createTtsChapterData } from './ttsChapterData'
 
 type UseLoadSoundProps = {
   book: Book
@@ -43,6 +44,7 @@ type UseLoadSoundProps = {
   goToNextChapter: () => void
   goToPrevChapter: () => void
   bibleAtom: PrimitiveAtom<BibleTab>
+  chapterVerses?: Verse[]
 }
 
 // iOS workaround: play silent audio to enable TTS in silent mode
@@ -56,9 +58,9 @@ const useLoadSound = ({
   goToNextChapter,
   goToPrevChapter,
   bibleAtom,
+  chapterVerses,
 }: UseLoadSoundProps) => {
   const bibleTab = useAtomValue(bibleAtom)
-  const resources = useResourceAccess()
   const setPlayingBibleTabId = useSetAtom(playingBibleTabIdAtom)
   const currentVerseIndex = useRef(0)
   const verseKeys = useRef<number[]>([])
@@ -194,32 +196,22 @@ const useLoadSound = ({
   const audioTitle = `${t(book.Nom)} ${chapter}:${currentVerseNum} ${version}`
   const audioSubtitle = bibleVersion?.name
 
-  // Effect 1: Load verse data when chapter/book/version changes
+  // Keep TTS on the exact chapter already loaded by the reader.
   useEffect(() => {
     let cancelled = false
     currentVerseIndex.current = 0
     verseKeys.current = []
     versesData.current = {}
+    if (!chapterVerses) {
+      Speech.stop()
+      return
+    }
+
+    const chapterData = createTtsChapterData(chapterVerses)
+    verseKeys.current = chapterData.verseKeys
+    versesData.current = chapterData.versesByNumber
     ;(async () => {
       try {
-        const chapterResult = await resources.bibleContent.loadChapter({
-          version,
-          book: book.Numero,
-          chapter,
-        })
-        if (cancelled) return
-        if (!chapterResult.success) throw chapterResult.error
-
-        const obj: Record<number, string> = {}
-        for (const row of chapterResult.data.verses) {
-          obj[Number(row.Verset)] = row.Texte
-        }
-        const sorted = Object.keys(obj)
-          .map(Number)
-          .sort((a, b) => a - b)
-        verseKeys.current = sorted
-        versesData.current = obj
-
         // Auto-play if currently playing (e.g., chapter changed during playback)
         if (isPlayingRef.current) {
           if (Platform.OS === 'ios') {
@@ -242,7 +234,7 @@ const useLoadSound = ({
       cancelled = true
       Speech.stop()
     }
-  }, [book.Numero, chapter, version, resources.bibleContent])
+  }, [book.Numero, chapter, version, chapterVerses])
 
   // Effect 2: Start/stop playback when user presses play/stop
   useEffect(() => {
@@ -301,6 +293,7 @@ const useLoadSound = ({
 type AudioTTSFooterProps = {
   book: Book
   chapter: number
+  chapterVerses?: Verse[]
   goToNextChapter: () => void
   goToPrevChapter: () => void
   disabled?: boolean
@@ -313,6 +306,7 @@ type AudioTTSFooterProps = {
 const AudioTTSFooter = ({
   book,
   chapter,
+  chapterVerses,
   goToNextChapter,
   goToPrevChapter,
   disabled,
@@ -340,6 +334,7 @@ const AudioTTSFooter = ({
   } = useLoadSound({
     book,
     chapter,
+    chapterVerses,
     version,
     goToNextChapter,
     goToPrevChapter,

--- a/src/features/bible/footer/BibleFooter.tsx
+++ b/src/features/bible/footer/BibleFooter.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { useAtomValue } from 'jotai/react'
 import { PrimitiveAtom } from 'jotai/vanilla'
+import type { Verse } from '~common/types'
 import { Book } from '~assets/bible_versions/books-desc'
 import type { BibleVersionCoverage } from '~helpers/biblesDb'
 import { getVersions, Version } from '~helpers/bibleVersions'
@@ -20,12 +21,14 @@ type BibleFooterProps = {
   disabled?: boolean
   version: VersionCode
   bibleAtom: PrimitiveAtom<BibleTab>
+  chapterVerses?: Verse[]
   coverage?: BibleVersionCoverage
   isInTab?: boolean
 }
 
 const BibleFooter = ({
   bibleAtom,
+  chapterVerses,
   book,
   chapter,
   goToNextChapter,
@@ -90,6 +93,7 @@ const BibleFooter = ({
       <AudioTTSFooter
         book={book}
         chapter={chapter}
+        chapterVerses={chapterVerses}
         goToNextChapter={goToNextChapter}
         goToPrevChapter={goToPrevChapter}
         disabled={disabled}

--- a/src/features/bible/footer/__tests__/BibleFooter-test.tsx
+++ b/src/features/bible/footer/__tests__/BibleFooter-test.tsx
@@ -33,6 +33,9 @@ describe('BibleFooter', () => {
 
   it('renders on a standalone full-chapter screen outside the primary Bible tab', () => {
     const bibleAtom = atom({ id: 'standalone-bible', data: {} } as BibleTab)
+    const chapterVerses = [
+      { Livre: 49, Chapitre: 2, Verset: 1, Texte: 'Vous étiez morts.' },
+    ] as never
     let renderer: ReturnType<typeof create>
 
     act(() => {
@@ -41,6 +44,7 @@ describe('BibleFooter', () => {
           bibleAtom={bibleAtom}
           book={{ Numero: 49, Nom: 'Éphésiens', Chapitres: 6 }}
           chapter={2}
+          chapterVerses={chapterVerses}
           goToPrevChapter={jest.fn()}
           goToNextChapter={jest.fn()}
           goToChapter={jest.fn()}
@@ -50,6 +54,8 @@ describe('BibleFooter', () => {
       )
     })
 
-    expect(renderer!.root.find(node => String(node.type) === 'AudioTTSFooter')).toBeDefined()
+    expect(
+      renderer!.root.find(node => String(node.type) === 'AudioTTSFooter').props.chapterVerses
+    ).toBe(chapterVerses)
   })
 })

--- a/src/features/bible/footer/__tests__/ttsChapterData-test.ts
+++ b/src/features/bible/footer/__tests__/ttsChapterData-test.ts
@@ -1,0 +1,23 @@
+import type { Verse } from '~common/types'
+import { createTtsChapterData } from '../ttsChapterData'
+
+describe('createTtsChapterData', () => {
+  it('builds an ordered TTS queue from the chapter already loaded by the reader', () => {
+    const verses = [
+      { Livre: 40, Chapitre: 21, Verset: 2, Texte: 'Détachez-les.' },
+      { Livre: 40, Chapitre: 21, Verset: 1, Texte: 'Ils approchèrent de Jérusalem.' },
+    ] as Verse[]
+
+    expect(createTtsChapterData(verses)).toEqual({
+      verseKeys: [1, 2],
+      versesByNumber: {
+        1: 'Ils approchèrent de Jérusalem.',
+        2: 'Détachez-les.',
+      },
+    })
+  })
+
+  it('returns an empty queue while the requested chapter is not ready', () => {
+    expect(createTtsChapterData([])).toEqual({ verseKeys: [], versesByNumber: {} })
+  })
+})

--- a/src/features/bible/footer/ttsChapterData.ts
+++ b/src/features/bible/footer/ttsChapterData.ts
@@ -1,0 +1,20 @@
+import type { Verse } from '~common/types'
+
+export type TtsChapterData = {
+  verseKeys: number[]
+  versesByNumber: Record<number, string>
+}
+
+export const createTtsChapterData = (verses: Verse[]): TtsChapterData => {
+  const versesByNumber: Record<number, string> = {}
+  for (const verse of verses) {
+    versesByNumber[Number(verse.Verset)] = verse.Texte
+  }
+
+  return {
+    verseKeys: Object.keys(versesByNumber)
+      .map(Number)
+      .sort((left, right) => left - right),
+    versesByNumber,
+  }
+}

--- a/src/features/lexique/StrongEntryRouteScaffold.tsx
+++ b/src/features/lexique/StrongEntryRouteScaffold.tsx
@@ -33,6 +33,7 @@ type Props = {
   context: StrongDetailRouteContext
   entryState: StrongEntryLoadState
   fontSize?: number
+  hasBackButton?: boolean
   isFormSheet?: boolean
   onBack?: () => void
   requireEntry?: boolean
@@ -46,6 +47,7 @@ const StrongEntryRouteScaffold = ({
   context,
   entryState,
   fontSize,
+  hasBackButton,
   isFormSheet = false,
   onBack,
   requireEntry = true,
@@ -73,7 +75,7 @@ const StrongEntryRouteScaffold = ({
   const openEntityRelations = useOpenEntityRelations()
   const header = (
     <Header
-      hasBackButton={onBack ? true : isFormSheet ? canGoBackInStack : true}
+      hasBackButton={hasBackButton ?? (onBack ? true : isFormSheet ? canGoBackInStack : true)}
       onCustomBackPress={onBack}
       fontSize={fontSize}
       subTitle={subTitle}

--- a/src/features/lexique/StrongMainScreen.tsx
+++ b/src/features/lexique/StrongMainScreen.tsx
@@ -22,6 +22,7 @@ import { useStrongRouteNavigation } from './useStrongRouteNavigation'
 
 interface StrongMainScreenProps {
   context: StrongDetailRouteContext
+  hasBackButton?: boolean
   isFormSheet?: boolean
   onBack?: () => void
   onTitleChange?: (title: string) => void
@@ -29,6 +30,7 @@ interface StrongMainScreenProps {
 
 const StrongMainScreen = ({
   context,
+  hasBackButton,
   isFormSheet = false,
   onBack,
   onTitleChange,
@@ -228,6 +230,7 @@ const StrongMainScreen = ({
       context={activeContext}
       entryState={entryState}
       fontSize={19}
+      hasBackButton={hasBackButton}
       isFormSheet={isFormSheet}
       onBack={onBack}
       showEntryMenu

--- a/src/features/lexique/StrongTabScreen.tsx
+++ b/src/features/lexique/StrongTabScreen.tsx
@@ -62,6 +62,7 @@ const StrongTabScreen = ({ strongAtom }: StrongTabScreenProps) => {
   return (
     <StrongMainScreen
       context={strongTab.data}
+      hasBackButton={false}
       onBack={returnToLexicon}
       onTitleChange={updateTitle}
     />

--- a/src/features/lexique/__tests__/StrongEntryRouteScaffold-test.tsx
+++ b/src/features/lexique/__tests__/StrongEntryRouteScaffold-test.tsx
@@ -176,6 +176,37 @@ describe('StrongEntryRouteScaffold', () => {
     expect(renderer.root.find(node => node.props.routeContent === 'entity')).toBeDefined()
   })
 
+  it('can hide the back button even when a custom back action exists', () => {
+    act(() => {
+      renderer = create(
+        <StrongEntryRouteScaffold
+          context={{ book: 1, reference: 'H0310A' }}
+          entryState={
+            {
+              identity: { kind: 'dstrong', code: 'H0310A' },
+              coreAvailability: { isPending: false, data: { status: 'available' } },
+              entryQuery: { isPending: false, isError: false },
+              entry: {
+                stepCode: 'H0310A',
+                language: 'hebrew',
+                gloss: 'après',
+                original: 'אַחַר',
+              },
+            } as never
+          }
+          hasBackButton={false}
+          onBack={jest.fn()}
+          title="Étude de mot"
+        >
+          <></>
+        </StrongEntryRouteScaffold>
+      )
+    })
+
+    const header = renderer.root.find(node => String(node.type) === 'Header')
+    expect(header.props.hasBackButton).toBe(false)
+  })
+
   it('renders a network failure instead of claiming that the Strong entry is absent', () => {
     act(() => {
       renderer = create(

--- a/src/features/lexique/__tests__/lexiqueNavigationMode-test.tsx
+++ b/src/features/lexique/__tests__/lexiqueNavigationMode-test.tsx
@@ -99,6 +99,7 @@ describe('lexicon navigation mode', () => {
 
     const detail = renderer.root.find(node => String(node.type) === 'StrongMainScreen')
     expect(detail.props).not.toHaveProperty('onStrongSelect')
+    expect(detail.props.hasBackButton).toBe(false)
 
     act(() => detail.props.onBack())
 

--- a/src/features/resources/__tests__/bibleContentAccess-test.ts
+++ b/src/features/resources/__tests__/bibleContentAccess-test.ts
@@ -87,6 +87,31 @@ const createDependencies = () => ({
 })
 
 describe('BibleContentAccess', () => {
+  it('preserves canonical text identity on a plain chapter result', async () => {
+    const dependencies = createDependencies()
+    dependencies.chapterAdapter.loadChapter.mockResolvedValue({
+      status: 'available',
+      presentation: 'canonical',
+      textRevision: 'lsg-text-v1',
+      textSha256: '1'.repeat(64),
+      verses: [{ Livre: 40, Chapitre: 21, Verset: 1, Texte: 'Ils approchèrent.' }],
+    })
+
+    await expect(
+      loadBibleContentChapter({ book: 40, chapter: 21, version: 'LSG' }, dependencies)
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          kind: 'plain',
+          presentation: 'canonical',
+          textRevision: 'lsg-text-v1',
+          textSha256: '1'.repeat(64),
+        }),
+      })
+    )
+  })
+
   it('fails explicitly when Strong presentation is requested for an unsupported Bible', async () => {
     const dependencies = createDependencies()
 

--- a/src/features/resources/__tests__/resourceQueryKeys-test.ts
+++ b/src/features/resources/__tests__/resourceQueryKeys-test.ts
@@ -53,4 +53,20 @@ describe('resourceQueryKeys', () => {
       request,
     ])
   })
+
+  it('keeps contextual chapter entities under the Strong lexicon invalidation root', () => {
+    const request = {
+      language: 'fr',
+      book: 40,
+      chapter: 21,
+      strongCodes: ['G2424'],
+    }
+
+    expect(resourceQueryKeys.strongLexiconChapterEntities(request)).toEqual([
+      'resource',
+      'strong-lexicon',
+      'chapter-entities',
+      request,
+    ])
+  })
 })

--- a/src/features/resources/__tests__/resourceSourceLogger-test.ts
+++ b/src/features/resources/__tests__/resourceSourceLogger-test.ts
@@ -58,6 +58,26 @@ describe('resource source development logger', () => {
     expect(consoleLog).toHaveBeenCalledWith('[ResourceSource] Cache · OFFLINE · loadCached')
   })
 
+  it('distinguishes array arguments from array results', async () => {
+    const adapter = withResourceSourceLogging(
+      {
+        loadChapterEntities: async (
+          _book: number,
+          _chapter: number,
+          _language: string,
+          _strongCodes: string[]
+        ) => ['Jesus', 'Jerusalem'],
+      },
+      { resource: 'Strong lexicon', source: 'online', enabled: true }
+    )
+
+    await adapter.loadChapterEntities(40, 21, 'fr', ['G2424', 'G2414', 'G1519'])
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      '[ResourceSource] Strong lexicon · ONLINE · loadChapterEntities · 40 · 21 · fr · strongCodes=3 · result=2'
+    )
+  })
+
   it('logs only the online source when the installed Bible is unavailable', async () => {
     const offline = withResourceSourceLogging<BibleChapterAdapter>(
       {

--- a/src/features/resources/__tests__/strongBibleHttpAccess-test.ts
+++ b/src/features/resources/__tests__/strongBibleHttpAccess-test.ts
@@ -145,6 +145,73 @@ describe('Strong Bible HTTP resource access', () => {
     )
   })
 
+  it('reuses compatible remote availability across chapter loads', async () => {
+    const fetcher = jest.fn((url: string) => {
+      if (url.endsWith('/coverage')) {
+        return jsonResponse({
+          resource,
+          books: [1],
+          chaptersByBook: { 1: [1, 2] },
+          verseCountByBookChapter: { '1-1': 1, '1-2': 1 },
+        })
+      }
+      const chapter = url.endsWith('/2') ? 2 : 1
+      return jsonResponse({
+        resource,
+        book: 1,
+        chapter,
+        verses: [{ number: 1, spans: [span] }],
+      })
+    }) as jest.MockedFunction<typeof fetch>
+    const loadCoverage = jest.fn(async () => ({
+      status: 'available' as const,
+      coverage: {
+        canon: { id: 'protestant-66', orderedBooks: [1] },
+        versification: 'protestant-66',
+        books: [1],
+        chaptersByBook: { 1: [1, 2] },
+        verseCountByBookChapter: { '1-1': 1, '1-2': 1 },
+      },
+      textRevision: resource.textRevision,
+      textSha256: resource.textSha256,
+    }))
+    const online = createHttpStrongBibleResourceAdapter({
+      baseUrl: 'http://localhost:8787',
+      fetcher,
+      isOnline: async () => true,
+      bibleChapterAdapter: {
+        loadChapter: async () => ({ status: 'unavailable', reason: 'chapter-not-available' }),
+        loadCoverage,
+      },
+    })
+    const hybrid = createHybridStrongBibleResourceAdapter({
+      offline: unavailableAdapter(),
+      online,
+      remotelyReadableVersions: new Set(['LSG']),
+      isOnline: async () => true,
+    })
+    const access = createStrongBibleResourceAccess(hybrid)
+
+    await access.loadChapterCodes({
+      currentVersionId: 'LSG',
+      defaultVersionId: 'LSG',
+      book: 1,
+      chapter: 1,
+    })
+    await access.loadChapterCodes({
+      currentVersionId: 'LSG',
+      defaultVersionId: 'LSG',
+      book: 1,
+      chapter: 2,
+    })
+
+    expect(loadCoverage).toHaveBeenCalledTimes(1)
+    expect(fetcher.mock.calls.filter(([url]) => String(url).endsWith('/coverage'))).toHaveLength(1)
+    expect(
+      fetcher.mock.calls.filter(([url]) => String(url).includes('/books/1/chapters/'))
+    ).toHaveLength(2)
+  })
+
   it('prefers installed SQLite, then returns to HTTP after that copy is removed', async () => {
     const offline = unavailableAdapter()
     let installed = true

--- a/src/features/resources/__tests__/strongBibleResourceAccess-test.ts
+++ b/src/features/resources/__tests__/strongBibleResourceAccess-test.ts
@@ -127,6 +127,28 @@ describe('strongBibleResourceAccess', () => {
     expect(dependencies.loadChapterSpans).toHaveBeenCalledWith('DBY', { book: 3, chapter: 1 })
   })
 
+  it('rejects contextual Strong codes from a different canonical text revision', async () => {
+    const dependencies = createDependencies()
+    dependencies.getAvailability.mockResolvedValue(available('LSG'))
+    dependencies.loadChapterSpans.mockResolvedValue({
+      spansByVerse: {},
+      textRevision: 'old-lsg-text',
+      textSha256: '0'.repeat(64),
+    })
+    const access = createStrongBibleResourceAccess(dependencies)
+
+    await expect(
+      access.loadChapterCodes({
+        currentVersionId: 'LSG',
+        defaultVersionId: 'LSG',
+        book: 40,
+        chapter: 21,
+        expectedTextRevision: 'current-lsg-text',
+        expectedTextSha256: '1'.repeat(64),
+      })
+    ).rejects.toMatchObject({ code: 'INTEGRITY_FAILURE' })
+  })
+
   it('keeps Strong spans on a contextual verse so untranslated occurrences remain positionable', async () => {
     const dependencies = createDependencies()
     const spans = [

--- a/src/features/resources/bibleContentAccess.ts
+++ b/src/features/resources/bibleContentAccess.ts
@@ -77,15 +77,22 @@ const isCanonicalChapterForVersion = (version: string, book: number, chapter: nu
 
 export type BibleChapterPresentationSource = 'canonical' | 'legacy-sidecars'
 
-export type BibleChapterData =
-  | { kind: 'plain'; verses: Verse[]; presentation: BibleChapterPresentationSource }
-  | { kind: 'strong'; verses: Verse[]; presentation: BibleChapterPresentationSource }
-  | { kind: 'interlinear'; verses: Verse[]; presentation: BibleChapterPresentationSource }
-  | {
-      kind: 'reverse-interlinear'
-      verses: Verse[]
-      presentation: BibleChapterPresentationSource
-    }
+type BibleChapterIdentity = {
+  presentation: BibleChapterPresentationSource
+  textRevision?: string
+  textSha256?: string
+}
+
+export type BibleChapterData = BibleChapterIdentity &
+  (
+    | { kind: 'plain'; verses: Verse[] }
+    | { kind: 'strong'; verses: Verse[] }
+    | { kind: 'interlinear'; verses: Verse[] }
+    | {
+        kind: 'reverse-interlinear'
+        verses: Verse[]
+      }
+  )
 
 export type BibleChapterRequest = {
   book: number
@@ -427,6 +434,11 @@ const loadRegularBibleChapter = async (
   const presentation =
     chapter.presentation ??
     (usesCanonicalBibleExtras(request.version) ? 'canonical' : 'legacy-sidecars')
+  const chapterIdentity: BibleChapterIdentity = {
+    presentation,
+    ...(chapter.textRevision ? { textRevision: chapter.textRevision } : {}),
+    ...(chapter.textSha256 ? { textSha256: chapter.textSha256 } : {}),
+  }
 
   if (
     request.version === 'BHG' &&
@@ -477,7 +489,7 @@ const loadRegularBibleChapter = async (
     }
     return successResult({
       kind: 'interlinear',
-      presentation,
+      ...chapterIdentity,
       verses: verses.map(verse => ({
         ...verse,
         InterlinearTokens: tokensByVerse[Number(verse.Verset)] ?? [],
@@ -589,7 +601,7 @@ const loadRegularBibleChapter = async (
 
     return successResult({
       kind: 'reverse-interlinear',
-      presentation,
+      ...chapterIdentity,
       verses: verses.map(verse => ({
         ...verse,
         ReverseInterlinearSpans: reconciliation.spansByVerse[Number(verse.Verset)] ?? [],
@@ -598,7 +610,7 @@ const loadRegularBibleChapter = async (
   }
 
   if (request.strongMode !== 'visible') {
-    return successResult({ kind: 'plain', verses, presentation })
+    return successResult({ kind: 'plain', verses, ...chapterIdentity })
   }
 
   const strongChapter = await dependencies.loadStrongBibleChapterSpans!(
@@ -649,7 +661,7 @@ const loadRegularBibleChapter = async (
   }
   return successResult({
     kind: 'strong',
-    presentation,
+    ...chapterIdentity,
     verses: verses.map(verse => {
       const verseNumber = Number(verse.Verset)
       const alignedTokens = alignedTokensByVerse[verseNumber] ?? []

--- a/src/features/resources/resourceSourceLogger.ts
+++ b/src/features/resources/resourceSourceLogger.ts
@@ -11,6 +11,14 @@ const TRACEABLE_OPERATION = /^(?:browse|find|list|load|random|search)/u
 
 const truncate = (value: string) => (value.length > 40 ? `${value.slice(0, 37)}...` : value)
 
+const ARRAY_ARGUMENT_LABELS: Record<string, Record<number, string>> = {
+  loadChapterEntities: { 3: 'strongCodes' },
+  loadEntries: { 0: 'identities' },
+  loadEntryCards: { 0: 'identities' },
+  loadMorphologies: { 0: 'codes' },
+  loadPreview: { 0: 'identities' },
+}
+
 const describeArgument = (value: unknown): string | undefined => {
   if (typeof value === 'string') return truncate(value)
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
@@ -48,11 +56,21 @@ const didLoadResource = (value: unknown) => {
 const logResourceSource = (
   options: ResourceSourceLoggerOptions,
   operation: string,
-  args: unknown[]
+  args: unknown[],
+  result: unknown
 ) => {
-  const details = args.map(describeArgument).filter(Boolean).join(' · ')
+  const details = args
+    .map((argument, index) => {
+      if (Array.isArray(argument)) {
+        const label = ARRAY_ARGUMENT_LABELS[operation]?.[index]
+        return label ? `${label}=${argument.length}` : `[${argument.length} items]`
+      }
+      return describeArgument(argument)
+    })
+    .filter(Boolean)
+  if (Array.isArray(result)) details.push(`result=${result.length}`)
   console.log(
-    `[ResourceSource] ${options.resource} · ${options.source.toUpperCase()} · ${operation}${details ? ` · ${details}` : ''}`
+    `[ResourceSource] ${options.resource} · ${options.source.toUpperCase()} · ${operation}${details.length ? ` · ${details.join(' · ')}` : ''}`
   )
 }
 
@@ -87,14 +105,14 @@ export const withResourceSourceLogging = <Adapter extends object>(
         if (result instanceof Promise) {
           return result.then(value => {
             if (shouldLogResult(options, property, value)) {
-              logResourceSource(options, property, args)
+              logResourceSource(options, property, args, value)
             }
             return value
           })
         }
 
         if (shouldLogResult(options, property, result)) {
-          logResourceSource(options, property, args)
+          logResourceSource(options, property, args, result)
         }
         return result
       }

--- a/src/features/resources/strongBibleResourceAccess.ts
+++ b/src/features/resources/strongBibleResourceAccess.ts
@@ -66,6 +66,8 @@ export interface StrongBibleVerseRequest extends StrongBibleResolutionRequest {
 export interface StrongBibleChapterRequest extends StrongBibleResolutionRequest {
   book: number
   chapter: number
+  expectedTextRevision?: string
+  expectedTextSha256?: string
 }
 
 export interface StrongBibleConcordanceRequest extends StrongBibleResolutionRequest {
@@ -294,7 +296,11 @@ type HttpStrongBibleResourceAdapterOptions = {
   isOnline: () => Promise<boolean>
   bibleChapterAdapter: BibleChapterAdapter
   timeoutMs?: number
+  availabilityStaleTimeMs?: number
+  now?: () => number
 }
+
+const STRONG_BIBLE_AVAILABILITY_STALE_TIME_MS = 6 * 60 * 60 * 1000
 
 const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '')
 
@@ -366,8 +372,14 @@ export const createHttpStrongBibleResourceAdapter = ({
   isOnline,
   bibleChapterAdapter,
   timeoutMs = 10_000,
+  availabilityStaleTimeMs = STRONG_BIBLE_AVAILABILITY_STALE_TIME_MS,
+  now = Date.now,
 }: HttpStrongBibleResourceAdapterOptions): StrongBibleResourceAdapter => {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const availabilityCache = new Map<
+    string,
+    { expiresAt: number; promise: Promise<StrongBibleSidecarAvailability> }
+  >()
   const get = async <A>(path: string, schema: Schema.Schema<A>): Promise<A> => {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -429,44 +441,63 @@ export const createHttpStrongBibleResourceAdapter = ({
     return response
   }
 
-  return {
-    async getAvailability(versionId) {
-      if (!isStrongCapableBibleVersion(versionId)) return { status: 'unsupported' }
-      try {
-        const coverage = await get(
-          `/v1/strong-bibles/${encodeURIComponent(versionId)}/coverage`,
-          StrongBibleCoverageDto
-        )
-        assertPublicationIdentity(coverage.resource, versionId)
-        const bibleCoverage = await bibleChapterAdapter.loadCoverage(versionId)
-        if (bibleCoverage.status !== 'available') {
-          throw bibleChapterUnavailableError(bibleCoverage)
-        }
-        if (
-          bibleCoverage.textRevision !== coverage.resource.textRevision ||
-          bibleCoverage.textSha256 !== coverage.resource.textSha256
-        ) {
-          warnAboutRecoverableResourceIntegrity('strong-bible-coverage-revision-mismatch', {
-            versionId,
-            bibleTextRevision: bibleCoverage.textRevision,
-            strongTextRevision: coverage.resource.textRevision,
-          })
-        }
-        return {
-          status: 'available',
-          versionId,
-          datasetId: coverage.resource.datasetId,
-          textRevision: coverage.resource.textRevision,
-          textSha256: coverage.resource.textSha256,
-          strongRevision: coverage.resource.strongRevision,
-        }
-      } catch (error) {
-        if (error instanceof ResourceAccessError && error.code === 'RESOURCE_UNSUPPORTED') {
-          return { status: 'unsupported' }
-        }
-        throw error
+  const loadAvailability = async (versionId: string): Promise<StrongBibleSidecarAvailability> => {
+    if (!isStrongCapableBibleVersion(versionId)) return { status: 'unsupported' }
+    try {
+      const coverage = await get(
+        `/v1/strong-bibles/${encodeURIComponent(versionId)}/coverage`,
+        StrongBibleCoverageDto
+      )
+      assertPublicationIdentity(coverage.resource, versionId)
+      const bibleCoverage = await bibleChapterAdapter.loadCoverage(versionId)
+      if (bibleCoverage.status !== 'available') {
+        throw bibleChapterUnavailableError(bibleCoverage)
       }
-    },
+      if (
+        bibleCoverage.textRevision !== coverage.resource.textRevision ||
+        bibleCoverage.textSha256 !== coverage.resource.textSha256
+      ) {
+        warnAboutRecoverableResourceIntegrity('strong-bible-coverage-revision-mismatch', {
+          versionId,
+          bibleTextRevision: bibleCoverage.textRevision,
+          strongTextRevision: coverage.resource.textRevision,
+        })
+      }
+      return {
+        status: 'available',
+        versionId,
+        datasetId: coverage.resource.datasetId,
+        textRevision: coverage.resource.textRevision,
+        textSha256: coverage.resource.textSha256,
+        strongRevision: coverage.resource.strongRevision,
+      }
+    } catch (error) {
+      if (error instanceof ResourceAccessError && error.code === 'RESOURCE_UNSUPPORTED') {
+        return { status: 'unsupported' }
+      }
+      throw error
+    }
+  }
+
+  const getAvailability = (versionId: string) => {
+    const cached = availabilityCache.get(versionId)
+    if (cached && cached.expiresAt > now()) return cached.promise
+
+    const promise = loadAvailability(versionId).catch(error => {
+      if (availabilityCache.get(versionId)?.promise === promise) {
+        availabilityCache.delete(versionId)
+      }
+      throw error
+    })
+    availabilityCache.set(versionId, {
+      expiresAt: now() + availabilityStaleTimeMs,
+      promise,
+    })
+    return promise
+  }
+
+  return {
+    getAvailability,
     async loadChapterSpans(versionId, request) {
       try {
         const chapter = await loadChapter(versionId, request.book, request.chapter)
@@ -784,6 +815,13 @@ export const createStrongBibleResourceAccess = (
         book: request.book,
         chapter: request.chapter,
       })
+      if (
+        (request.expectedTextRevision &&
+          spansByVerse.textRevision !== request.expectedTextRevision) ||
+        (request.expectedTextSha256 && spansByVerse.textSha256 !== request.expectedTextSha256)
+      ) {
+        throw new ResourceAccessError('INTEGRITY_FAILURE')
+      }
       return {
         status: 'available',
         provenance: resolution.provenance,

--- a/src/helpers/resourceQueryKeys.ts
+++ b/src/helpers/resourceQueryKeys.ts
@@ -73,6 +73,8 @@ export const resourceQueryKeys = {
     defaultVersionId: string
     book: number
     chapter: number
+    expectedTextRevision?: string
+    expectedTextSha256?: string
   }) => [...strongBible, 'chapter-codes', request] as const,
   strongBibleCounts: (request: LexiconBibleQueryRequest) =>
     [...strongBible, 'counts', request] as const,
@@ -81,6 +83,12 @@ export const resourceQueryKeys = {
   strongLexicon: () => strongLexicon,
   strongLexiconAvailability: (moduleId: string) =>
     [...strongLexicon, 'availability', moduleId] as const,
+  strongLexiconChapterEntities: (request: {
+    language: string
+    book: number
+    chapter: number
+    strongCodes: readonly string[]
+  }) => [...strongLexicon, 'chapter-entities', request] as const,
   offlineDatabaseAvailability: (databaseId: string, language: string) =>
     [...offlineDatabase, 'availability', databaseId, language] as const,
   timeline: (language: string) => [...timeline, language] as const,


### PR DESCRIPTION
## Contexte

La navigation Mat 20 → 21 en LSG simple déclenchait des chargements Bible, Strong et entités redondants. Le détail Strong ouvert dans un onglet affichait aussi un bouton précédent absent des autres détails en mode onglet.

## Changements

- masque le bouton précédent du détail Strong uniquement en mode onglet
- empêche la requête entités initiale avec une liste Strong vide
- réutilise les codes Strong déjà présents dans les chapitres Strong et interlinéaires inversés
- transmet au TTS les versets déjà chargés par le lecteur au lieu de recharger le chapitre
- met en cache la disponibilité distante Strong et la couverture Bible pendant la session de lecture
- vérifie identité texte/révision lors de la réutilisation des spans Strong
- normalise les clés React Query des entités et clarifie les logs avec les tailles entrée/résultat
- ajoute les tests de budget de requêtes, intégrité, TTS et navigation onglet

## Validation

- `yarn test --runInBand` — 227 suites, 1709 tests
- `yarn typecheck`
- `yarn lint`
- `yarn agents:styles:check`
- `yarn resources:architecture:check`
- `yarn agents:architecture:check` — 0 erreur, avertissements existants uniquement
- Prettier ciblé et `git diff --check`

## Limite de validation

Le smoke test interactif Android n’a pas pu atteindre l’application : l’unique AVD local `Pixel_6_Pro_API_36` plante au démarrage avec `SIGSEGV` avant le lancement. Deux tentatives propres ont échoué sans effacement de l’AVD. Les validations automatisées sont toutes vertes.

## Risques

Le cache de disponibilité Strong expire après 6 heures. Les erreurs ne sont jamais conservées en cache, et l’identité du chapitre est toujours contrôlée avant de réutiliser les données Strong.